### PR TITLE
fix(billing): clamp progress to 100% and bind plan click handler

### DIFF
--- a/src/pages/OrganizationLimitsPage/model/PlanItemViewModel.ts
+++ b/src/pages/OrganizationLimitsPage/model/PlanItemViewModel.ts
@@ -12,7 +12,7 @@ export class PlanItemViewModel {
     private readonly plan: LimitsPagePlanFragment,
     private readonly parent: LimitsPageViewModel,
   ) {
-    makeAutoObservable(this)
+    makeAutoObservable(this, {}, { autoBind: true })
   }
 
   public get id(): string {

--- a/src/pages/OrganizationLimitsPage/model/UsageItemViewModel.ts
+++ b/src/pages/OrganizationLimitsPage/model/UsageItemViewModel.ts
@@ -41,7 +41,9 @@ export class UsageItemViewModel {
   }
 
   public get percentage(): number | null {
-    return this.metric.percentage ?? null
+    const value = this.metric.percentage ?? null
+    if (value === null) return null
+    return Math.min(value, 100)
   }
 
   public get progressColor(): string {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clamp usage progress to a maximum of 100% and auto-bind `PlanItemViewModel` methods so the plan card click handler works on the Limits page.

<sup>Written for commit 93f6d6646a959d97256e12d7298c53b21bea9dcc. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/318">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

