### PR TITLE
fix: env.js cache headers priority in nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -55,7 +55,7 @@ server {
       proxy_cache off;
   }
 
-  location /env.js {
+  location = /env.js {
     add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
     return 200 'window.__env__ = {
         "REACT_APP_GRAPHQL_SERVER_URL": "${REACT_APP_GRAPHQL_SERVER_URL}",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Serve /env.js with correct no-store cache headers by switching to an exact-match Nginx location. This prevents the generic .js regex from matching first and applying long-term caching.

<sup>Written for commit cd37153fad6b715d0235f31399f1a0dd8eca15c6. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/319">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

