### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@
 
 name: Client CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/revisium/revisium-admin/security/code-scanning/5](https://github.com/revisium/revisium-admin/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations, the minimal permissions required are `contents: read`. This block can be added at the root level of the workflow to apply to all jobs, ensuring consistency and security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
