### PR TITLE
feat: implement API key management UI

### DIFF
--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -1,847 +1,977 @@
-export type Maybe<T> = T | null
-export type InputMaybe<T> = Maybe<T>
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never }
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never }
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string }
-  String: { input: string; output: string }
-  Boolean: { input: boolean; output: boolean }
-  Int: { input: number; output: number }
-  Float: { input: number; output: number }
-  DateTime: { input: string; output: string }
-  JSON: {
-    input: { [key: string]: any } | string | number | boolean | null
-    output: { [key: string]: any } | string | number | boolean | null
-  }
-}
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: string; output: string; }
+  JSON: { input: { [key: string]: any } | string | number | boolean | null; output: { [key: string]: any } | string | number | boolean | null; }
+  JSONObject: { input: any; output: any; }
+};
 
 export type ActivateEarlyAccessInput = {
-  organizationId: Scalars['ID']['input']
-  planId: Scalars['ID']['input']
-}
+  organizationId: Scalars['ID']['input'];
+  planId: Scalars['ID']['input'];
+};
 
 export type AddUserToOrganizationInput = {
-  organizationId: Scalars['String']['input']
-  roleId: UserOrganizationRoles
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  roleId: UserOrganizationRoles;
+  userId: Scalars['String']['input'];
+};
 
 export type AddUserToProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  roleId: UserProjectRoles
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  roleId: UserProjectRoles;
+  userId: Scalars['String']['input'];
+};
 
 export type AddedRowChangeModel = {
-  __typename: 'AddedRowChangeModel'
-  changeType: ChangeType
-  fieldChanges: Array<FieldChangeModel>
-  row: RowChangeRowModel
-  table: RowChangeTableModel
-}
+  __typename: 'AddedRowChangeModel';
+  changeType: ChangeType;
+  fieldChanges: Array<FieldChangeModel>;
+  row: RowChangeRowModel;
+  table: RowChangeTableModel;
+};
 
 export type AdminUserInput = {
-  userId: Scalars['String']['input']
+  userId: Scalars['String']['input'];
+};
+
+export type ApiKeyModel = {
+  __typename: 'ApiKeyModel';
+  allowedIps: Array<Scalars['String']['output']>;
+  branchNames: Array<Scalars['String']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  expiresAt?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['ID']['output'];
+  lastUsedAt?: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  organizationId?: Maybe<Scalars['String']['output']>;
+  permissions?: Maybe<Scalars['JSON']['output']>;
+  prefix: Scalars['String']['output'];
+  projectIds: Array<Scalars['String']['output']>;
+  readOnly: Scalars['Boolean']['output'];
+  revokedAt?: Maybe<Scalars['DateTime']['output']>;
+  tableIds: Array<Scalars['String']['output']>;
+  type: ApiKeyType;
+};
+
+export enum ApiKeyType {
+  INTERNAL = 'INTERNAL',
+  PERSONAL = 'PERSONAL',
+  SERVICE = 'SERVICE'
 }
 
+export type ApiKeyWithSecretModel = {
+  __typename: 'ApiKeyWithSecretModel';
+  apiKey: ApiKeyModel;
+  secret: Scalars['String']['output'];
+};
+
 export type ApplyMigrationResultModel = {
-  __typename: 'ApplyMigrationResultModel'
-  error?: Maybe<Scalars['String']['output']>
-  id: Scalars['String']['output']
-  status: ApplyMigrationStatus
-}
+  __typename: 'ApplyMigrationResultModel';
+  error?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  status: ApplyMigrationStatus;
+};
 
 /** Status of migration application */
 export enum ApplyMigrationStatus {
   APPLIED = 'applied',
   FAILED = 'failed',
-  SKIPPED = 'skipped',
+  SKIPPED = 'skipped'
 }
 
 export type ApplyMigrationsInput = {
-  migrations: Array<Scalars['JSON']['input']>
-  revisionId: Scalars['String']['input']
-}
+  migrations: Array<Scalars['JSON']['input']>;
+  revisionId: Scalars['String']['input'];
+};
 
 export type BillingConfigurationModel = {
-  __typename: 'BillingConfigurationModel'
-  enabled: Scalars['Boolean']['output']
-}
+  __typename: 'BillingConfigurationModel';
+  enabled: Scalars['Boolean']['output'];
+};
 
 export enum BillingStatus {
   ACTIVE = 'active',
   CANCELLED = 'cancelled',
   EARLY_ADOPTER = 'early_adopter',
   FREE = 'free',
-  PAST_DUE = 'past_due',
+  PAST_DUE = 'past_due'
 }
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']['input']>
-  not?: InputMaybe<Scalars['Boolean']['input']>
-}
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<Scalars['Boolean']['input']>;
+};
 
 export type BranchModel = {
-  __typename: 'BranchModel'
-  createdAt: Scalars['DateTime']['output']
-  draft: RevisionModel
-  head: RevisionModel
-  id: Scalars['String']['output']
-  isRoot: Scalars['Boolean']['output']
-  name: Scalars['String']['output']
-  parent?: Maybe<ParentBranchModel>
-  project: ProjectModel
-  projectId: Scalars['String']['output']
-  revisions: RevisionConnection
-  start: RevisionModel
-  touched: Scalars['Boolean']['output']
-}
+  __typename: 'BranchModel';
+  createdAt: Scalars['DateTime']['output'];
+  draft: RevisionModel;
+  head: RevisionModel;
+  id: Scalars['String']['output'];
+  isRoot: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  parent?: Maybe<ParentBranchModel>;
+  project: ProjectModel;
+  projectId: Scalars['String']['output'];
+  revisions: RevisionConnection;
+  start: RevisionModel;
+  touched: Scalars['Boolean']['output'];
+};
+
 
 export type BranchModelRevisionsArgs = {
-  data: GetBranchRevisionsInput
-}
+  data: GetBranchRevisionsInput;
+};
 
 export type BranchModelEdge = {
-  __typename: 'BranchModelEdge'
-  cursor: Scalars['String']['output']
-  node: BranchModel
-}
+  __typename: 'BranchModelEdge';
+  cursor: Scalars['String']['output'];
+  node: BranchModel;
+};
 
 export type BranchesConnection = {
-  __typename: 'BranchesConnection'
-  edges: Array<BranchModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'BranchesConnection';
+  edges: Array<BranchModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type CancelSubscriptionInput = {
-  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>
-  organizationId: Scalars['ID']['input']
-}
+  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>;
+  organizationId: Scalars['ID']['input'];
+};
+
+export type CaslPermissionsInput = {
+  rules: Array<CaslRuleInput>;
+};
+
+export type CaslRuleInput = {
+  action: Array<Scalars['String']['input']>;
+  conditions?: InputMaybe<Scalars['JSONObject']['input']>;
+  fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  inverted?: InputMaybe<Scalars['Boolean']['input']>;
+  subject: Array<Scalars['String']['input']>;
+};
 
 export enum ChangeType {
   ADDED = 'ADDED',
   MODIFIED = 'MODIFIED',
   REMOVED = 'REMOVED',
   RENAMED = 'RENAMED',
-  RENAMED_AND_MODIFIED = 'RENAMED_AND_MODIFIED',
+  RENAMED_AND_MODIFIED = 'RENAMED_AND_MODIFIED'
 }
 
 export type CheckoutResultModel = {
-  __typename: 'CheckoutResultModel'
-  checkoutUrl: Scalars['String']['output']
-}
+  __typename: 'CheckoutResultModel';
+  checkoutUrl: Scalars['String']['output'];
+};
 
 export type ChildBranchModel = {
-  __typename: 'ChildBranchModel'
-  branch: BranchModel
-  revision: RevisionModel
-}
+  __typename: 'ChildBranchModel';
+  branch: BranchModel;
+  revision: RevisionModel;
+};
 
 export type ConfigurationModel = {
-  __typename: 'ConfigurationModel'
-  availableEmailSignUp: Scalars['Boolean']['output']
-  billing: BillingConfigurationModel
-  github: GithubOauth
-  google: GoogleOauth
-  noAuth: Scalars['Boolean']['output']
-  plugins: PluginsModel
-}
+  __typename: 'ConfigurationModel';
+  availableEmailSignUp: Scalars['Boolean']['output'];
+  billing: BillingConfigurationModel;
+  github: GithubOauth;
+  google: GoogleOauth;
+  noAuth: Scalars['Boolean']['output'];
+  plugins: PluginsModel;
+};
 
 export type ConfirmEmailCodeInput = {
-  code: Scalars['String']['input']
-}
+  code: Scalars['String']['input'];
+};
 
 export type CreateBranchInput = {
-  branchName: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type CreateCheckoutInput = {
-  cancelUrl: Scalars['String']['input']
-  country?: InputMaybe<Scalars['String']['input']>
-  interval?: InputMaybe<Scalars['String']['input']>
-  method?: InputMaybe<Scalars['String']['input']>
-  organizationId: Scalars['ID']['input']
-  planId: Scalars['ID']['input']
-  providerId?: InputMaybe<Scalars['String']['input']>
-  successUrl: Scalars['String']['input']
-}
+  cancelUrl: Scalars['String']['input'];
+  country?: InputMaybe<Scalars['String']['input']>;
+  interval?: InputMaybe<Scalars['String']['input']>;
+  method?: InputMaybe<Scalars['String']['input']>;
+  organizationId: Scalars['ID']['input'];
+  planId: Scalars['ID']['input'];
+  providerId?: InputMaybe<Scalars['String']['input']>;
+  successUrl: Scalars['String']['input'];
+};
 
 export type CreateEndpointInput = {
-  revisionId: Scalars['String']['input']
-  type: EndpointType
-}
+  revisionId: Scalars['String']['input'];
+  type: EndpointType;
+};
+
+export type CreatePersonalApiKeyInput = {
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
+  name: Scalars['String']['input'];
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
+};
 
 export type CreateProjectInput = {
-  branchName?: InputMaybe<Scalars['String']['input']>
-  fromRevisionId?: InputMaybe<Scalars['String']['input']>
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName?: InputMaybe<Scalars['String']['input']>;
+  fromRevisionId?: InputMaybe<Scalars['String']['input']>;
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type CreateRevisionInput = {
-  branchName: Scalars['String']['input']
-  comment?: InputMaybe<Scalars['String']['input']>
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  comment?: InputMaybe<Scalars['String']['input']>;
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type CreateRowInput = {
-  data: Scalars['JSON']['input']
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type CreateRowResultModel = {
-  __typename: 'CreateRowResultModel'
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  __typename: 'CreateRowResultModel';
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type CreateRowsInput = {
-  isRestore?: InputMaybe<Scalars['Boolean']['input']>
-  revisionId: Scalars['String']['input']
-  rows: Array<CreateRowsRowInput>
-  tableId: Scalars['String']['input']
-}
+  isRestore?: InputMaybe<Scalars['Boolean']['input']>;
+  revisionId: Scalars['String']['input'];
+  rows: Array<CreateRowsRowInput>;
+  tableId: Scalars['String']['input'];
+};
 
 export type CreateRowsResultModel = {
-  __typename: 'CreateRowsResultModel'
-  previousVersionTableId: Scalars['String']['output']
-  rows: Array<RowModel>
-  table: TableModel
-}
+  __typename: 'CreateRowsResultModel';
+  previousVersionTableId: Scalars['String']['output'];
+  rows: Array<RowModel>;
+  table: TableModel;
+};
 
 export type CreateRowsRowInput = {
-  data: Scalars['JSON']['input']
-  rowId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  rowId: Scalars['String']['input'];
+};
+
+export type CreateServiceApiKeyInput = {
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
+  name: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  permissions: CaslPermissionsInput;
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
+};
 
 export type CreateTableInput = {
-  revisionId: Scalars['String']['input']
-  schema: Scalars['JSON']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  schema: Scalars['JSON']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type CreateTableResultModel = {
-  __typename: 'CreateTableResultModel'
-  branch: BranchModel
-  table: TableModel
-}
+  __typename: 'CreateTableResultModel';
+  branch: BranchModel;
+  table: TableModel;
+};
 
 export type CreateUserInput = {
-  email?: InputMaybe<Scalars['String']['input']>
-  password: Scalars['String']['input']
-  roleId: UserSystemRole
-  username: Scalars['String']['input']
-}
+  email?: InputMaybe<Scalars['String']['input']>;
+  password: Scalars['String']['input'];
+  roleId: UserSystemRole;
+  username: Scalars['String']['input'];
+};
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['String']['input']>
-  gt?: InputMaybe<Scalars['String']['input']>
-  gte?: InputMaybe<Scalars['String']['input']>
-  in?: InputMaybe<Array<Scalars['String']['input']>>
-  lt?: InputMaybe<Scalars['String']['input']>
-  lte?: InputMaybe<Scalars['String']['input']>
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>
-}
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+};
 
 export type DeleteBranchInput = {
-  branchName: Scalars['String']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type DeleteEndpointInput = {
-  endpointId: Scalars['String']['input']
-}
+  endpointId: Scalars['String']['input'];
+};
 
 export type DeleteProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type DeleteRowInput = {
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type DeleteRowResultModel = {
-  __typename: 'DeleteRowResultModel'
-  branch: BranchModel
-  previousVersionTableId?: Maybe<Scalars['String']['output']>
-  table?: Maybe<TableModel>
-}
+  __typename: 'DeleteRowResultModel';
+  branch: BranchModel;
+  previousVersionTableId?: Maybe<Scalars['String']['output']>;
+  table?: Maybe<TableModel>;
+};
 
 export type DeleteRowsInput = {
-  revisionId: Scalars['String']['input']
-  rowIds: Array<Scalars['String']['input']>
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowIds: Array<Scalars['String']['input']>;
+  tableId: Scalars['String']['input'];
+};
 
 export type DeleteRowsResultModel = {
-  __typename: 'DeleteRowsResultModel'
-  branch: BranchModel
-  previousVersionTableId?: Maybe<Scalars['String']['output']>
-  table?: Maybe<TableModel>
-}
+  __typename: 'DeleteRowsResultModel';
+  branch: BranchModel;
+  previousVersionTableId?: Maybe<Scalars['String']['output']>;
+  table?: Maybe<TableModel>;
+};
 
 export type DeleteTableInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type DeleteTableResultModel = {
-  __typename: 'DeleteTableResultModel'
-  branch: BranchModel
-}
+  __typename: 'DeleteTableResultModel';
+  branch: BranchModel;
+};
 
 export type EndpointModel = {
-  __typename: 'EndpointModel'
-  createdAt: Scalars['DateTime']['output']
-  id: Scalars['String']['output']
-  revision: RevisionModel
-  revisionId: Scalars['String']['output']
-  type: EndpointType
-}
+  __typename: 'EndpointModel';
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  revision: RevisionModel;
+  revisionId: Scalars['String']['output'];
+  type: EndpointType;
+};
 
 export type EndpointModelEdge = {
-  __typename: 'EndpointModelEdge'
-  cursor: Scalars['String']['output']
-  node: EndpointModel
-}
+  __typename: 'EndpointModelEdge';
+  cursor: Scalars['String']['output'];
+  node: EndpointModel;
+};
 
 export enum EndpointType {
   GRAPHQL = 'GRAPHQL',
-  REST_API = 'REST_API',
+  REST_API = 'REST_API'
 }
 
 export type EndpointsConnection = {
-  __typename: 'EndpointsConnection'
-  edges: Array<EndpointModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'EndpointsConnection';
+  edges: Array<EndpointModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type FieldChangeModel = {
-  __typename: 'FieldChangeModel'
-  changeType: RowChangeDetailType
-  fieldPath: Scalars['String']['output']
-  movedFrom?: Maybe<Scalars['String']['output']>
-  newValue?: Maybe<Scalars['JSON']['output']>
-  oldValue?: Maybe<Scalars['JSON']['output']>
-}
+  __typename: 'FieldChangeModel';
+  changeType: RowChangeDetailType;
+  fieldPath: Scalars['String']['output'];
+  movedFrom?: Maybe<Scalars['String']['output']>;
+  newValue?: Maybe<Scalars['JSON']['output']>;
+  oldValue?: Maybe<Scalars['JSON']['output']>;
+};
 
 export type FormulaFieldErrorModel = {
-  __typename: 'FormulaFieldErrorModel'
-  defaultUsed: Scalars['Boolean']['output']
-  error: Scalars['String']['output']
-  expression: Scalars['String']['output']
-  field: Scalars['String']['output']
-}
+  __typename: 'FormulaFieldErrorModel';
+  defaultUsed: Scalars['Boolean']['output'];
+  error: Scalars['String']['output'];
+  expression: Scalars['String']['output'];
+  field: Scalars['String']['output'];
+};
 
 export type GetBranchInput = {
-  branchName: Scalars['String']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GetBranchRevisionsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  before?: InputMaybe<Scalars['String']['input']>
-  comment?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  inclusive?: InputMaybe<Scalars['Boolean']['input']>
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  comment?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  inclusive?: InputMaybe<Scalars['Boolean']['input']>;
   /** Sort order: asc (default) or desc */
-  sort?: InputMaybe<SortOrder>
-}
+  sort?: InputMaybe<SortOrder>;
+};
 
 export type GetBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GetMeProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetOrganizationInput = {
-  organizationId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+};
 
 export type GetProjectBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetProjectEndpointsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  branchId?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  type?: InputMaybe<EndpointType>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  branchId?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  type?: InputMaybe<EndpointType>;
+};
 
 export type GetProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GetProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+};
 
 export type GetRevisionChangesInput = {
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
-  revisionId: Scalars['String']['input']
-}
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetRevisionInput = {
-  revisionId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetRevisionTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetRowChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<RowChangesFiltersInput>
-  first: Scalars['Int']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<RowChangesFiltersInput>;
+  first: Scalars['Int']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetRowCountForeignKeysByInput = {
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetRowForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  foreignKeyTableId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  foreignKeyTableId: Scalars['String']['input'];
+};
 
 export type GetRowInput = {
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  orderBy?: InputMaybe<Array<OrderBy>>
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-  where?: InputMaybe<WhereInput>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  orderBy?: InputMaybe<Array<OrderBy>>;
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+  where?: InputMaybe<WhereInput>;
+};
 
 export type GetSubSchemaItemsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>
-  revisionId: Scalars['String']['input']
-  schemaId: Scalars['String']['input']
-  where?: InputMaybe<SubSchemaWhereInput>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>;
+  revisionId: Scalars['String']['input'];
+  schemaId: Scalars['String']['input'];
+  where?: InputMaybe<SubSchemaWhereInput>;
+};
 
 export type GetTableChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<TableChangesFiltersInput>
-  first: Scalars['Int']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<TableChangesFiltersInput>;
+  first: Scalars['Int']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetTableForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetTableInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetTableRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetTableViewsInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetUsersOrganizationInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+};
 
 export type GetUsersProjectInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GithubOauth = {
-  __typename: 'GithubOauth'
-  available: Scalars['Boolean']['output']
-  clientId?: Maybe<Scalars['String']['output']>
-}
+  __typename: 'GithubOauth';
+  available: Scalars['Boolean']['output'];
+  clientId?: Maybe<Scalars['String']['output']>;
+};
 
 export type GoogleOauth = {
-  __typename: 'GoogleOauth'
-  available: Scalars['Boolean']['output']
-  clientId?: Maybe<Scalars['String']['output']>
-}
+  __typename: 'GoogleOauth';
+  available: Scalars['Boolean']['output'];
+  clientId?: Maybe<Scalars['String']['output']>;
+};
 
 export type HistoryPatchModel = {
-  __typename: 'HistoryPatchModel'
-  hash: Scalars['String']['output']
-  patches: Array<JsonPatchOperationModel>
-}
+  __typename: 'HistoryPatchModel';
+  hash: Scalars['String']['output'];
+  patches: Array<JsonPatchOperationModel>;
+};
 
 export type JsonFilter = {
-  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>
-  array_ends_with?: InputMaybe<Scalars['JSON']['input']>
-  array_starts_with?: InputMaybe<Scalars['JSON']['input']>
-  equals?: InputMaybe<Scalars['JSON']['input']>
-  gt?: InputMaybe<Scalars['Float']['input']>
-  gte?: InputMaybe<Scalars['Float']['input']>
-  lt?: InputMaybe<Scalars['Float']['input']>
-  lte?: InputMaybe<Scalars['Float']['input']>
-  mode?: InputMaybe<QueryMode>
-  path?: InputMaybe<Array<Scalars['String']['input']>>
-  search?: InputMaybe<Scalars['String']['input']>
-  searchIn?: InputMaybe<SearchIn>
+  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>;
+  array_ends_with?: InputMaybe<Scalars['JSON']['input']>;
+  array_starts_with?: InputMaybe<Scalars['JSON']['input']>;
+  equals?: InputMaybe<Scalars['JSON']['input']>;
+  gt?: InputMaybe<Scalars['Float']['input']>;
+  gte?: InputMaybe<Scalars['Float']['input']>;
+  lt?: InputMaybe<Scalars['Float']['input']>;
+  lte?: InputMaybe<Scalars['Float']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  path?: InputMaybe<Array<Scalars['String']['input']>>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  searchIn?: InputMaybe<SearchIn>;
   /** Default: simple */
-  searchLanguage?: InputMaybe<SearchLanguage>
-  searchType?: InputMaybe<SearchType>
-  string_contains?: InputMaybe<Scalars['String']['input']>
-  string_ends_with?: InputMaybe<Scalars['String']['input']>
-  string_starts_with?: InputMaybe<Scalars['String']['input']>
-}
+  searchLanguage?: InputMaybe<SearchLanguage>;
+  searchType?: InputMaybe<SearchType>;
+  string_contains?: InputMaybe<Scalars['String']['input']>;
+  string_ends_with?: InputMaybe<Scalars['String']['input']>;
+  string_starts_with?: InputMaybe<Scalars['String']['input']>;
+};
 
 export enum JsonPatchOp {
   ADD = 'ADD',
   COPY = 'COPY',
   MOVE = 'MOVE',
   REMOVE = 'REMOVE',
-  REPLACE = 'REPLACE',
+  REPLACE = 'REPLACE'
 }
 
 export type JsonPatchOperationModel = {
-  __typename: 'JsonPatchOperationModel'
-  from?: Maybe<Scalars['String']['output']>
-  op: JsonPatchOp
-  path: Scalars['String']['output']
-  value?: Maybe<Scalars['JSON']['output']>
-}
+  __typename: 'JsonPatchOperationModel';
+  from?: Maybe<Scalars['String']['output']>;
+  op: JsonPatchOp;
+  path: Scalars['String']['output'];
+  value?: Maybe<Scalars['JSON']['output']>;
+};
 
 export type LoginGithubInput = {
-  code: Scalars['String']['input']
-}
+  code: Scalars['String']['input'];
+};
 
 export type LoginGoogleInput = {
-  code: Scalars['String']['input']
-  redirectUrl: Scalars['String']['input']
-}
+  code: Scalars['String']['input'];
+  redirectUrl: Scalars['String']['input'];
+};
 
 export type LoginInput = {
-  emailOrUsername: Scalars['String']['input']
-  password: Scalars['String']['input']
-}
+  emailOrUsername: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+};
 
 export type LoginModel = {
-  __typename: 'LoginModel'
-  accessToken: Scalars['String']['output']
-}
+  __typename: 'LoginModel';
+  accessToken: Scalars['String']['output'];
+};
 
 export type MeModel = {
-  __typename: 'MeModel'
-  email?: Maybe<Scalars['String']['output']>
-  hasPassword: Scalars['Boolean']['output']
-  id: Scalars['String']['output']
-  organization?: Maybe<OrganizationModel>
-  organizationId?: Maybe<Scalars['String']['output']>
-  role?: Maybe<RoleModel>
-  username?: Maybe<Scalars['String']['output']>
-}
+  __typename: 'MeModel';
+  email?: Maybe<Scalars['String']['output']>;
+  hasPassword: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
+  organization?: Maybe<OrganizationModel>;
+  organizationId?: Maybe<Scalars['String']['output']>;
+  role?: Maybe<RoleModel>;
+  username?: Maybe<Scalars['String']['output']>;
+};
 
 export enum MigrationType {
   INIT = 'INIT',
   REMOVE = 'REMOVE',
   RENAME = 'RENAME',
-  UPDATE = 'UPDATE',
+  UPDATE = 'UPDATE'
 }
 
 export type ModifiedRowChangeModel = {
-  __typename: 'ModifiedRowChangeModel'
-  changeType: ChangeType
-  fieldChanges: Array<FieldChangeModel>
-  fromRow: RowChangeRowModel
-  fromTable: RowChangeTableModel
-  row: RowChangeRowModel
-  table: RowChangeTableModel
-}
+  __typename: 'ModifiedRowChangeModel';
+  changeType: ChangeType;
+  fieldChanges: Array<FieldChangeModel>;
+  fromRow: RowChangeRowModel;
+  fromTable: RowChangeTableModel;
+  row: RowChangeRowModel;
+  table: RowChangeTableModel;
+};
 
 export type Mutation = {
-  __typename: 'Mutation'
-  activateEarlyAccess: SubscriptionModel
-  addUserToOrganization: Scalars['Boolean']['output']
-  addUserToProject: Scalars['Boolean']['output']
-  applyMigrations: Array<ApplyMigrationResultModel>
-  cancelSubscription: Scalars['Boolean']['output']
-  confirmEmailCode: LoginModel
-  createBranch: BranchModel
-  createCheckout: CheckoutResultModel
-  createEndpoint: EndpointModel
-  createProject: ProjectModel
-  createRevision: RevisionModel
-  createRow: CreateRowResultModel
-  createRows: CreateRowsResultModel
-  createTable: CreateTableResultModel
-  createUser: Scalars['Boolean']['output']
-  deleteBranch: Scalars['Boolean']['output']
-  deleteEndpoint: Scalars['Boolean']['output']
-  deleteProject: Scalars['Boolean']['output']
-  deleteRow: DeleteRowResultModel
-  deleteRows: DeleteRowsResultModel
-  deleteTable: DeleteTableResultModel
-  login: LoginModel
-  loginGithub: LoginModel
-  loginGoogle: LoginModel
-  patchRow: PatchRowResultModel
-  patchRows: PatchRowsResultModel
-  removeUserFromOrganization: Scalars['Boolean']['output']
-  removeUserFromProject: Scalars['Boolean']['output']
-  renameRow: RenameRowResultModel
-  renameTable: RenameTableResultModel
-  resetPassword: Scalars['Boolean']['output']
-  revertChanges: BranchModel
-  setUsername: Scalars['Boolean']['output']
-  signUp: Scalars['Boolean']['output']
-  updatePassword: Scalars['Boolean']['output']
-  updateProject: Scalars['Boolean']['output']
-  updateRow: UpdateRowResultModel
-  updateRows: UpdateRowsResultModel
-  updateTable: UpdateTableResultModel
-  updateTableViews: TableViewsDataModel
-  updateUserProjectRole: Scalars['Boolean']['output']
-}
+  __typename: 'Mutation';
+  activateEarlyAccess: SubscriptionModel;
+  addUserToOrganization: Scalars['Boolean']['output'];
+  addUserToProject: Scalars['Boolean']['output'];
+  applyMigrations: Array<ApplyMigrationResultModel>;
+  cancelSubscription: Scalars['Boolean']['output'];
+  confirmEmailCode: LoginModel;
+  createBranch: BranchModel;
+  createCheckout: CheckoutResultModel;
+  createEndpoint: EndpointModel;
+  createPersonalApiKey: ApiKeyWithSecretModel;
+  createProject: ProjectModel;
+  createRevision: RevisionModel;
+  createRow: CreateRowResultModel;
+  createRows: CreateRowsResultModel;
+  createServiceApiKey: ApiKeyWithSecretModel;
+  createTable: CreateTableResultModel;
+  createUser: Scalars['Boolean']['output'];
+  deleteBranch: Scalars['Boolean']['output'];
+  deleteEndpoint: Scalars['Boolean']['output'];
+  deleteProject: Scalars['Boolean']['output'];
+  deleteRow: DeleteRowResultModel;
+  deleteRows: DeleteRowsResultModel;
+  deleteTable: DeleteTableResultModel;
+  login: LoginModel;
+  loginGithub: LoginModel;
+  loginGoogle: LoginModel;
+  patchRow: PatchRowResultModel;
+  patchRows: PatchRowsResultModel;
+  removeUserFromOrganization: Scalars['Boolean']['output'];
+  removeUserFromProject: Scalars['Boolean']['output'];
+  renameRow: RenameRowResultModel;
+  renameTable: RenameTableResultModel;
+  resetPassword: Scalars['Boolean']['output'];
+  revertChanges: BranchModel;
+  revokeApiKey: ApiKeyModel;
+  rotateApiKey: ApiKeyWithSecretModel;
+  setUsername: Scalars['Boolean']['output'];
+  signUp: Scalars['Boolean']['output'];
+  updatePassword: Scalars['Boolean']['output'];
+  updateProject: Scalars['Boolean']['output'];
+  updateRow: UpdateRowResultModel;
+  updateRows: UpdateRowsResultModel;
+  updateTable: UpdateTableResultModel;
+  updateTableViews: TableViewsDataModel;
+  updateUserProjectRole: Scalars['Boolean']['output'];
+};
+
 
 export type MutationActivateEarlyAccessArgs = {
-  data: ActivateEarlyAccessInput
-}
+  data: ActivateEarlyAccessInput;
+};
+
 
 export type MutationAddUserToOrganizationArgs = {
-  data: AddUserToOrganizationInput
-}
+  data: AddUserToOrganizationInput;
+};
+
 
 export type MutationAddUserToProjectArgs = {
-  data: AddUserToProjectInput
-}
+  data: AddUserToProjectInput;
+};
+
 
 export type MutationApplyMigrationsArgs = {
-  data: ApplyMigrationsInput
-}
+  data: ApplyMigrationsInput;
+};
+
 
 export type MutationCancelSubscriptionArgs = {
-  data: CancelSubscriptionInput
-}
+  data: CancelSubscriptionInput;
+};
+
 
 export type MutationConfirmEmailCodeArgs = {
-  data: ConfirmEmailCodeInput
-}
+  data: ConfirmEmailCodeInput;
+};
+
 
 export type MutationCreateBranchArgs = {
-  data: CreateBranchInput
-}
+  data: CreateBranchInput;
+};
+
 
 export type MutationCreateCheckoutArgs = {
-  data: CreateCheckoutInput
-}
+  data: CreateCheckoutInput;
+};
+
 
 export type MutationCreateEndpointArgs = {
-  data: CreateEndpointInput
-}
+  data: CreateEndpointInput;
+};
+
+
+export type MutationCreatePersonalApiKeyArgs = {
+  data: CreatePersonalApiKeyInput;
+};
+
 
 export type MutationCreateProjectArgs = {
-  data: CreateProjectInput
-}
+  data: CreateProjectInput;
+};
+
 
 export type MutationCreateRevisionArgs = {
-  data: CreateRevisionInput
-}
+  data: CreateRevisionInput;
+};
+
 
 export type MutationCreateRowArgs = {
-  data: CreateRowInput
-}
+  data: CreateRowInput;
+};
+
 
 export type MutationCreateRowsArgs = {
-  data: CreateRowsInput
-}
+  data: CreateRowsInput;
+};
+
+
+export type MutationCreateServiceApiKeyArgs = {
+  data: CreateServiceApiKeyInput;
+};
+
 
 export type MutationCreateTableArgs = {
-  data: CreateTableInput
-}
+  data: CreateTableInput;
+};
+
 
 export type MutationCreateUserArgs = {
-  data: CreateUserInput
-}
+  data: CreateUserInput;
+};
+
 
 export type MutationDeleteBranchArgs = {
-  data: DeleteBranchInput
-}
+  data: DeleteBranchInput;
+};
+
 
 export type MutationDeleteEndpointArgs = {
-  data: DeleteEndpointInput
-}
+  data: DeleteEndpointInput;
+};
+
 
 export type MutationDeleteProjectArgs = {
-  data: DeleteProjectInput
-}
+  data: DeleteProjectInput;
+};
+
 
 export type MutationDeleteRowArgs = {
-  data: DeleteRowInput
-}
+  data: DeleteRowInput;
+};
+
 
 export type MutationDeleteRowsArgs = {
-  data: DeleteRowsInput
-}
+  data: DeleteRowsInput;
+};
+
 
 export type MutationDeleteTableArgs = {
-  data: DeleteTableInput
-}
+  data: DeleteTableInput;
+};
+
 
 export type MutationLoginArgs = {
-  data: LoginInput
-}
+  data: LoginInput;
+};
+
 
 export type MutationLoginGithubArgs = {
-  data: LoginGithubInput
-}
+  data: LoginGithubInput;
+};
+
 
 export type MutationLoginGoogleArgs = {
-  data: LoginGoogleInput
-}
+  data: LoginGoogleInput;
+};
+
 
 export type MutationPatchRowArgs = {
-  data: PatchRowInput
-}
+  data: PatchRowInput;
+};
+
 
 export type MutationPatchRowsArgs = {
-  data: PatchRowsInput
-}
+  data: PatchRowsInput;
+};
+
 
 export type MutationRemoveUserFromOrganizationArgs = {
-  data: RemoveUserFromOrganizationInput
-}
+  data: RemoveUserFromOrganizationInput;
+};
+
 
 export type MutationRemoveUserFromProjectArgs = {
-  data: RemoveUserFromProjectInput
-}
+  data: RemoveUserFromProjectInput;
+};
+
 
 export type MutationRenameRowArgs = {
-  data: RenameRowInput
-}
+  data: RenameRowInput;
+};
+
 
 export type MutationRenameTableArgs = {
-  data: RenameTableInput
-}
+  data: RenameTableInput;
+};
+
 
 export type MutationResetPasswordArgs = {
-  data: ResetPasswordInput
-}
+  data: ResetPasswordInput;
+};
+
 
 export type MutationRevertChangesArgs = {
-  data: RevertChangesInput
-}
+  data: RevertChangesInput;
+};
+
+
+export type MutationRevokeApiKeyArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationRotateApiKeyArgs = {
+  id: Scalars['ID']['input'];
+};
+
 
 export type MutationSetUsernameArgs = {
-  data: SetUsernameInput
-}
+  data: SetUsernameInput;
+};
+
 
 export type MutationSignUpArgs = {
-  data: SignUpInput
-}
+  data: SignUpInput;
+};
+
 
 export type MutationUpdatePasswordArgs = {
-  data: UpdatePasswordInput
-}
+  data: UpdatePasswordInput;
+};
+
 
 export type MutationUpdateProjectArgs = {
-  data: UpdateProjectInput
-}
+  data: UpdateProjectInput;
+};
+
 
 export type MutationUpdateRowArgs = {
-  data: UpdateRowInput
-}
+  data: UpdateRowInput;
+};
+
 
 export type MutationUpdateRowsArgs = {
-  data: UpdateRowsInput
-}
+  data: UpdateRowsInput;
+};
+
 
 export type MutationUpdateTableArgs = {
-  data: UpdateTableInput
-}
+  data: UpdateTableInput;
+};
+
 
 export type MutationUpdateTableViewsArgs = {
-  data: UpdateTableViewsInput
-}
+  data: UpdateTableViewsInput;
+};
+
 
 export type MutationUpdateUserProjectRoleArgs = {
-  data: UpdateUserProjectRoleInput
-}
+  data: UpdateUserProjectRoleInput;
+};
 
 export enum NullsPosition {
   FIRST = 'first',
-  LAST = 'last',
+  LAST = 'last'
 }
 
 export type OrderBy = {
-  aggregation?: InputMaybe<OrderDataAggregation>
-  direction: SortOrder
-  field: OrderByField
-  path?: InputMaybe<Scalars['String']['input']>
-  type?: InputMaybe<OrderDataType>
-}
+  aggregation?: InputMaybe<OrderDataAggregation>;
+  direction: SortOrder;
+  field: OrderByField;
+  path?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<OrderDataType>;
+};
 
 export enum OrderByField {
   CREATEDAT = 'createdAt',
   DATA = 'data',
   ID = 'id',
   PUBLISHEDAT = 'publishedAt',
-  UPDATEDAT = 'updatedAt',
+  UPDATEDAT = 'updatedAt'
 }
 
 export enum OrderDataAggregation {
@@ -849,7 +979,7 @@ export enum OrderDataAggregation {
   FIRST = 'first',
   LAST = 'last',
   MAX = 'max',
-  MIN = 'min',
+  MIN = 'min'
 }
 
 export enum OrderDataType {
@@ -857,516 +987,561 @@ export enum OrderDataType {
   FLOAT = 'float',
   INT = 'int',
   TEXT = 'text',
-  TIMESTAMP = 'timestamp',
+  TIMESTAMP = 'timestamp'
 }
 
 export type OrganizationModel = {
-  __typename: 'OrganizationModel'
-  createdId: Scalars['String']['output']
-  id: Scalars['String']['output']
-  subscription?: Maybe<SubscriptionModel>
-  usage?: Maybe<UsageSummaryModel>
-  userOrganization?: Maybe<UsersOrganizationModel>
-}
+  __typename: 'OrganizationModel';
+  createdId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  subscription?: Maybe<SubscriptionModel>;
+  usage?: Maybe<UsageSummaryModel>;
+  userOrganization?: Maybe<UsersOrganizationModel>;
+};
 
 export type PageInfo = {
-  __typename: 'PageInfo'
-  endCursor?: Maybe<Scalars['String']['output']>
-  hasNextPage: Scalars['Boolean']['output']
-  hasPreviousPage: Scalars['Boolean']['output']
-  startCursor?: Maybe<Scalars['String']['output']>
-}
+  __typename: 'PageInfo';
+  endCursor?: Maybe<Scalars['String']['output']>;
+  hasNextPage: Scalars['Boolean']['output'];
+  hasPreviousPage: Scalars['Boolean']['output'];
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
 
 export type ParentBranchModel = {
-  __typename: 'ParentBranchModel'
-  branch: BranchModel
-  revision: RevisionModel
-}
+  __typename: 'ParentBranchModel';
+  branch: BranchModel;
+  revision: RevisionModel;
+};
 
 export type PatchRow = {
-  op: PatchRowOp
-  path: Scalars['String']['input']
-  value: Scalars['JSON']['input']
-}
+  op: PatchRowOp;
+  path: Scalars['String']['input'];
+  value: Scalars['JSON']['input'];
+};
 
 export type PatchRowInput = {
-  patches: Array<PatchRow>
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  patches: Array<PatchRow>;
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export enum PatchRowOp {
-  REPLACE = 'replace',
+  REPLACE = 'replace'
 }
 
 export type PatchRowResultModel = {
-  __typename: 'PatchRowResultModel'
-  previousVersionRowId: Scalars['String']['output']
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  __typename: 'PatchRowResultModel';
+  previousVersionRowId: Scalars['String']['output'];
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type PatchRowsInput = {
-  revisionId: Scalars['String']['input']
-  rows: Array<PatchRowsRowInput>
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rows: Array<PatchRowsRowInput>;
+  tableId: Scalars['String']['input'];
+};
 
 export type PatchRowsResultModel = {
-  __typename: 'PatchRowsResultModel'
-  previousVersionTableId: Scalars['String']['output']
-  rows: Array<RowModel>
-  table: TableModel
-}
+  __typename: 'PatchRowsResultModel';
+  previousVersionTableId: Scalars['String']['output'];
+  rows: Array<RowModel>;
+  table: TableModel;
+};
 
 export type PatchRowsRowInput = {
-  patches: Array<PatchRow>
-  rowId: Scalars['String']['input']
-}
+  patches: Array<PatchRow>;
+  rowId: Scalars['String']['input'];
+};
 
 export type PaymentProviderModel = {
-  __typename: 'PaymentProviderModel'
-  id: Scalars['ID']['output']
-  methods: Array<Scalars['String']['output']>
-  name: Scalars['String']['output']
-  supportsRecurring: Scalars['Boolean']['output']
-}
+  __typename: 'PaymentProviderModel';
+  id: Scalars['ID']['output'];
+  methods: Array<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  supportsRecurring: Scalars['Boolean']['output'];
+};
 
 export type PermissionModel = {
-  __typename: 'PermissionModel'
-  action: Scalars['String']['output']
-  condition?: Maybe<Scalars['JSON']['output']>
-  id: Scalars['String']['output']
-  subject: Scalars['String']['output']
-}
+  __typename: 'PermissionModel';
+  action: Scalars['String']['output'];
+  condition?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['String']['output'];
+  subject: Scalars['String']['output'];
+};
 
 export type PlanLimitsModel = {
-  __typename: 'PlanLimitsModel'
-  apiCallsPerDay?: Maybe<Scalars['Int']['output']>
-  projects?: Maybe<Scalars['Int']['output']>
-  rowVersions?: Maybe<Scalars['Int']['output']>
-  seats?: Maybe<Scalars['Int']['output']>
-  storageBytes?: Maybe<Scalars['Float']['output']>
-}
+  __typename: 'PlanLimitsModel';
+  apiCallsPerDay?: Maybe<Scalars['Int']['output']>;
+  branchesPerProject?: Maybe<Scalars['Int']['output']>;
+  projects?: Maybe<Scalars['Int']['output']>;
+  rowVersions?: Maybe<Scalars['Int']['output']>;
+  rowsPerTable?: Maybe<Scalars['Int']['output']>;
+  seats?: Maybe<Scalars['Int']['output']>;
+  storageBytes?: Maybe<Scalars['Float']['output']>;
+  tablesPerRevision?: Maybe<Scalars['Int']['output']>;
+};
 
 export type PlanModel = {
-  __typename: 'PlanModel'
-  features: Scalars['JSON']['output']
-  id: Scalars['ID']['output']
-  isPublic: Scalars['Boolean']['output']
-  limits: PlanLimitsModel
-  monthlyPriceUsd: Scalars['Float']['output']
-  name: Scalars['String']['output']
-  yearlyPriceUsd: Scalars['Float']['output']
-}
+  __typename: 'PlanModel';
+  features: Scalars['JSON']['output'];
+  id: Scalars['ID']['output'];
+  isPublic: Scalars['Boolean']['output'];
+  limits: PlanLimitsModel;
+  monthlyPriceUsd: Scalars['Float']['output'];
+  name: Scalars['String']['output'];
+  yearlyPriceUsd: Scalars['Float']['output'];
+};
 
 export type PluginsModel = {
-  __typename: 'PluginsModel'
-  file: Scalars['Boolean']['output']
-}
+  __typename: 'PluginsModel';
+  file: Scalars['Boolean']['output'];
+};
 
 export type ProjectModel = {
-  __typename: 'ProjectModel'
-  allBranches: BranchesConnection
-  createdAt: Scalars['DateTime']['output']
-  id: Scalars['String']['output']
-  isPublic: Scalars['Boolean']['output']
-  name: Scalars['String']['output']
-  organization: OrganizationModel
-  organizationId: Scalars['String']['output']
-  rootBranch: BranchModel
-  userProject?: Maybe<UsersProjectModel>
-}
+  __typename: 'ProjectModel';
+  allBranches: BranchesConnection;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  isPublic: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  organization: OrganizationModel;
+  organizationId: Scalars['String']['output'];
+  rootBranch: BranchModel;
+  userProject?: Maybe<UsersProjectModel>;
+};
+
 
 export type ProjectModelAllBranchesArgs = {
-  data: GetProjectBranchesInput
-}
+  data: GetProjectBranchesInput;
+};
 
 export type ProjectModelEdge = {
-  __typename: 'ProjectModelEdge'
-  cursor: Scalars['String']['output']
-  node: ProjectModel
-}
+  __typename: 'ProjectModelEdge';
+  cursor: Scalars['String']['output'];
+  node: ProjectModel;
+};
 
 export type ProjectsConnection = {
-  __typename: 'ProjectsConnection'
-  edges: Array<ProjectModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'ProjectsConnection';
+  edges: Array<ProjectModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type Query = {
-  __typename: 'Query'
-  adminUser?: Maybe<UserModel>
-  adminUsers: UsersConnection
-  availableProviders: Array<PaymentProviderModel>
-  branch: BranchModel
-  branches: BranchesConnection
-  configuration: ConfigurationModel
+  __typename: 'Query';
+  adminUser?: Maybe<UserModel>;
+  adminUsers: UsersConnection;
+  apiKeyById: ApiKeyModel;
+  availableProviders: Array<PaymentProviderModel>;
+  branch: BranchModel;
+  branches: BranchesConnection;
+  configuration: ConfigurationModel;
   /** @deprecated use RowModel.rowForeignKeysBy.totalCount */
-  getRowCountForeignKeysTo: Scalars['Int']['output']
-  me: MeModel
-  meProjects: ProjectsConnection
-  organization: OrganizationModel
-  plans: Array<PlanModel>
-  project: ProjectModel
-  projectEndpoints: EndpointsConnection
-  projects: ProjectsConnection
-  revision: RevisionModel
-  revisionChanges: RevisionChangesModel
-  row?: Maybe<RowModel>
-  rowChanges: RowChangesConnection
-  rows: RowsConnection
-  searchRows: SearchResultsConnection
-  searchUsers: SearchUsersConnection
-  subSchemaItems: SubSchemaItemsConnection
-  table?: Maybe<TableModel>
-  tableChanges: TableChangesConnection
-  tableViews: TableViewsDataModel
-  tables: TablesConnection
-  usersOrganization: UsersOrganizationConnection
-  usersProject: UsersProjectConnection
-}
+  getRowCountForeignKeysTo: Scalars['Int']['output'];
+  me: MeModel;
+  meProjects: ProjectsConnection;
+  myApiKeys: Array<ApiKeyModel>;
+  organization: OrganizationModel;
+  plans: Array<PlanModel>;
+  project: ProjectModel;
+  projectEndpoints: EndpointsConnection;
+  projects: ProjectsConnection;
+  revision: RevisionModel;
+  revisionChanges: RevisionChangesModel;
+  row?: Maybe<RowModel>;
+  rowChanges: RowChangesConnection;
+  rows: RowsConnection;
+  searchRows: SearchResultsConnection;
+  searchUsers: SearchUsersConnection;
+  serviceApiKeys: Array<ApiKeyModel>;
+  subSchemaItems: SubSchemaItemsConnection;
+  table?: Maybe<TableModel>;
+  tableChanges: TableChangesConnection;
+  tableViews: TableViewsDataModel;
+  tables: TablesConnection;
+  usersOrganization: UsersOrganizationConnection;
+  usersProject: UsersProjectConnection;
+};
+
 
 export type QueryAdminUserArgs = {
-  data: AdminUserInput
-}
+  data: AdminUserInput;
+};
+
 
 export type QueryAdminUsersArgs = {
-  data: SearchUsersInput
-}
+  data: SearchUsersInput;
+};
+
+
+export type QueryApiKeyByIdArgs = {
+  id: Scalars['ID']['input'];
+};
+
 
 export type QueryAvailableProvidersArgs = {
-  country?: InputMaybe<Scalars['String']['input']>
-  method?: InputMaybe<Scalars['String']['input']>
-}
+  country?: InputMaybe<Scalars['String']['input']>;
+  method?: InputMaybe<Scalars['String']['input']>;
+};
+
 
 export type QueryBranchArgs = {
-  data: GetBranchInput
-}
+  data: GetBranchInput;
+};
+
 
 export type QueryBranchesArgs = {
-  data: GetBranchesInput
-}
+  data: GetBranchesInput;
+};
+
 
 export type QueryGetRowCountForeignKeysToArgs = {
-  data: GetRowCountForeignKeysByInput
-}
+  data: GetRowCountForeignKeysByInput;
+};
+
 
 export type QueryMeProjectsArgs = {
-  data: GetMeProjectsInput
-}
+  data: GetMeProjectsInput;
+};
+
 
 export type QueryOrganizationArgs = {
-  data: GetOrganizationInput
-}
+  data: GetOrganizationInput;
+};
+
 
 export type QueryProjectArgs = {
-  data: GetProjectInput
-}
+  data: GetProjectInput;
+};
+
 
 export type QueryProjectEndpointsArgs = {
-  data: GetProjectEndpointsInput
-}
+  data: GetProjectEndpointsInput;
+};
+
 
 export type QueryProjectsArgs = {
-  data: GetProjectsInput
-}
+  data: GetProjectsInput;
+};
+
 
 export type QueryRevisionArgs = {
-  data: GetRevisionInput
-}
+  data: GetRevisionInput;
+};
+
 
 export type QueryRevisionChangesArgs = {
-  data: GetRevisionChangesInput
-}
+  data: GetRevisionChangesInput;
+};
+
 
 export type QueryRowArgs = {
-  data: GetRowInput
-}
+  data: GetRowInput;
+};
+
 
 export type QueryRowChangesArgs = {
-  data: GetRowChangesInput
-}
+  data: GetRowChangesInput;
+};
+
 
 export type QueryRowsArgs = {
-  data: GetRowsInput
-}
+  data: GetRowsInput;
+};
+
 
 export type QuerySearchRowsArgs = {
-  data: SearchRowsInput
-}
+  data: SearchRowsInput;
+};
+
 
 export type QuerySearchUsersArgs = {
-  data: SearchUsersInput
-}
+  data: SearchUsersInput;
+};
+
+
+export type QueryServiceApiKeysArgs = {
+  organizationId: Scalars['String']['input'];
+};
+
 
 export type QuerySubSchemaItemsArgs = {
-  data: GetSubSchemaItemsInput
-}
+  data: GetSubSchemaItemsInput;
+};
+
 
 export type QueryTableArgs = {
-  data: GetTableInput
-}
+  data: GetTableInput;
+};
+
 
 export type QueryTableChangesArgs = {
-  data: GetTableChangesInput
-}
+  data: GetTableChangesInput;
+};
+
 
 export type QueryTableViewsArgs = {
-  data: GetTableViewsInput
-}
+  data: GetTableViewsInput;
+};
+
 
 export type QueryTablesArgs = {
-  data: GetTablesInput
-}
+  data: GetTablesInput;
+};
+
 
 export type QueryUsersOrganizationArgs = {
-  data: GetUsersOrganizationInput
-}
+  data: GetUsersOrganizationInput;
+};
+
 
 export type QueryUsersProjectArgs = {
-  data: GetUsersProjectInput
-}
+  data: GetUsersProjectInput;
+};
 
 export enum QueryMode {
   DEFAULT = 'default',
-  INSENSITIVE = 'insensitive',
+  INSENSITIVE = 'insensitive'
 }
 
 export type RemoveUserFromOrganizationInput = {
-  organizationId: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
 
 export type RemoveUserFromProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
 
 export type RemovedRowChangeModel = {
-  __typename: 'RemovedRowChangeModel'
-  changeType: ChangeType
-  fieldChanges: Array<FieldChangeModel>
-  fromRow: RowChangeRowModel
-  fromTable: RowChangeTableModel
-}
+  __typename: 'RemovedRowChangeModel';
+  changeType: ChangeType;
+  fieldChanges: Array<FieldChangeModel>;
+  fromRow: RowChangeRowModel;
+  fromTable: RowChangeTableModel;
+};
 
 export type RenameRowInput = {
-  nextRowId: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  nextRowId: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type RenameRowResultModel = {
-  __typename: 'RenameRowResultModel'
-  previousVersionRowId: Scalars['String']['output']
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  __typename: 'RenameRowResultModel';
+  previousVersionRowId: Scalars['String']['output'];
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type RenameTableInput = {
-  nextTableId: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  nextTableId: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type RenameTableResultModel = {
-  __typename: 'RenameTableResultModel'
-  previousVersionTableId: Scalars['String']['output']
-  table: TableModel
-}
+  __typename: 'RenameTableResultModel';
+  previousVersionTableId: Scalars['String']['output'];
+  table: TableModel;
+};
 
 export type ResetPasswordInput = {
-  newPassword: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}
+  newPassword: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
 
 export type RevertChangesInput = {
-  branchName: Scalars['String']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type RevisionChangeSummaryModel = {
-  __typename: 'RevisionChangeSummaryModel'
-  added: Scalars['Int']['output']
-  modified: Scalars['Int']['output']
-  removed: Scalars['Int']['output']
-  renamed: Scalars['Int']['output']
-  total: Scalars['Int']['output']
-}
+  __typename: 'RevisionChangeSummaryModel';
+  added: Scalars['Int']['output'];
+  modified: Scalars['Int']['output'];
+  removed: Scalars['Int']['output'];
+  renamed: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
 
 export type RevisionChangesModel = {
-  __typename: 'RevisionChangesModel'
-  parentRevisionId?: Maybe<Scalars['String']['output']>
-  revisionId: Scalars['String']['output']
-  rowsSummary: RevisionChangeSummaryModel
-  tablesSummary: RevisionChangeSummaryModel
-  totalChanges: Scalars['Int']['output']
-}
+  __typename: 'RevisionChangesModel';
+  parentRevisionId?: Maybe<Scalars['String']['output']>;
+  revisionId: Scalars['String']['output'];
+  rowsSummary: RevisionChangeSummaryModel;
+  tablesSummary: RevisionChangeSummaryModel;
+  totalChanges: Scalars['Int']['output'];
+};
 
 export type RevisionConnection = {
-  __typename: 'RevisionConnection'
-  edges: Array<RevisionModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'RevisionConnection';
+  edges: Array<RevisionModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type RevisionModel = {
-  __typename: 'RevisionModel'
-  branch: BranchModel
-  changes: RevisionChangesModel
-  child?: Maybe<RevisionModel>
-  childBranches: Array<ChildBranchModel>
-  children: Array<RevisionModel>
-  comment: Scalars['String']['output']
-  createdAt: Scalars['DateTime']['output']
-  endpoints: Array<EndpointModel>
-  id: Scalars['String']['output']
-  isDraft: Scalars['Boolean']['output']
-  isHead: Scalars['Boolean']['output']
-  isStart: Scalars['Boolean']['output']
-  migrations: Array<Scalars['JSON']['output']>
-  parent?: Maybe<RevisionModel>
-  sequence: Scalars['Int']['output']
-  tables: TablesConnection
-}
+  __typename: 'RevisionModel';
+  branch: BranchModel;
+  changes: RevisionChangesModel;
+  child?: Maybe<RevisionModel>;
+  childBranches: Array<ChildBranchModel>;
+  children: Array<RevisionModel>;
+  comment: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  endpoints: Array<EndpointModel>;
+  id: Scalars['String']['output'];
+  isDraft: Scalars['Boolean']['output'];
+  isHead: Scalars['Boolean']['output'];
+  isStart: Scalars['Boolean']['output'];
+  migrations: Array<Scalars['JSON']['output']>;
+  parent?: Maybe<RevisionModel>;
+  sequence: Scalars['Int']['output'];
+  tables: TablesConnection;
+};
+
 
 export type RevisionModelTablesArgs = {
-  data: GetRevisionTablesInput
-}
+  data: GetRevisionTablesInput;
+};
 
 export type RevisionModelEdge = {
-  __typename: 'RevisionModelEdge'
-  cursor: Scalars['String']['output']
-  node: RevisionModel
-}
+  __typename: 'RevisionModelEdge';
+  cursor: Scalars['String']['output'];
+  node: RevisionModel;
+};
 
 export type RoleModel = {
-  __typename: 'RoleModel'
-  id: Scalars['String']['output']
-  name: Scalars['String']['output']
-  permissions: Array<PermissionModel>
-}
+  __typename: 'RoleModel';
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  permissions: Array<PermissionModel>;
+};
 
-export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel
+export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel;
 
 export enum RowChangeDetailType {
   FIELD_ADDED = 'FIELD_ADDED',
   FIELD_MODIFIED = 'FIELD_MODIFIED',
   FIELD_MOVED = 'FIELD_MOVED',
-  FIELD_REMOVED = 'FIELD_REMOVED',
+  FIELD_REMOVED = 'FIELD_REMOVED'
 }
 
 export type RowChangeEdge = {
-  __typename: 'RowChangeEdge'
-  cursor: Scalars['String']['output']
-  node: RowChange
-}
+  __typename: 'RowChangeEdge';
+  cursor: Scalars['String']['output'];
+  node: RowChange;
+};
 
 export type RowChangeRowModel = {
-  __typename: 'RowChangeRowModel'
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  data: Scalars['JSON']['output']
-  hash: Scalars['String']['output']
-  id: Scalars['String']['output']
-  meta: Scalars['JSON']['output']
-  publishedAt: Scalars['DateTime']['output']
-  readonly: Scalars['Boolean']['output']
-  schemaHash: Scalars['String']['output']
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-}
+  __typename: 'RowChangeRowModel';
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  data: Scalars['JSON']['output'];
+  hash: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  meta: Scalars['JSON']['output'];
+  publishedAt: Scalars['DateTime']['output'];
+  readonly: Scalars['Boolean']['output'];
+  schemaHash: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+};
 
 export type RowChangeTableModel = {
-  __typename: 'RowChangeTableModel'
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  id: Scalars['String']['output']
-  readonly: Scalars['Boolean']['output']
-  system: Scalars['Boolean']['output']
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-}
+  __typename: 'RowChangeTableModel';
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  readonly: Scalars['Boolean']['output'];
+  system: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+};
 
 export type RowChangesConnection = {
-  __typename: 'RowChangesConnection'
-  edges: Array<RowChangeEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'RowChangesConnection';
+  edges: Array<RowChangeEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type RowChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
-  search?: InputMaybe<Scalars['String']['input']>
-  tableId?: InputMaybe<Scalars['String']['input']>
-}
+  changeTypes?: InputMaybe<Array<ChangeType>>;
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  tableId?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type RowModel = {
-  __typename: 'RowModel'
-  countForeignKeysTo: Scalars['Int']['output']
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  data: Scalars['JSON']['output']
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
-  id: Scalars['String']['output']
-  publishedAt: Scalars['DateTime']['output']
-  readonly: Scalars['Boolean']['output']
-  rowForeignKeysBy: RowsConnection
-  rowForeignKeysTo: RowsConnection
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-}
+  __typename: 'RowModel';
+  countForeignKeysTo: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  data: Scalars['JSON']['output'];
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
+  id: Scalars['String']['output'];
+  publishedAt: Scalars['DateTime']['output'];
+  readonly: Scalars['Boolean']['output'];
+  rowForeignKeysBy: RowsConnection;
+  rowForeignKeysTo: RowsConnection;
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+};
+
 
 export type RowModelRowForeignKeysByArgs = {
-  data: GetRowForeignKeysInput
-}
+  data: GetRowForeignKeysInput;
+};
+
 
 export type RowModelRowForeignKeysToArgs = {
-  data: GetRowForeignKeysInput
-}
+  data: GetRowForeignKeysInput;
+};
 
 export type RowModelEdge = {
-  __typename: 'RowModelEdge'
-  cursor: Scalars['String']['output']
-  node: RowModel
-}
+  __typename: 'RowModelEdge';
+  cursor: Scalars['String']['output'];
+  node: RowModel;
+};
 
 export type RowsConnection = {
-  __typename: 'RowsConnection'
-  edges: Array<RowModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'RowsConnection';
+  edges: Array<RowModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SchemaFieldChangeModel = {
-  __typename: 'SchemaFieldChangeModel'
-  changeType: Scalars['String']['output']
-  fieldPath: Scalars['String']['output']
-  movedFrom?: Maybe<Scalars['String']['output']>
-  movedTo?: Maybe<Scalars['String']['output']>
-  newSchema?: Maybe<Scalars['JSON']['output']>
-  oldSchema?: Maybe<Scalars['JSON']['output']>
-}
+  __typename: 'SchemaFieldChangeModel';
+  changeType: Scalars['String']['output'];
+  fieldPath: Scalars['String']['output'];
+  movedFrom?: Maybe<Scalars['String']['output']>;
+  movedTo?: Maybe<Scalars['String']['output']>;
+  newSchema?: Maybe<Scalars['JSON']['output']>;
+  oldSchema?: Maybe<Scalars['JSON']['output']>;
+};
 
 export type SchemaMigrationDetailModel = {
-  __typename: 'SchemaMigrationDetailModel'
-  historyPatches?: Maybe<Array<HistoryPatchModel>>
-  initialSchema?: Maybe<Scalars['JSON']['output']>
-  migrationId: Scalars['String']['output']
-  migrationType: MigrationType
-  newTableId?: Maybe<Scalars['String']['output']>
-  oldTableId?: Maybe<Scalars['String']['output']>
-  patches?: Maybe<Array<JsonPatchOperationModel>>
-}
+  __typename: 'SchemaMigrationDetailModel';
+  historyPatches?: Maybe<Array<HistoryPatchModel>>;
+  initialSchema?: Maybe<Scalars['JSON']['output']>;
+  migrationId: Scalars['String']['output'];
+  migrationType: MigrationType;
+  newTableId?: Maybe<Scalars['String']['output']>;
+  oldTableId?: Maybe<Scalars['String']['output']>;
+  patches?: Maybe<Array<JsonPatchOperationModel>>;
+};
 
 export enum SearchIn {
   ALL = 'all',
@@ -1374,7 +1549,7 @@ export enum SearchIn {
   KEYS = 'keys',
   NUMBERS = 'numbers',
   STRINGS = 'strings',
-  VALUES = 'values',
+  VALUES = 'values'
 }
 
 /** Language for full-text search. Default: simple */
@@ -1407,528 +1582,531 @@ export enum SearchLanguage {
   SWEDISH = 'swedish',
   TAMIL = 'tamil',
   TURKISH = 'turkish',
-  YIDDISH = 'yiddish',
+  YIDDISH = 'yiddish'
 }
 
 export type SearchMatch = {
-  __typename: 'SearchMatch'
-  highlight?: Maybe<Scalars['String']['output']>
-  path: Scalars['String']['output']
-  value: Scalars['JSON']['output']
-}
+  __typename: 'SearchMatch';
+  highlight?: Maybe<Scalars['String']['output']>;
+  path: Scalars['String']['output'];
+  value: Scalars['JSON']['output'];
+};
 
 export type SearchResult = {
-  __typename: 'SearchResult'
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
-  matches: Array<SearchMatch>
-  row: RowModel
-  table: TableModel
-}
+  __typename: 'SearchResult';
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
+  matches: Array<SearchMatch>;
+  row: RowModel;
+  table: TableModel;
+};
 
 export type SearchResultEdge = {
-  __typename: 'SearchResultEdge'
-  cursor: Scalars['String']['output']
-  node: SearchResult
-}
+  __typename: 'SearchResultEdge';
+  cursor: Scalars['String']['output'];
+  node: SearchResult;
+};
 
 export type SearchResultsConnection = {
-  __typename: 'SearchResultsConnection'
-  edges: Array<SearchResultEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'SearchResultsConnection';
+  edges: Array<SearchResultEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SearchRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first?: InputMaybe<Scalars['Int']['input']>
-  query: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  query: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export enum SearchType {
   PHRASE = 'phrase',
   PLAIN = 'plain',
   PREFIX = 'prefix',
-  TSQUERY = 'tsquery',
+  TSQUERY = 'tsquery'
 }
 
 export type SearchUserModel = {
-  __typename: 'SearchUserModel'
-  email?: Maybe<Scalars['String']['output']>
-  id: Scalars['String']['output']
-  username?: Maybe<Scalars['String']['output']>
-}
+  __typename: 'SearchUserModel';
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  username?: Maybe<Scalars['String']['output']>;
+};
 
 export type SearchUserModelEdge = {
-  __typename: 'SearchUserModelEdge'
-  cursor: Scalars['String']['output']
-  node: SearchUserModel
-}
+  __typename: 'SearchUserModelEdge';
+  cursor: Scalars['String']['output'];
+  node: SearchUserModel;
+};
 
 export type SearchUsersConnection = {
-  __typename: 'SearchUsersConnection'
-  edges: Array<SearchUserModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'SearchUsersConnection';
+  edges: Array<SearchUserModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SearchUsersInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  search?: InputMaybe<Scalars['String']['input']>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  search?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SetUsernameInput = {
-  username: Scalars['String']['input']
-}
+  username: Scalars['String']['input'];
+};
 
 export type SignUpInput = {
-  email: Scalars['String']['input']
-  password: Scalars['String']['input']
-  username: Scalars['String']['input']
-}
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  username: Scalars['String']['input'];
+};
 
 export enum SortOrder {
   ASC = 'asc',
-  DESC = 'desc',
+  DESC = 'desc'
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']['input']>
-  endsWith?: InputMaybe<Scalars['String']['input']>
-  equals?: InputMaybe<Scalars['String']['input']>
-  gt?: InputMaybe<Scalars['String']['input']>
-  gte?: InputMaybe<Scalars['String']['input']>
-  in?: InputMaybe<Array<Scalars['String']['input']>>
-  lt?: InputMaybe<Scalars['String']['input']>
-  lte?: InputMaybe<Scalars['String']['input']>
-  mode?: InputMaybe<QueryMode>
-  not?: InputMaybe<Scalars['String']['input']>
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>
-  startsWith?: InputMaybe<Scalars['String']['input']>
-}
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SubSchemaDataOrderByInput = {
-  nulls?: InputMaybe<NullsPosition>
-  order: SortOrder
-  path: Scalars['JSON']['input']
-}
+  nulls?: InputMaybe<NullsPosition>;
+  order: SortOrder;
+  path: Scalars['JSON']['input'];
+};
 
 export type SubSchemaItemModel = {
-  __typename: 'SubSchemaItemModel'
-  data: Scalars['JSON']['output']
-  fieldPath: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  __typename: 'SubSchemaItemModel';
+  data: Scalars['JSON']['output'];
+  fieldPath: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type SubSchemaItemModelEdge = {
-  __typename: 'SubSchemaItemModelEdge'
-  cursor: Scalars['String']['output']
-  node: SubSchemaItemModel
-}
+  __typename: 'SubSchemaItemModelEdge';
+  cursor: Scalars['String']['output'];
+  node: SubSchemaItemModel;
+};
 
 export type SubSchemaItemsConnection = {
-  __typename: 'SubSchemaItemsConnection'
-  edges: Array<SubSchemaItemModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'SubSchemaItemsConnection';
+  edges: Array<SubSchemaItemModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SubSchemaJsonFilterInput = {
-  equals?: InputMaybe<Scalars['JSON']['input']>
-  gt?: InputMaybe<Scalars['JSON']['input']>
-  gte?: InputMaybe<Scalars['JSON']['input']>
-  in?: InputMaybe<Array<Scalars['JSON']['input']>>
-  lt?: InputMaybe<Scalars['JSON']['input']>
-  lte?: InputMaybe<Scalars['JSON']['input']>
-  mode?: InputMaybe<QueryMode>
-  not?: InputMaybe<Scalars['JSON']['input']>
-  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>
-  path: Scalars['JSON']['input']
-  string_contains?: InputMaybe<Scalars['String']['input']>
-  string_ends_with?: InputMaybe<Scalars['String']['input']>
-  string_starts_with?: InputMaybe<Scalars['String']['input']>
-}
+  equals?: InputMaybe<Scalars['JSON']['input']>;
+  gt?: InputMaybe<Scalars['JSON']['input']>;
+  gte?: InputMaybe<Scalars['JSON']['input']>;
+  in?: InputMaybe<Array<Scalars['JSON']['input']>>;
+  lt?: InputMaybe<Scalars['JSON']['input']>;
+  lte?: InputMaybe<Scalars['JSON']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['JSON']['input']>;
+  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>;
+  path: Scalars['JSON']['input'];
+  string_contains?: InputMaybe<Scalars['String']['input']>;
+  string_ends_with?: InputMaybe<Scalars['String']['input']>;
+  string_starts_with?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SubSchemaOrderByItemInput = {
-  data?: InputMaybe<SubSchemaDataOrderByInput>
-  fieldPath?: InputMaybe<SortOrder>
-  rowCreatedAt?: InputMaybe<SortOrder>
-  rowId?: InputMaybe<SortOrder>
-  tableId?: InputMaybe<SortOrder>
-}
+  data?: InputMaybe<SubSchemaDataOrderByInput>;
+  fieldPath?: InputMaybe<SortOrder>;
+  rowCreatedAt?: InputMaybe<SortOrder>;
+  rowId?: InputMaybe<SortOrder>;
+  tableId?: InputMaybe<SortOrder>;
+};
 
 export type SubSchemaStringFilterInput = {
-  contains?: InputMaybe<Scalars['String']['input']>
-  endsWith?: InputMaybe<Scalars['String']['input']>
-  equals?: InputMaybe<Scalars['String']['input']>
-  gt?: InputMaybe<Scalars['String']['input']>
-  gte?: InputMaybe<Scalars['String']['input']>
-  in?: InputMaybe<Array<Scalars['String']['input']>>
-  lt?: InputMaybe<Scalars['String']['input']>
-  lte?: InputMaybe<Scalars['String']['input']>
-  mode?: InputMaybe<QueryMode>
-  not?: InputMaybe<Scalars['String']['input']>
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>
-  startsWith?: InputMaybe<Scalars['String']['input']>
-}
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SubSchemaWhereInput = {
-  AND?: InputMaybe<Array<SubSchemaWhereInput>>
-  NOT?: InputMaybe<SubSchemaWhereInput>
-  OR?: InputMaybe<Array<SubSchemaWhereInput>>
-  data?: InputMaybe<SubSchemaJsonFilterInput>
-  fieldPath?: InputMaybe<SubSchemaStringFilterInput>
-  rowId?: InputMaybe<SubSchemaStringFilterInput>
-  tableId?: InputMaybe<SubSchemaStringFilterInput>
-}
+  AND?: InputMaybe<Array<SubSchemaWhereInput>>;
+  NOT?: InputMaybe<SubSchemaWhereInput>;
+  OR?: InputMaybe<Array<SubSchemaWhereInput>>;
+  data?: InputMaybe<SubSchemaJsonFilterInput>;
+  fieldPath?: InputMaybe<SubSchemaStringFilterInput>;
+  rowId?: InputMaybe<SubSchemaStringFilterInput>;
+  tableId?: InputMaybe<SubSchemaStringFilterInput>;
+};
 
 export type SubscriptionModel = {
-  __typename: 'SubscriptionModel'
-  cancelAt?: Maybe<Scalars['DateTime']['output']>
-  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>
-  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>
-  interval?: Maybe<Scalars['String']['output']>
-  planId: Scalars['String']['output']
-  provider?: Maybe<Scalars['String']['output']>
-  status: BillingStatus
-}
+  __typename: 'SubscriptionModel';
+  cancelAt?: Maybe<Scalars['DateTime']['output']>;
+  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>;
+  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>;
+  interval?: Maybe<Scalars['String']['output']>;
+  planId: Scalars['String']['output'];
+  provider?: Maybe<Scalars['String']['output']>;
+  status: BillingStatus;
+};
 
 export type TableChangeModel = {
-  __typename: 'TableChangeModel'
-  addedRowsCount: Scalars['Int']['output']
-  changeType: ChangeType
-  fromVersionId?: Maybe<Scalars['String']['output']>
-  modifiedRowsCount: Scalars['Int']['output']
-  newTableId?: Maybe<Scalars['String']['output']>
-  oldTableId?: Maybe<Scalars['String']['output']>
-  removedRowsCount: Scalars['Int']['output']
-  renamedRowsCount: Scalars['Int']['output']
-  rowChangesCount: Scalars['Int']['output']
-  schemaMigrations: Array<SchemaMigrationDetailModel>
-  tableCreatedId: Scalars['String']['output']
-  tableId: Scalars['String']['output']
-  toVersionId?: Maybe<Scalars['String']['output']>
-  viewsChanges: ViewsChangeDetailModel
-}
+  __typename: 'TableChangeModel';
+  addedRowsCount: Scalars['Int']['output'];
+  changeType: ChangeType;
+  fromVersionId?: Maybe<Scalars['String']['output']>;
+  modifiedRowsCount: Scalars['Int']['output'];
+  newTableId?: Maybe<Scalars['String']['output']>;
+  oldTableId?: Maybe<Scalars['String']['output']>;
+  removedRowsCount: Scalars['Int']['output'];
+  renamedRowsCount: Scalars['Int']['output'];
+  rowChangesCount: Scalars['Int']['output'];
+  schemaMigrations: Array<SchemaMigrationDetailModel>;
+  tableCreatedId: Scalars['String']['output'];
+  tableId: Scalars['String']['output'];
+  toVersionId?: Maybe<Scalars['String']['output']>;
+  viewsChanges: ViewsChangeDetailModel;
+};
 
 export type TableChangeModelEdge = {
-  __typename: 'TableChangeModelEdge'
-  cursor: Scalars['String']['output']
-  node: TableChangeModel
-}
+  __typename: 'TableChangeModelEdge';
+  cursor: Scalars['String']['output'];
+  node: TableChangeModel;
+};
 
 export type TableChangesConnection = {
-  __typename: 'TableChangesConnection'
-  edges: Array<TableChangeModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'TableChangesConnection';
+  edges: Array<TableChangeModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type TableChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
-  search?: InputMaybe<Scalars['String']['input']>
-  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>
-}
+  changeTypes?: InputMaybe<Array<ChangeType>>;
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>;
+};
 
 export type TableModel = {
-  __typename: 'TableModel'
-  count: Scalars['Int']['output']
-  countForeignKeysBy: Scalars['Int']['output']
-  countForeignKeysTo: Scalars['Int']['output']
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  foreignKeysBy: TablesConnection
-  foreignKeysTo: TablesConnection
-  id: Scalars['String']['output']
-  readonly: Scalars['Boolean']['output']
-  rows: RowsConnection
-  schema: Scalars['JSON']['output']
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-  views: TableViewsDataModel
-}
+  __typename: 'TableModel';
+  count: Scalars['Int']['output'];
+  countForeignKeysBy: Scalars['Int']['output'];
+  countForeignKeysTo: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  foreignKeysBy: TablesConnection;
+  foreignKeysTo: TablesConnection;
+  id: Scalars['String']['output'];
+  readonly: Scalars['Boolean']['output'];
+  rows: RowsConnection;
+  schema: Scalars['JSON']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+  views: TableViewsDataModel;
+};
+
 
 export type TableModelForeignKeysByArgs = {
-  data: GetTableForeignKeysInput
-}
+  data: GetTableForeignKeysInput;
+};
+
 
 export type TableModelForeignKeysToArgs = {
-  data: GetTableForeignKeysInput
-}
+  data: GetTableForeignKeysInput;
+};
+
 
 export type TableModelRowsArgs = {
-  data: GetTableRowsInput
-}
+  data: GetTableRowsInput;
+};
 
 export type TableModelEdge = {
-  __typename: 'TableModelEdge'
-  cursor: Scalars['String']['output']
-  node: TableModel
-}
+  __typename: 'TableModelEdge';
+  cursor: Scalars['String']['output'];
+  node: TableModel;
+};
 
 export type TableViewsDataInput = {
-  defaultViewId: Scalars['String']['input']
-  version: Scalars['Int']['input']
-  views: Array<ViewInput>
-}
+  defaultViewId: Scalars['String']['input'];
+  version: Scalars['Int']['input'];
+  views: Array<ViewInput>;
+};
 
 export type TableViewsDataModel = {
-  __typename: 'TableViewsDataModel'
-  defaultViewId: Scalars['String']['output']
-  version: Scalars['Int']['output']
-  views: Array<ViewModel>
-}
+  __typename: 'TableViewsDataModel';
+  defaultViewId: Scalars['String']['output'];
+  version: Scalars['Int']['output'];
+  views: Array<ViewModel>;
+};
 
 export type TablesConnection = {
-  __typename: 'TablesConnection'
-  edges: Array<TableModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'TablesConnection';
+  edges: Array<TableModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UpdatePasswordInput = {
-  newPassword: Scalars['String']['input']
-  oldPassword: Scalars['String']['input']
-}
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
+};
 
 export type UpdateProjectInput = {
-  isPublic: Scalars['Boolean']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  isPublic: Scalars['Boolean']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type UpdateRowInput = {
-  data: Scalars['JSON']['input']
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type UpdateRowResultModel = {
-  __typename: 'UpdateRowResultModel'
-  previousVersionRowId: Scalars['String']['output']
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  __typename: 'UpdateRowResultModel';
+  previousVersionRowId: Scalars['String']['output'];
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type UpdateRowsInput = {
-  revisionId: Scalars['String']['input']
-  rows: Array<UpdateRowsRowInput>
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rows: Array<UpdateRowsRowInput>;
+  tableId: Scalars['String']['input'];
+};
 
 export type UpdateRowsResultModel = {
-  __typename: 'UpdateRowsResultModel'
-  previousVersionTableId: Scalars['String']['output']
-  rows: Array<RowModel>
-  table: TableModel
-}
+  __typename: 'UpdateRowsResultModel';
+  previousVersionTableId: Scalars['String']['output'];
+  rows: Array<RowModel>;
+  table: TableModel;
+};
 
 export type UpdateRowsRowInput = {
-  data: Scalars['JSON']['input']
-  rowId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  rowId: Scalars['String']['input'];
+};
 
 export type UpdateTableInput = {
-  patches: Scalars['JSON']['input']
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  patches: Scalars['JSON']['input'];
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type UpdateTableResultModel = {
-  __typename: 'UpdateTableResultModel'
-  previousVersionTableId: Scalars['String']['output']
-  table: TableModel
-}
+  __typename: 'UpdateTableResultModel';
+  previousVersionTableId: Scalars['String']['output'];
+  table: TableModel;
+};
 
 export type UpdateTableViewsInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-  viewsData: TableViewsDataInput
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+  viewsData: TableViewsDataInput;
+};
 
 export type UpdateUserProjectRoleInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  roleId: UserProjectRoles
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  roleId: UserProjectRoles;
+  userId: Scalars['String']['input'];
+};
 
 export type UsageMetricModel = {
-  __typename: 'UsageMetricModel'
-  current: Scalars['Float']['output']
-  limit?: Maybe<Scalars['Float']['output']>
-  percentage?: Maybe<Scalars['Float']['output']>
-}
+  __typename: 'UsageMetricModel';
+  current: Scalars['Float']['output'];
+  limit?: Maybe<Scalars['Float']['output']>;
+  percentage?: Maybe<Scalars['Float']['output']>;
+};
 
 export type UsageSummaryModel = {
-  __typename: 'UsageSummaryModel'
-  projects: UsageMetricModel
-  rowVersions: UsageMetricModel
-  seats: UsageMetricModel
-  storageBytes: UsageMetricModel
-}
+  __typename: 'UsageSummaryModel';
+  projects: UsageMetricModel;
+  rowVersions: UsageMetricModel;
+  seats: UsageMetricModel;
+  storageBytes: UsageMetricModel;
+};
 
 export type UserModel = {
-  __typename: 'UserModel'
-  email?: Maybe<Scalars['String']['output']>
-  id: Scalars['String']['output']
-  organizationId?: Maybe<Scalars['String']['output']>
-  role: RoleModel
-  roleId: Scalars['String']['output']
-  username?: Maybe<Scalars['String']['output']>
-}
+  __typename: 'UserModel';
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  organizationId?: Maybe<Scalars['String']['output']>;
+  role: RoleModel;
+  roleId: Scalars['String']['output'];
+  username?: Maybe<Scalars['String']['output']>;
+};
 
 export type UserModelEdge = {
-  __typename: 'UserModelEdge'
-  cursor: Scalars['String']['output']
-  node: UserModel
-}
+  __typename: 'UserModelEdge';
+  cursor: Scalars['String']['output'];
+  node: UserModel;
+};
 
 export enum UserOrganizationRoles {
   DEVELOPER = 'developer',
   EDITOR = 'editor',
   ORGANIZATIONADMIN = 'organizationAdmin',
   ORGANIZATIONOWNER = 'organizationOwner',
-  READER = 'reader',
+  READER = 'reader'
 }
 
 export enum UserProjectRoles {
   DEVELOPER = 'developer',
   EDITOR = 'editor',
-  READER = 'reader',
+  READER = 'reader'
 }
 
 export enum UserSystemRole {
   SYSTEMADMIN = 'systemAdmin',
   SYSTEMFULLAPIREAD = 'systemFullApiRead',
-  SYSTEMUSER = 'systemUser',
+  SYSTEMUSER = 'systemUser'
 }
 
 export type UsersConnection = {
-  __typename: 'UsersConnection'
-  edges: Array<UserModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'UsersConnection';
+  edges: Array<UserModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UsersOrganizationConnection = {
-  __typename: 'UsersOrganizationConnection'
-  edges: Array<UsersOrganizationModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'UsersOrganizationConnection';
+  edges: Array<UsersOrganizationModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UsersOrganizationModel = {
-  __typename: 'UsersOrganizationModel'
-  id: Scalars['String']['output']
-  role: RoleModel
-  user: UserModel
-}
+  __typename: 'UsersOrganizationModel';
+  id: Scalars['String']['output'];
+  role: RoleModel;
+  user: UserModel;
+};
 
 export type UsersOrganizationModelEdge = {
-  __typename: 'UsersOrganizationModelEdge'
-  cursor: Scalars['String']['output']
-  node: UsersOrganizationModel
-}
+  __typename: 'UsersOrganizationModelEdge';
+  cursor: Scalars['String']['output'];
+  node: UsersOrganizationModel;
+};
 
 export type UsersProjectConnection = {
-  __typename: 'UsersProjectConnection'
-  edges: Array<UsersProjectModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  __typename: 'UsersProjectConnection';
+  edges: Array<UsersProjectModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UsersProjectModel = {
-  __typename: 'UsersProjectModel'
-  id: Scalars['String']['output']
-  role: RoleModel
-  user: UserModel
-}
+  __typename: 'UsersProjectModel';
+  id: Scalars['String']['output'];
+  role: RoleModel;
+  user: UserModel;
+};
 
 export type UsersProjectModelEdge = {
-  __typename: 'UsersProjectModelEdge'
-  cursor: Scalars['String']['output']
-  node: UsersProjectModel
-}
+  __typename: 'UsersProjectModelEdge';
+  cursor: Scalars['String']['output'];
+  node: UsersProjectModel;
+};
 
 export type ViewChangeModel = {
-  __typename: 'ViewChangeModel'
-  changeType: ChangeType
-  oldViewName?: Maybe<Scalars['String']['output']>
-  viewId: Scalars['String']['output']
-  viewName: Scalars['String']['output']
-}
+  __typename: 'ViewChangeModel';
+  changeType: ChangeType;
+  oldViewName?: Maybe<Scalars['String']['output']>;
+  viewId: Scalars['String']['output'];
+  viewName: Scalars['String']['output'];
+};
 
 export type ViewColumnInput = {
-  field: Scalars['String']['input']
-  pinned?: InputMaybe<Scalars['String']['input']>
-  width?: InputMaybe<Scalars['Float']['input']>
-}
+  field: Scalars['String']['input'];
+  pinned?: InputMaybe<Scalars['String']['input']>;
+  width?: InputMaybe<Scalars['Float']['input']>;
+};
 
 export type ViewColumnModel = {
-  __typename: 'ViewColumnModel'
-  field: Scalars['String']['output']
-  pinned?: Maybe<Scalars['String']['output']>
-  width?: Maybe<Scalars['Float']['output']>
-}
+  __typename: 'ViewColumnModel';
+  field: Scalars['String']['output'];
+  pinned?: Maybe<Scalars['String']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
 
 export type ViewInput = {
-  columns?: InputMaybe<Array<ViewColumnInput>>
-  description?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<Scalars['JSON']['input']>
-  id: Scalars['String']['input']
-  name: Scalars['String']['input']
-  search?: InputMaybe<Scalars['String']['input']>
-  sorts?: InputMaybe<Array<ViewSortInput>>
-}
+  columns?: InputMaybe<Array<ViewColumnInput>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<Scalars['JSON']['input']>;
+  id: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+  search?: InputMaybe<Scalars['String']['input']>;
+  sorts?: InputMaybe<Array<ViewSortInput>>;
+};
 
 export type ViewModel = {
-  __typename: 'ViewModel'
-  columns?: Maybe<Array<ViewColumnModel>>
-  description?: Maybe<Scalars['String']['output']>
-  filters?: Maybe<Scalars['JSON']['output']>
-  id: Scalars['String']['output']
-  name: Scalars['String']['output']
-  search?: Maybe<Scalars['String']['output']>
-  sorts?: Maybe<Array<ViewSortModel>>
-}
+  __typename: 'ViewModel';
+  columns?: Maybe<Array<ViewColumnModel>>;
+  description?: Maybe<Scalars['String']['output']>;
+  filters?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  search?: Maybe<Scalars['String']['output']>;
+  sorts?: Maybe<Array<ViewSortModel>>;
+};
 
 export type ViewSortInput = {
-  direction: SortOrder
-  field: Scalars['String']['input']
-}
+  direction: SortOrder;
+  field: Scalars['String']['input'];
+};
 
 export type ViewSortModel = {
-  __typename: 'ViewSortModel'
-  direction: Scalars['String']['output']
-  field: Scalars['String']['output']
-}
+  __typename: 'ViewSortModel';
+  direction: Scalars['String']['output'];
+  field: Scalars['String']['output'];
+};
 
 export type ViewsChangeDetailModel = {
-  __typename: 'ViewsChangeDetailModel'
-  addedCount: Scalars['Int']['output']
-  changes: Array<ViewChangeModel>
-  hasChanges: Scalars['Boolean']['output']
-  modifiedCount: Scalars['Int']['output']
-  removedCount: Scalars['Int']['output']
-  renamedCount: Scalars['Int']['output']
-}
+  __typename: 'ViewsChangeDetailModel';
+  addedCount: Scalars['Int']['output'];
+  changes: Array<ViewChangeModel>;
+  hasChanges: Scalars['Boolean']['output'];
+  modifiedCount: Scalars['Int']['output'];
+  removedCount: Scalars['Int']['output'];
+  renamedCount: Scalars['Int']['output'];
+};
 
 export type WhereInput = {
-  AND?: InputMaybe<Array<WhereInput>>
-  NOT?: InputMaybe<Array<WhereInput>>
-  OR?: InputMaybe<Array<WhereInput>>
-  createdAt?: InputMaybe<DateTimeFilter>
-  createdId?: InputMaybe<StringFilter>
-  data?: InputMaybe<JsonFilter>
-  id?: InputMaybe<StringFilter>
-  publishedAt?: InputMaybe<DateTimeFilter>
-  readonly?: InputMaybe<BooleanFilter>
-  updatedAt?: InputMaybe<DateTimeFilter>
-  versionId?: InputMaybe<StringFilter>
-}
+  AND?: InputMaybe<Array<WhereInput>>;
+  NOT?: InputMaybe<Array<WhereInput>>;
+  OR?: InputMaybe<Array<WhereInput>>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  createdId?: InputMaybe<StringFilter>;
+  data?: InputMaybe<JsonFilter>;
+  id?: InputMaybe<StringFilter>;
+  publishedAt?: InputMaybe<DateTimeFilter>;
+  readonly?: InputMaybe<BooleanFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  versionId?: InputMaybe<StringFilter>;
+};

--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -1,823 +1,951 @@
 // @ts-ignore
-import { GraphQLClient, RequestOptions } from 'graphql-request'
-import gql from 'graphql-tag'
-export type Maybe<T> = T | null
-export type InputMaybe<T> = Maybe<T>
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never }
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never }
-type GraphQLClientRequestHeaders = RequestOptions['requestHeaders']
+import { GraphQLClient, RequestOptions } from 'graphql-request';
+import gql from 'graphql-tag';
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string }
-  String: { input: string; output: string }
-  Boolean: { input: boolean; output: boolean }
-  Int: { input: number; output: number }
-  Float: { input: number; output: number }
-  DateTime: { input: string; output: string }
-  JSON: {
-    input: { [key: string]: any } | string | number | boolean | null
-    output: { [key: string]: any } | string | number | boolean | null
-  }
-}
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: string; output: string; }
+  JSON: { input: { [key: string]: any } | string | number | boolean | null; output: { [key: string]: any } | string | number | boolean | null; }
+  JSONObject: { input: any; output: any; }
+};
 
 export type ActivateEarlyAccessInput = {
-  organizationId: Scalars['ID']['input']
-  planId: Scalars['ID']['input']
-}
+  organizationId: Scalars['ID']['input'];
+  planId: Scalars['ID']['input'];
+};
 
 export type AddUserToOrganizationInput = {
-  organizationId: Scalars['String']['input']
-  roleId: UserOrganizationRoles
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  roleId: UserOrganizationRoles;
+  userId: Scalars['String']['input'];
+};
 
 export type AddUserToProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  roleId: UserProjectRoles
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  roleId: UserProjectRoles;
+  userId: Scalars['String']['input'];
+};
 
 export type AddedRowChangeModel = {
-  changeType: ChangeType
-  fieldChanges: Array<FieldChangeModel>
-  row: RowChangeRowModel
-  table: RowChangeTableModel
-}
+  changeType: ChangeType;
+  fieldChanges: Array<FieldChangeModel>;
+  row: RowChangeRowModel;
+  table: RowChangeTableModel;
+};
 
 export type AdminUserInput = {
-  userId: Scalars['String']['input']
+  userId: Scalars['String']['input'];
+};
+
+export type ApiKeyModel = {
+  allowedIps: Array<Scalars['String']['output']>;
+  branchNames: Array<Scalars['String']['output']>;
+  createdAt: Scalars['DateTime']['output'];
+  expiresAt?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['ID']['output'];
+  lastUsedAt?: Maybe<Scalars['DateTime']['output']>;
+  name: Scalars['String']['output'];
+  organizationId?: Maybe<Scalars['String']['output']>;
+  permissions?: Maybe<Scalars['JSON']['output']>;
+  prefix: Scalars['String']['output'];
+  projectIds: Array<Scalars['String']['output']>;
+  readOnly: Scalars['Boolean']['output'];
+  revokedAt?: Maybe<Scalars['DateTime']['output']>;
+  tableIds: Array<Scalars['String']['output']>;
+  type: ApiKeyType;
+};
+
+export enum ApiKeyType {
+  Internal = 'INTERNAL',
+  Personal = 'PERSONAL',
+  Service = 'SERVICE'
 }
 
+export type ApiKeyWithSecretModel = {
+  apiKey: ApiKeyModel;
+  secret: Scalars['String']['output'];
+};
+
 export type ApplyMigrationResultModel = {
-  error?: Maybe<Scalars['String']['output']>
-  id: Scalars['String']['output']
-  status: ApplyMigrationStatus
-}
+  error?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  status: ApplyMigrationStatus;
+};
 
 /** Status of migration application */
 export enum ApplyMigrationStatus {
   Applied = 'applied',
   Failed = 'failed',
-  Skipped = 'skipped',
+  Skipped = 'skipped'
 }
 
 export type ApplyMigrationsInput = {
-  migrations: Array<Scalars['JSON']['input']>
-  revisionId: Scalars['String']['input']
-}
+  migrations: Array<Scalars['JSON']['input']>;
+  revisionId: Scalars['String']['input'];
+};
 
 export type BillingConfigurationModel = {
-  enabled: Scalars['Boolean']['output']
-}
+  enabled: Scalars['Boolean']['output'];
+};
 
 export enum BillingStatus {
   Active = 'active',
   Cancelled = 'cancelled',
   EarlyAdopter = 'early_adopter',
   Free = 'free',
-  PastDue = 'past_due',
+  PastDue = 'past_due'
 }
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']['input']>
-  not?: InputMaybe<Scalars['Boolean']['input']>
-}
+  equals?: InputMaybe<Scalars['Boolean']['input']>;
+  not?: InputMaybe<Scalars['Boolean']['input']>;
+};
 
 export type BranchModel = {
-  createdAt: Scalars['DateTime']['output']
-  draft: RevisionModel
-  head: RevisionModel
-  id: Scalars['String']['output']
-  isRoot: Scalars['Boolean']['output']
-  name: Scalars['String']['output']
-  parent?: Maybe<ParentBranchModel>
-  project: ProjectModel
-  projectId: Scalars['String']['output']
-  revisions: RevisionConnection
-  start: RevisionModel
-  touched: Scalars['Boolean']['output']
-}
+  createdAt: Scalars['DateTime']['output'];
+  draft: RevisionModel;
+  head: RevisionModel;
+  id: Scalars['String']['output'];
+  isRoot: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  parent?: Maybe<ParentBranchModel>;
+  project: ProjectModel;
+  projectId: Scalars['String']['output'];
+  revisions: RevisionConnection;
+  start: RevisionModel;
+  touched: Scalars['Boolean']['output'];
+};
+
 
 export type BranchModelRevisionsArgs = {
-  data: GetBranchRevisionsInput
-}
+  data: GetBranchRevisionsInput;
+};
 
 export type BranchModelEdge = {
-  cursor: Scalars['String']['output']
-  node: BranchModel
-}
+  cursor: Scalars['String']['output'];
+  node: BranchModel;
+};
 
 export type BranchesConnection = {
-  edges: Array<BranchModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<BranchModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type CancelSubscriptionInput = {
-  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>
-  organizationId: Scalars['ID']['input']
-}
+  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>;
+  organizationId: Scalars['ID']['input'];
+};
+
+export type CaslPermissionsInput = {
+  rules: Array<CaslRuleInput>;
+};
+
+export type CaslRuleInput = {
+  action: Array<Scalars['String']['input']>;
+  conditions?: InputMaybe<Scalars['JSONObject']['input']>;
+  fields?: InputMaybe<Array<Scalars['String']['input']>>;
+  inverted?: InputMaybe<Scalars['Boolean']['input']>;
+  subject: Array<Scalars['String']['input']>;
+};
 
 export enum ChangeType {
   Added = 'ADDED',
   Modified = 'MODIFIED',
   Removed = 'REMOVED',
   Renamed = 'RENAMED',
-  RenamedAndModified = 'RENAMED_AND_MODIFIED',
+  RenamedAndModified = 'RENAMED_AND_MODIFIED'
 }
 
 export type CheckoutResultModel = {
-  checkoutUrl: Scalars['String']['output']
-}
+  checkoutUrl: Scalars['String']['output'];
+};
 
 export type ChildBranchModel = {
-  branch: BranchModel
-  revision: RevisionModel
-}
+  branch: BranchModel;
+  revision: RevisionModel;
+};
 
 export type ConfigurationModel = {
-  availableEmailSignUp: Scalars['Boolean']['output']
-  billing: BillingConfigurationModel
-  github: GithubOauth
-  google: GoogleOauth
-  noAuth: Scalars['Boolean']['output']
-  plugins: PluginsModel
-}
+  availableEmailSignUp: Scalars['Boolean']['output'];
+  billing: BillingConfigurationModel;
+  github: GithubOauth;
+  google: GoogleOauth;
+  noAuth: Scalars['Boolean']['output'];
+  plugins: PluginsModel;
+};
 
 export type ConfirmEmailCodeInput = {
-  code: Scalars['String']['input']
-}
+  code: Scalars['String']['input'];
+};
 
 export type CreateBranchInput = {
-  branchName: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type CreateCheckoutInput = {
-  cancelUrl: Scalars['String']['input']
-  country?: InputMaybe<Scalars['String']['input']>
-  interval?: InputMaybe<Scalars['String']['input']>
-  method?: InputMaybe<Scalars['String']['input']>
-  organizationId: Scalars['ID']['input']
-  planId: Scalars['ID']['input']
-  providerId?: InputMaybe<Scalars['String']['input']>
-  successUrl: Scalars['String']['input']
-}
+  cancelUrl: Scalars['String']['input'];
+  country?: InputMaybe<Scalars['String']['input']>;
+  interval?: InputMaybe<Scalars['String']['input']>;
+  method?: InputMaybe<Scalars['String']['input']>;
+  organizationId: Scalars['ID']['input'];
+  planId: Scalars['ID']['input'];
+  providerId?: InputMaybe<Scalars['String']['input']>;
+  successUrl: Scalars['String']['input'];
+};
 
 export type CreateEndpointInput = {
-  revisionId: Scalars['String']['input']
-  type: EndpointType
-}
+  revisionId: Scalars['String']['input'];
+  type: EndpointType;
+};
+
+export type CreatePersonalApiKeyInput = {
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
+  name: Scalars['String']['input'];
+  organizationId?: InputMaybe<Scalars['String']['input']>;
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
+};
 
 export type CreateProjectInput = {
-  branchName?: InputMaybe<Scalars['String']['input']>
-  fromRevisionId?: InputMaybe<Scalars['String']['input']>
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName?: InputMaybe<Scalars['String']['input']>;
+  fromRevisionId?: InputMaybe<Scalars['String']['input']>;
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type CreateRevisionInput = {
-  branchName: Scalars['String']['input']
-  comment?: InputMaybe<Scalars['String']['input']>
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  comment?: InputMaybe<Scalars['String']['input']>;
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type CreateRowInput = {
-  data: Scalars['JSON']['input']
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type CreateRowResultModel = {
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type CreateRowsInput = {
-  isRestore?: InputMaybe<Scalars['Boolean']['input']>
-  revisionId: Scalars['String']['input']
-  rows: Array<CreateRowsRowInput>
-  tableId: Scalars['String']['input']
-}
+  isRestore?: InputMaybe<Scalars['Boolean']['input']>;
+  revisionId: Scalars['String']['input'];
+  rows: Array<CreateRowsRowInput>;
+  tableId: Scalars['String']['input'];
+};
 
 export type CreateRowsResultModel = {
-  previousVersionTableId: Scalars['String']['output']
-  rows: Array<RowModel>
-  table: TableModel
-}
+  previousVersionTableId: Scalars['String']['output'];
+  rows: Array<RowModel>;
+  table: TableModel;
+};
 
 export type CreateRowsRowInput = {
-  data: Scalars['JSON']['input']
-  rowId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  rowId: Scalars['String']['input'];
+};
+
+export type CreateServiceApiKeyInput = {
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
+  name: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  permissions: CaslPermissionsInput;
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
+};
 
 export type CreateTableInput = {
-  revisionId: Scalars['String']['input']
-  schema: Scalars['JSON']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  schema: Scalars['JSON']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type CreateTableResultModel = {
-  branch: BranchModel
-  table: TableModel
-}
+  branch: BranchModel;
+  table: TableModel;
+};
 
 export type CreateUserInput = {
-  email?: InputMaybe<Scalars['String']['input']>
-  password: Scalars['String']['input']
-  roleId: UserSystemRole
-  username: Scalars['String']['input']
-}
+  email?: InputMaybe<Scalars['String']['input']>;
+  password: Scalars['String']['input'];
+  roleId: UserSystemRole;
+  username: Scalars['String']['input'];
+};
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['String']['input']>
-  gt?: InputMaybe<Scalars['String']['input']>
-  gte?: InputMaybe<Scalars['String']['input']>
-  in?: InputMaybe<Array<Scalars['String']['input']>>
-  lt?: InputMaybe<Scalars['String']['input']>
-  lte?: InputMaybe<Scalars['String']['input']>
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>
-}
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+};
 
 export type DeleteBranchInput = {
-  branchName: Scalars['String']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type DeleteEndpointInput = {
-  endpointId: Scalars['String']['input']
-}
+  endpointId: Scalars['String']['input'];
+};
 
 export type DeleteProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type DeleteRowInput = {
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type DeleteRowResultModel = {
-  branch: BranchModel
-  previousVersionTableId?: Maybe<Scalars['String']['output']>
-  table?: Maybe<TableModel>
-}
+  branch: BranchModel;
+  previousVersionTableId?: Maybe<Scalars['String']['output']>;
+  table?: Maybe<TableModel>;
+};
 
 export type DeleteRowsInput = {
-  revisionId: Scalars['String']['input']
-  rowIds: Array<Scalars['String']['input']>
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowIds: Array<Scalars['String']['input']>;
+  tableId: Scalars['String']['input'];
+};
 
 export type DeleteRowsResultModel = {
-  branch: BranchModel
-  previousVersionTableId?: Maybe<Scalars['String']['output']>
-  table?: Maybe<TableModel>
-}
+  branch: BranchModel;
+  previousVersionTableId?: Maybe<Scalars['String']['output']>;
+  table?: Maybe<TableModel>;
+};
 
 export type DeleteTableInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type DeleteTableResultModel = {
-  branch: BranchModel
-}
+  branch: BranchModel;
+};
 
 export type EndpointModel = {
-  createdAt: Scalars['DateTime']['output']
-  id: Scalars['String']['output']
-  revision: RevisionModel
-  revisionId: Scalars['String']['output']
-  type: EndpointType
-}
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  revision: RevisionModel;
+  revisionId: Scalars['String']['output'];
+  type: EndpointType;
+};
 
 export type EndpointModelEdge = {
-  cursor: Scalars['String']['output']
-  node: EndpointModel
-}
+  cursor: Scalars['String']['output'];
+  node: EndpointModel;
+};
 
 export enum EndpointType {
   Graphql = 'GRAPHQL',
-  RestApi = 'REST_API',
+  RestApi = 'REST_API'
 }
 
 export type EndpointsConnection = {
-  edges: Array<EndpointModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<EndpointModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type FieldChangeModel = {
-  changeType: RowChangeDetailType
-  fieldPath: Scalars['String']['output']
-  movedFrom?: Maybe<Scalars['String']['output']>
-  newValue?: Maybe<Scalars['JSON']['output']>
-  oldValue?: Maybe<Scalars['JSON']['output']>
-}
+  changeType: RowChangeDetailType;
+  fieldPath: Scalars['String']['output'];
+  movedFrom?: Maybe<Scalars['String']['output']>;
+  newValue?: Maybe<Scalars['JSON']['output']>;
+  oldValue?: Maybe<Scalars['JSON']['output']>;
+};
 
 export type FormulaFieldErrorModel = {
-  defaultUsed: Scalars['Boolean']['output']
-  error: Scalars['String']['output']
-  expression: Scalars['String']['output']
-  field: Scalars['String']['output']
-}
+  defaultUsed: Scalars['Boolean']['output'];
+  error: Scalars['String']['output'];
+  expression: Scalars['String']['output'];
+  field: Scalars['String']['output'];
+};
 
 export type GetBranchInput = {
-  branchName: Scalars['String']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GetBranchRevisionsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  before?: InputMaybe<Scalars['String']['input']>
-  comment?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  inclusive?: InputMaybe<Scalars['Boolean']['input']>
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  comment?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  inclusive?: InputMaybe<Scalars['Boolean']['input']>;
   /** Sort order: asc (default) or desc */
-  sort?: InputMaybe<SortOrder>
-}
+  sort?: InputMaybe<SortOrder>;
+};
 
 export type GetBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GetMeProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetOrganizationInput = {
-  organizationId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+};
 
 export type GetProjectBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetProjectEndpointsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  branchId?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  type?: InputMaybe<EndpointType>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  branchId?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  type?: InputMaybe<EndpointType>;
+};
 
 export type GetProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GetProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+};
 
 export type GetRevisionChangesInput = {
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
-  revisionId: Scalars['String']['input']
-}
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetRevisionInput = {
-  revisionId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetRevisionTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetRowChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<RowChangesFiltersInput>
-  first: Scalars['Int']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<RowChangesFiltersInput>;
+  first: Scalars['Int']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetRowCountForeignKeysByInput = {
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetRowForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  foreignKeyTableId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  foreignKeyTableId: Scalars['String']['input'];
+};
 
 export type GetRowInput = {
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  orderBy?: InputMaybe<Array<OrderBy>>
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-  where?: InputMaybe<WhereInput>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  orderBy?: InputMaybe<Array<OrderBy>>;
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+  where?: InputMaybe<WhereInput>;
+};
 
 export type GetSubSchemaItemsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>
-  revisionId: Scalars['String']['input']
-  schemaId: Scalars['String']['input']
-  where?: InputMaybe<SubSchemaWhereInput>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>;
+  revisionId: Scalars['String']['input'];
+  schemaId: Scalars['String']['input'];
+  where?: InputMaybe<SubSchemaWhereInput>;
+};
 
 export type GetTableChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<TableChangesFiltersInput>
-  first: Scalars['Int']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<TableChangesFiltersInput>;
+  first: Scalars['Int']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetTableForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetTableInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetTableRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+};
 
 export type GetTableViewsInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type GetTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export type GetUsersOrganizationInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+};
 
 export type GetUsersProjectInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type GithubOauth = {
-  available: Scalars['Boolean']['output']
-  clientId?: Maybe<Scalars['String']['output']>
-}
+  available: Scalars['Boolean']['output'];
+  clientId?: Maybe<Scalars['String']['output']>;
+};
 
 export type GoogleOauth = {
-  available: Scalars['Boolean']['output']
-  clientId?: Maybe<Scalars['String']['output']>
-}
+  available: Scalars['Boolean']['output'];
+  clientId?: Maybe<Scalars['String']['output']>;
+};
 
 export type HistoryPatchModel = {
-  hash: Scalars['String']['output']
-  patches: Array<JsonPatchOperationModel>
-}
+  hash: Scalars['String']['output'];
+  patches: Array<JsonPatchOperationModel>;
+};
 
 export type JsonFilter = {
-  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>
-  array_ends_with?: InputMaybe<Scalars['JSON']['input']>
-  array_starts_with?: InputMaybe<Scalars['JSON']['input']>
-  equals?: InputMaybe<Scalars['JSON']['input']>
-  gt?: InputMaybe<Scalars['Float']['input']>
-  gte?: InputMaybe<Scalars['Float']['input']>
-  lt?: InputMaybe<Scalars['Float']['input']>
-  lte?: InputMaybe<Scalars['Float']['input']>
-  mode?: InputMaybe<QueryMode>
-  path?: InputMaybe<Array<Scalars['String']['input']>>
-  search?: InputMaybe<Scalars['String']['input']>
-  searchIn?: InputMaybe<SearchIn>
+  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>;
+  array_ends_with?: InputMaybe<Scalars['JSON']['input']>;
+  array_starts_with?: InputMaybe<Scalars['JSON']['input']>;
+  equals?: InputMaybe<Scalars['JSON']['input']>;
+  gt?: InputMaybe<Scalars['Float']['input']>;
+  gte?: InputMaybe<Scalars['Float']['input']>;
+  lt?: InputMaybe<Scalars['Float']['input']>;
+  lte?: InputMaybe<Scalars['Float']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  path?: InputMaybe<Array<Scalars['String']['input']>>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  searchIn?: InputMaybe<SearchIn>;
   /** Default: simple */
-  searchLanguage?: InputMaybe<SearchLanguage>
-  searchType?: InputMaybe<SearchType>
-  string_contains?: InputMaybe<Scalars['String']['input']>
-  string_ends_with?: InputMaybe<Scalars['String']['input']>
-  string_starts_with?: InputMaybe<Scalars['String']['input']>
-}
+  searchLanguage?: InputMaybe<SearchLanguage>;
+  searchType?: InputMaybe<SearchType>;
+  string_contains?: InputMaybe<Scalars['String']['input']>;
+  string_ends_with?: InputMaybe<Scalars['String']['input']>;
+  string_starts_with?: InputMaybe<Scalars['String']['input']>;
+};
 
 export enum JsonPatchOp {
   Add = 'ADD',
   Copy = 'COPY',
   Move = 'MOVE',
   Remove = 'REMOVE',
-  Replace = 'REPLACE',
+  Replace = 'REPLACE'
 }
 
 export type JsonPatchOperationModel = {
-  from?: Maybe<Scalars['String']['output']>
-  op: JsonPatchOp
-  path: Scalars['String']['output']
-  value?: Maybe<Scalars['JSON']['output']>
-}
+  from?: Maybe<Scalars['String']['output']>;
+  op: JsonPatchOp;
+  path: Scalars['String']['output'];
+  value?: Maybe<Scalars['JSON']['output']>;
+};
 
 export type LoginGithubInput = {
-  code: Scalars['String']['input']
-}
+  code: Scalars['String']['input'];
+};
 
 export type LoginGoogleInput = {
-  code: Scalars['String']['input']
-  redirectUrl: Scalars['String']['input']
-}
+  code: Scalars['String']['input'];
+  redirectUrl: Scalars['String']['input'];
+};
 
 export type LoginInput = {
-  emailOrUsername: Scalars['String']['input']
-  password: Scalars['String']['input']
-}
+  emailOrUsername: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+};
 
 export type LoginModel = {
-  accessToken: Scalars['String']['output']
-}
+  accessToken: Scalars['String']['output'];
+};
 
 export type MeModel = {
-  email?: Maybe<Scalars['String']['output']>
-  hasPassword: Scalars['Boolean']['output']
-  id: Scalars['String']['output']
-  organization?: Maybe<OrganizationModel>
-  organizationId?: Maybe<Scalars['String']['output']>
-  role?: Maybe<RoleModel>
-  username?: Maybe<Scalars['String']['output']>
-}
+  email?: Maybe<Scalars['String']['output']>;
+  hasPassword: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
+  organization?: Maybe<OrganizationModel>;
+  organizationId?: Maybe<Scalars['String']['output']>;
+  role?: Maybe<RoleModel>;
+  username?: Maybe<Scalars['String']['output']>;
+};
 
 export enum MigrationType {
   Init = 'INIT',
   Remove = 'REMOVE',
   Rename = 'RENAME',
-  Update = 'UPDATE',
+  Update = 'UPDATE'
 }
 
 export type ModifiedRowChangeModel = {
-  changeType: ChangeType
-  fieldChanges: Array<FieldChangeModel>
-  fromRow: RowChangeRowModel
-  fromTable: RowChangeTableModel
-  row: RowChangeRowModel
-  table: RowChangeTableModel
-}
+  changeType: ChangeType;
+  fieldChanges: Array<FieldChangeModel>;
+  fromRow: RowChangeRowModel;
+  fromTable: RowChangeTableModel;
+  row: RowChangeRowModel;
+  table: RowChangeTableModel;
+};
 
 export type Mutation = {
-  activateEarlyAccess: SubscriptionModel
-  addUserToOrganization: Scalars['Boolean']['output']
-  addUserToProject: Scalars['Boolean']['output']
-  applyMigrations: Array<ApplyMigrationResultModel>
-  cancelSubscription: Scalars['Boolean']['output']
-  confirmEmailCode: LoginModel
-  createBranch: BranchModel
-  createCheckout: CheckoutResultModel
-  createEndpoint: EndpointModel
-  createProject: ProjectModel
-  createRevision: RevisionModel
-  createRow: CreateRowResultModel
-  createRows: CreateRowsResultModel
-  createTable: CreateTableResultModel
-  createUser: Scalars['Boolean']['output']
-  deleteBranch: Scalars['Boolean']['output']
-  deleteEndpoint: Scalars['Boolean']['output']
-  deleteProject: Scalars['Boolean']['output']
-  deleteRow: DeleteRowResultModel
-  deleteRows: DeleteRowsResultModel
-  deleteTable: DeleteTableResultModel
-  login: LoginModel
-  loginGithub: LoginModel
-  loginGoogle: LoginModel
-  patchRow: PatchRowResultModel
-  patchRows: PatchRowsResultModel
-  removeUserFromOrganization: Scalars['Boolean']['output']
-  removeUserFromProject: Scalars['Boolean']['output']
-  renameRow: RenameRowResultModel
-  renameTable: RenameTableResultModel
-  resetPassword: Scalars['Boolean']['output']
-  revertChanges: BranchModel
-  setUsername: Scalars['Boolean']['output']
-  signUp: Scalars['Boolean']['output']
-  updatePassword: Scalars['Boolean']['output']
-  updateProject: Scalars['Boolean']['output']
-  updateRow: UpdateRowResultModel
-  updateRows: UpdateRowsResultModel
-  updateTable: UpdateTableResultModel
-  updateTableViews: TableViewsDataModel
-  updateUserProjectRole: Scalars['Boolean']['output']
-}
+  activateEarlyAccess: SubscriptionModel;
+  addUserToOrganization: Scalars['Boolean']['output'];
+  addUserToProject: Scalars['Boolean']['output'];
+  applyMigrations: Array<ApplyMigrationResultModel>;
+  cancelSubscription: Scalars['Boolean']['output'];
+  confirmEmailCode: LoginModel;
+  createBranch: BranchModel;
+  createCheckout: CheckoutResultModel;
+  createEndpoint: EndpointModel;
+  createPersonalApiKey: ApiKeyWithSecretModel;
+  createProject: ProjectModel;
+  createRevision: RevisionModel;
+  createRow: CreateRowResultModel;
+  createRows: CreateRowsResultModel;
+  createServiceApiKey: ApiKeyWithSecretModel;
+  createTable: CreateTableResultModel;
+  createUser: Scalars['Boolean']['output'];
+  deleteBranch: Scalars['Boolean']['output'];
+  deleteEndpoint: Scalars['Boolean']['output'];
+  deleteProject: Scalars['Boolean']['output'];
+  deleteRow: DeleteRowResultModel;
+  deleteRows: DeleteRowsResultModel;
+  deleteTable: DeleteTableResultModel;
+  login: LoginModel;
+  loginGithub: LoginModel;
+  loginGoogle: LoginModel;
+  patchRow: PatchRowResultModel;
+  patchRows: PatchRowsResultModel;
+  removeUserFromOrganization: Scalars['Boolean']['output'];
+  removeUserFromProject: Scalars['Boolean']['output'];
+  renameRow: RenameRowResultModel;
+  renameTable: RenameTableResultModel;
+  resetPassword: Scalars['Boolean']['output'];
+  revertChanges: BranchModel;
+  revokeApiKey: ApiKeyModel;
+  rotateApiKey: ApiKeyWithSecretModel;
+  setUsername: Scalars['Boolean']['output'];
+  signUp: Scalars['Boolean']['output'];
+  updatePassword: Scalars['Boolean']['output'];
+  updateProject: Scalars['Boolean']['output'];
+  updateRow: UpdateRowResultModel;
+  updateRows: UpdateRowsResultModel;
+  updateTable: UpdateTableResultModel;
+  updateTableViews: TableViewsDataModel;
+  updateUserProjectRole: Scalars['Boolean']['output'];
+};
+
 
 export type MutationActivateEarlyAccessArgs = {
-  data: ActivateEarlyAccessInput
-}
+  data: ActivateEarlyAccessInput;
+};
+
 
 export type MutationAddUserToOrganizationArgs = {
-  data: AddUserToOrganizationInput
-}
+  data: AddUserToOrganizationInput;
+};
+
 
 export type MutationAddUserToProjectArgs = {
-  data: AddUserToProjectInput
-}
+  data: AddUserToProjectInput;
+};
+
 
 export type MutationApplyMigrationsArgs = {
-  data: ApplyMigrationsInput
-}
+  data: ApplyMigrationsInput;
+};
+
 
 export type MutationCancelSubscriptionArgs = {
-  data: CancelSubscriptionInput
-}
+  data: CancelSubscriptionInput;
+};
+
 
 export type MutationConfirmEmailCodeArgs = {
-  data: ConfirmEmailCodeInput
-}
+  data: ConfirmEmailCodeInput;
+};
+
 
 export type MutationCreateBranchArgs = {
-  data: CreateBranchInput
-}
+  data: CreateBranchInput;
+};
+
 
 export type MutationCreateCheckoutArgs = {
-  data: CreateCheckoutInput
-}
+  data: CreateCheckoutInput;
+};
+
 
 export type MutationCreateEndpointArgs = {
-  data: CreateEndpointInput
-}
+  data: CreateEndpointInput;
+};
+
+
+export type MutationCreatePersonalApiKeyArgs = {
+  data: CreatePersonalApiKeyInput;
+};
+
 
 export type MutationCreateProjectArgs = {
-  data: CreateProjectInput
-}
+  data: CreateProjectInput;
+};
+
 
 export type MutationCreateRevisionArgs = {
-  data: CreateRevisionInput
-}
+  data: CreateRevisionInput;
+};
+
 
 export type MutationCreateRowArgs = {
-  data: CreateRowInput
-}
+  data: CreateRowInput;
+};
+
 
 export type MutationCreateRowsArgs = {
-  data: CreateRowsInput
-}
+  data: CreateRowsInput;
+};
+
+
+export type MutationCreateServiceApiKeyArgs = {
+  data: CreateServiceApiKeyInput;
+};
+
 
 export type MutationCreateTableArgs = {
-  data: CreateTableInput
-}
+  data: CreateTableInput;
+};
+
 
 export type MutationCreateUserArgs = {
-  data: CreateUserInput
-}
+  data: CreateUserInput;
+};
+
 
 export type MutationDeleteBranchArgs = {
-  data: DeleteBranchInput
-}
+  data: DeleteBranchInput;
+};
+
 
 export type MutationDeleteEndpointArgs = {
-  data: DeleteEndpointInput
-}
+  data: DeleteEndpointInput;
+};
+
 
 export type MutationDeleteProjectArgs = {
-  data: DeleteProjectInput
-}
+  data: DeleteProjectInput;
+};
+
 
 export type MutationDeleteRowArgs = {
-  data: DeleteRowInput
-}
+  data: DeleteRowInput;
+};
+
 
 export type MutationDeleteRowsArgs = {
-  data: DeleteRowsInput
-}
+  data: DeleteRowsInput;
+};
+
 
 export type MutationDeleteTableArgs = {
-  data: DeleteTableInput
-}
+  data: DeleteTableInput;
+};
+
 
 export type MutationLoginArgs = {
-  data: LoginInput
-}
+  data: LoginInput;
+};
+
 
 export type MutationLoginGithubArgs = {
-  data: LoginGithubInput
-}
+  data: LoginGithubInput;
+};
+
 
 export type MutationLoginGoogleArgs = {
-  data: LoginGoogleInput
-}
+  data: LoginGoogleInput;
+};
+
 
 export type MutationPatchRowArgs = {
-  data: PatchRowInput
-}
+  data: PatchRowInput;
+};
+
 
 export type MutationPatchRowsArgs = {
-  data: PatchRowsInput
-}
+  data: PatchRowsInput;
+};
+
 
 export type MutationRemoveUserFromOrganizationArgs = {
-  data: RemoveUserFromOrganizationInput
-}
+  data: RemoveUserFromOrganizationInput;
+};
+
 
 export type MutationRemoveUserFromProjectArgs = {
-  data: RemoveUserFromProjectInput
-}
+  data: RemoveUserFromProjectInput;
+};
+
 
 export type MutationRenameRowArgs = {
-  data: RenameRowInput
-}
+  data: RenameRowInput;
+};
+
 
 export type MutationRenameTableArgs = {
-  data: RenameTableInput
-}
+  data: RenameTableInput;
+};
+
 
 export type MutationResetPasswordArgs = {
-  data: ResetPasswordInput
-}
+  data: ResetPasswordInput;
+};
+
 
 export type MutationRevertChangesArgs = {
-  data: RevertChangesInput
-}
+  data: RevertChangesInput;
+};
+
+
+export type MutationRevokeApiKeyArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationRotateApiKeyArgs = {
+  id: Scalars['ID']['input'];
+};
+
 
 export type MutationSetUsernameArgs = {
-  data: SetUsernameInput
-}
+  data: SetUsernameInput;
+};
+
 
 export type MutationSignUpArgs = {
-  data: SignUpInput
-}
+  data: SignUpInput;
+};
+
 
 export type MutationUpdatePasswordArgs = {
-  data: UpdatePasswordInput
-}
+  data: UpdatePasswordInput;
+};
+
 
 export type MutationUpdateProjectArgs = {
-  data: UpdateProjectInput
-}
+  data: UpdateProjectInput;
+};
+
 
 export type MutationUpdateRowArgs = {
-  data: UpdateRowInput
-}
+  data: UpdateRowInput;
+};
+
 
 export type MutationUpdateRowsArgs = {
-  data: UpdateRowsInput
-}
+  data: UpdateRowsInput;
+};
+
 
 export type MutationUpdateTableArgs = {
-  data: UpdateTableInput
-}
+  data: UpdateTableInput;
+};
+
 
 export type MutationUpdateTableViewsArgs = {
-  data: UpdateTableViewsInput
-}
+  data: UpdateTableViewsInput;
+};
+
 
 export type MutationUpdateUserProjectRoleArgs = {
-  data: UpdateUserProjectRoleInput
-}
+  data: UpdateUserProjectRoleInput;
+};
 
 export enum NullsPosition {
   First = 'first',
-  Last = 'last',
+  Last = 'last'
 }
 
 export type OrderBy = {
-  aggregation?: InputMaybe<OrderDataAggregation>
-  direction: SortOrder
-  field: OrderByField
-  path?: InputMaybe<Scalars['String']['input']>
-  type?: InputMaybe<OrderDataType>
-}
+  aggregation?: InputMaybe<OrderDataAggregation>;
+  direction: SortOrder;
+  field: OrderByField;
+  path?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<OrderDataType>;
+};
 
 export enum OrderByField {
   CreatedAt = 'createdAt',
   Data = 'data',
   Id = 'id',
   PublishedAt = 'publishedAt',
-  UpdatedAt = 'updatedAt',
+  UpdatedAt = 'updatedAt'
 }
 
 export enum OrderDataAggregation {
@@ -825,7 +953,7 @@ export enum OrderDataAggregation {
   First = 'first',
   Last = 'last',
   Max = 'max',
-  Min = 'min',
+  Min = 'min'
 }
 
 export enum OrderDataType {
@@ -833,484 +961,529 @@ export enum OrderDataType {
   Float = 'float',
   Int = 'int',
   Text = 'text',
-  Timestamp = 'timestamp',
+  Timestamp = 'timestamp'
 }
 
 export type OrganizationModel = {
-  createdId: Scalars['String']['output']
-  id: Scalars['String']['output']
-  subscription?: Maybe<SubscriptionModel>
-  usage?: Maybe<UsageSummaryModel>
-  userOrganization?: Maybe<UsersOrganizationModel>
-}
+  createdId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  subscription?: Maybe<SubscriptionModel>;
+  usage?: Maybe<UsageSummaryModel>;
+  userOrganization?: Maybe<UsersOrganizationModel>;
+};
 
 export type PageInfo = {
-  endCursor?: Maybe<Scalars['String']['output']>
-  hasNextPage: Scalars['Boolean']['output']
-  hasPreviousPage: Scalars['Boolean']['output']
-  startCursor?: Maybe<Scalars['String']['output']>
-}
+  endCursor?: Maybe<Scalars['String']['output']>;
+  hasNextPage: Scalars['Boolean']['output'];
+  hasPreviousPage: Scalars['Boolean']['output'];
+  startCursor?: Maybe<Scalars['String']['output']>;
+};
 
 export type ParentBranchModel = {
-  branch: BranchModel
-  revision: RevisionModel
-}
+  branch: BranchModel;
+  revision: RevisionModel;
+};
 
 export type PatchRow = {
-  op: PatchRowOp
-  path: Scalars['String']['input']
-  value: Scalars['JSON']['input']
-}
+  op: PatchRowOp;
+  path: Scalars['String']['input'];
+  value: Scalars['JSON']['input'];
+};
 
 export type PatchRowInput = {
-  patches: Array<PatchRow>
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  patches: Array<PatchRow>;
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export enum PatchRowOp {
-  Replace = 'replace',
+  Replace = 'replace'
 }
 
 export type PatchRowResultModel = {
-  previousVersionRowId: Scalars['String']['output']
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  previousVersionRowId: Scalars['String']['output'];
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type PatchRowsInput = {
-  revisionId: Scalars['String']['input']
-  rows: Array<PatchRowsRowInput>
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rows: Array<PatchRowsRowInput>;
+  tableId: Scalars['String']['input'];
+};
 
 export type PatchRowsResultModel = {
-  previousVersionTableId: Scalars['String']['output']
-  rows: Array<RowModel>
-  table: TableModel
-}
+  previousVersionTableId: Scalars['String']['output'];
+  rows: Array<RowModel>;
+  table: TableModel;
+};
 
 export type PatchRowsRowInput = {
-  patches: Array<PatchRow>
-  rowId: Scalars['String']['input']
-}
+  patches: Array<PatchRow>;
+  rowId: Scalars['String']['input'];
+};
 
 export type PaymentProviderModel = {
-  id: Scalars['ID']['output']
-  methods: Array<Scalars['String']['output']>
-  name: Scalars['String']['output']
-  supportsRecurring: Scalars['Boolean']['output']
-}
+  id: Scalars['ID']['output'];
+  methods: Array<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  supportsRecurring: Scalars['Boolean']['output'];
+};
 
 export type PermissionModel = {
-  action: Scalars['String']['output']
-  condition?: Maybe<Scalars['JSON']['output']>
-  id: Scalars['String']['output']
-  subject: Scalars['String']['output']
-}
+  action: Scalars['String']['output'];
+  condition?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['String']['output'];
+  subject: Scalars['String']['output'];
+};
 
 export type PlanLimitsModel = {
-  apiCallsPerDay?: Maybe<Scalars['Int']['output']>
-  projects?: Maybe<Scalars['Int']['output']>
-  rowVersions?: Maybe<Scalars['Int']['output']>
-  seats?: Maybe<Scalars['Int']['output']>
-  storageBytes?: Maybe<Scalars['Float']['output']>
-}
+  apiCallsPerDay?: Maybe<Scalars['Int']['output']>;
+  branchesPerProject?: Maybe<Scalars['Int']['output']>;
+  projects?: Maybe<Scalars['Int']['output']>;
+  rowVersions?: Maybe<Scalars['Int']['output']>;
+  rowsPerTable?: Maybe<Scalars['Int']['output']>;
+  seats?: Maybe<Scalars['Int']['output']>;
+  storageBytes?: Maybe<Scalars['Float']['output']>;
+  tablesPerRevision?: Maybe<Scalars['Int']['output']>;
+};
 
 export type PlanModel = {
-  features: Scalars['JSON']['output']
-  id: Scalars['ID']['output']
-  isPublic: Scalars['Boolean']['output']
-  limits: PlanLimitsModel
-  monthlyPriceUsd: Scalars['Float']['output']
-  name: Scalars['String']['output']
-  yearlyPriceUsd: Scalars['Float']['output']
-}
+  features: Scalars['JSON']['output'];
+  id: Scalars['ID']['output'];
+  isPublic: Scalars['Boolean']['output'];
+  limits: PlanLimitsModel;
+  monthlyPriceUsd: Scalars['Float']['output'];
+  name: Scalars['String']['output'];
+  yearlyPriceUsd: Scalars['Float']['output'];
+};
 
 export type PluginsModel = {
-  file: Scalars['Boolean']['output']
-}
+  file: Scalars['Boolean']['output'];
+};
 
 export type ProjectModel = {
-  allBranches: BranchesConnection
-  createdAt: Scalars['DateTime']['output']
-  id: Scalars['String']['output']
-  isPublic: Scalars['Boolean']['output']
-  name: Scalars['String']['output']
-  organization: OrganizationModel
-  organizationId: Scalars['String']['output']
-  rootBranch: BranchModel
-  userProject?: Maybe<UsersProjectModel>
-}
+  allBranches: BranchesConnection;
+  createdAt: Scalars['DateTime']['output'];
+  id: Scalars['String']['output'];
+  isPublic: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  organization: OrganizationModel;
+  organizationId: Scalars['String']['output'];
+  rootBranch: BranchModel;
+  userProject?: Maybe<UsersProjectModel>;
+};
+
 
 export type ProjectModelAllBranchesArgs = {
-  data: GetProjectBranchesInput
-}
+  data: GetProjectBranchesInput;
+};
 
 export type ProjectModelEdge = {
-  cursor: Scalars['String']['output']
-  node: ProjectModel
-}
+  cursor: Scalars['String']['output'];
+  node: ProjectModel;
+};
 
 export type ProjectsConnection = {
-  edges: Array<ProjectModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<ProjectModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type Query = {
-  adminUser?: Maybe<UserModel>
-  adminUsers: UsersConnection
-  availableProviders: Array<PaymentProviderModel>
-  branch: BranchModel
-  branches: BranchesConnection
-  configuration: ConfigurationModel
+  adminUser?: Maybe<UserModel>;
+  adminUsers: UsersConnection;
+  apiKeyById: ApiKeyModel;
+  availableProviders: Array<PaymentProviderModel>;
+  branch: BranchModel;
+  branches: BranchesConnection;
+  configuration: ConfigurationModel;
   /** @deprecated use RowModel.rowForeignKeysBy.totalCount */
-  getRowCountForeignKeysTo: Scalars['Int']['output']
-  me: MeModel
-  meProjects: ProjectsConnection
-  organization: OrganizationModel
-  plans: Array<PlanModel>
-  project: ProjectModel
-  projectEndpoints: EndpointsConnection
-  projects: ProjectsConnection
-  revision: RevisionModel
-  revisionChanges: RevisionChangesModel
-  row?: Maybe<RowModel>
-  rowChanges: RowChangesConnection
-  rows: RowsConnection
-  searchRows: SearchResultsConnection
-  searchUsers: SearchUsersConnection
-  subSchemaItems: SubSchemaItemsConnection
-  table?: Maybe<TableModel>
-  tableChanges: TableChangesConnection
-  tableViews: TableViewsDataModel
-  tables: TablesConnection
-  usersOrganization: UsersOrganizationConnection
-  usersProject: UsersProjectConnection
-}
+  getRowCountForeignKeysTo: Scalars['Int']['output'];
+  me: MeModel;
+  meProjects: ProjectsConnection;
+  myApiKeys: Array<ApiKeyModel>;
+  organization: OrganizationModel;
+  plans: Array<PlanModel>;
+  project: ProjectModel;
+  projectEndpoints: EndpointsConnection;
+  projects: ProjectsConnection;
+  revision: RevisionModel;
+  revisionChanges: RevisionChangesModel;
+  row?: Maybe<RowModel>;
+  rowChanges: RowChangesConnection;
+  rows: RowsConnection;
+  searchRows: SearchResultsConnection;
+  searchUsers: SearchUsersConnection;
+  serviceApiKeys: Array<ApiKeyModel>;
+  subSchemaItems: SubSchemaItemsConnection;
+  table?: Maybe<TableModel>;
+  tableChanges: TableChangesConnection;
+  tableViews: TableViewsDataModel;
+  tables: TablesConnection;
+  usersOrganization: UsersOrganizationConnection;
+  usersProject: UsersProjectConnection;
+};
+
 
 export type QueryAdminUserArgs = {
-  data: AdminUserInput
-}
+  data: AdminUserInput;
+};
+
 
 export type QueryAdminUsersArgs = {
-  data: SearchUsersInput
-}
+  data: SearchUsersInput;
+};
+
+
+export type QueryApiKeyByIdArgs = {
+  id: Scalars['ID']['input'];
+};
+
 
 export type QueryAvailableProvidersArgs = {
-  country?: InputMaybe<Scalars['String']['input']>
-  method?: InputMaybe<Scalars['String']['input']>
-}
+  country?: InputMaybe<Scalars['String']['input']>;
+  method?: InputMaybe<Scalars['String']['input']>;
+};
+
 
 export type QueryBranchArgs = {
-  data: GetBranchInput
-}
+  data: GetBranchInput;
+};
+
 
 export type QueryBranchesArgs = {
-  data: GetBranchesInput
-}
+  data: GetBranchesInput;
+};
+
 
 export type QueryGetRowCountForeignKeysToArgs = {
-  data: GetRowCountForeignKeysByInput
-}
+  data: GetRowCountForeignKeysByInput;
+};
+
 
 export type QueryMeProjectsArgs = {
-  data: GetMeProjectsInput
-}
+  data: GetMeProjectsInput;
+};
+
 
 export type QueryOrganizationArgs = {
-  data: GetOrganizationInput
-}
+  data: GetOrganizationInput;
+};
+
 
 export type QueryProjectArgs = {
-  data: GetProjectInput
-}
+  data: GetProjectInput;
+};
+
 
 export type QueryProjectEndpointsArgs = {
-  data: GetProjectEndpointsInput
-}
+  data: GetProjectEndpointsInput;
+};
+
 
 export type QueryProjectsArgs = {
-  data: GetProjectsInput
-}
+  data: GetProjectsInput;
+};
+
 
 export type QueryRevisionArgs = {
-  data: GetRevisionInput
-}
+  data: GetRevisionInput;
+};
+
 
 export type QueryRevisionChangesArgs = {
-  data: GetRevisionChangesInput
-}
+  data: GetRevisionChangesInput;
+};
+
 
 export type QueryRowArgs = {
-  data: GetRowInput
-}
+  data: GetRowInput;
+};
+
 
 export type QueryRowChangesArgs = {
-  data: GetRowChangesInput
-}
+  data: GetRowChangesInput;
+};
+
 
 export type QueryRowsArgs = {
-  data: GetRowsInput
-}
+  data: GetRowsInput;
+};
+
 
 export type QuerySearchRowsArgs = {
-  data: SearchRowsInput
-}
+  data: SearchRowsInput;
+};
+
 
 export type QuerySearchUsersArgs = {
-  data: SearchUsersInput
-}
+  data: SearchUsersInput;
+};
+
+
+export type QueryServiceApiKeysArgs = {
+  organizationId: Scalars['String']['input'];
+};
+
 
 export type QuerySubSchemaItemsArgs = {
-  data: GetSubSchemaItemsInput
-}
+  data: GetSubSchemaItemsInput;
+};
+
 
 export type QueryTableArgs = {
-  data: GetTableInput
-}
+  data: GetTableInput;
+};
+
 
 export type QueryTableChangesArgs = {
-  data: GetTableChangesInput
-}
+  data: GetTableChangesInput;
+};
+
 
 export type QueryTableViewsArgs = {
-  data: GetTableViewsInput
-}
+  data: GetTableViewsInput;
+};
+
 
 export type QueryTablesArgs = {
-  data: GetTablesInput
-}
+  data: GetTablesInput;
+};
+
 
 export type QueryUsersOrganizationArgs = {
-  data: GetUsersOrganizationInput
-}
+  data: GetUsersOrganizationInput;
+};
+
 
 export type QueryUsersProjectArgs = {
-  data: GetUsersProjectInput
-}
+  data: GetUsersProjectInput;
+};
 
 export enum QueryMode {
   Default = 'default',
-  Insensitive = 'insensitive',
+  Insensitive = 'insensitive'
 }
 
 export type RemoveUserFromOrganizationInput = {
-  organizationId: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
 
 export type RemoveUserFromProjectInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
 
 export type RemovedRowChangeModel = {
-  changeType: ChangeType
-  fieldChanges: Array<FieldChangeModel>
-  fromRow: RowChangeRowModel
-  fromTable: RowChangeTableModel
-}
+  changeType: ChangeType;
+  fieldChanges: Array<FieldChangeModel>;
+  fromRow: RowChangeRowModel;
+  fromTable: RowChangeTableModel;
+};
 
 export type RenameRowInput = {
-  nextRowId: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  nextRowId: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type RenameRowResultModel = {
-  previousVersionRowId: Scalars['String']['output']
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  previousVersionRowId: Scalars['String']['output'];
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type RenameTableInput = {
-  nextTableId: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  nextTableId: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type RenameTableResultModel = {
-  previousVersionTableId: Scalars['String']['output']
-  table: TableModel
-}
+  previousVersionTableId: Scalars['String']['output'];
+  table: TableModel;
+};
 
 export type ResetPasswordInput = {
-  newPassword: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}
+  newPassword: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+};
 
 export type RevertChangesInput = {
-  branchName: Scalars['String']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  branchName: Scalars['String']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type RevisionChangeSummaryModel = {
-  added: Scalars['Int']['output']
-  modified: Scalars['Int']['output']
-  removed: Scalars['Int']['output']
-  renamed: Scalars['Int']['output']
-  total: Scalars['Int']['output']
-}
+  added: Scalars['Int']['output'];
+  modified: Scalars['Int']['output'];
+  removed: Scalars['Int']['output'];
+  renamed: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
 
 export type RevisionChangesModel = {
-  parentRevisionId?: Maybe<Scalars['String']['output']>
-  revisionId: Scalars['String']['output']
-  rowsSummary: RevisionChangeSummaryModel
-  tablesSummary: RevisionChangeSummaryModel
-  totalChanges: Scalars['Int']['output']
-}
+  parentRevisionId?: Maybe<Scalars['String']['output']>;
+  revisionId: Scalars['String']['output'];
+  rowsSummary: RevisionChangeSummaryModel;
+  tablesSummary: RevisionChangeSummaryModel;
+  totalChanges: Scalars['Int']['output'];
+};
 
 export type RevisionConnection = {
-  edges: Array<RevisionModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<RevisionModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type RevisionModel = {
-  branch: BranchModel
-  changes: RevisionChangesModel
-  child?: Maybe<RevisionModel>
-  childBranches: Array<ChildBranchModel>
-  children: Array<RevisionModel>
-  comment: Scalars['String']['output']
-  createdAt: Scalars['DateTime']['output']
-  endpoints: Array<EndpointModel>
-  id: Scalars['String']['output']
-  isDraft: Scalars['Boolean']['output']
-  isHead: Scalars['Boolean']['output']
-  isStart: Scalars['Boolean']['output']
-  migrations: Array<Scalars['JSON']['output']>
-  parent?: Maybe<RevisionModel>
-  sequence: Scalars['Int']['output']
-  tables: TablesConnection
-}
+  branch: BranchModel;
+  changes: RevisionChangesModel;
+  child?: Maybe<RevisionModel>;
+  childBranches: Array<ChildBranchModel>;
+  children: Array<RevisionModel>;
+  comment: Scalars['String']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  endpoints: Array<EndpointModel>;
+  id: Scalars['String']['output'];
+  isDraft: Scalars['Boolean']['output'];
+  isHead: Scalars['Boolean']['output'];
+  isStart: Scalars['Boolean']['output'];
+  migrations: Array<Scalars['JSON']['output']>;
+  parent?: Maybe<RevisionModel>;
+  sequence: Scalars['Int']['output'];
+  tables: TablesConnection;
+};
+
 
 export type RevisionModelTablesArgs = {
-  data: GetRevisionTablesInput
-}
+  data: GetRevisionTablesInput;
+};
 
 export type RevisionModelEdge = {
-  cursor: Scalars['String']['output']
-  node: RevisionModel
-}
+  cursor: Scalars['String']['output'];
+  node: RevisionModel;
+};
 
 export type RoleModel = {
-  id: Scalars['String']['output']
-  name: Scalars['String']['output']
-  permissions: Array<PermissionModel>
-}
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  permissions: Array<PermissionModel>;
+};
 
-export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel
+export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel;
 
 export enum RowChangeDetailType {
   FieldAdded = 'FIELD_ADDED',
   FieldModified = 'FIELD_MODIFIED',
   FieldMoved = 'FIELD_MOVED',
-  FieldRemoved = 'FIELD_REMOVED',
+  FieldRemoved = 'FIELD_REMOVED'
 }
 
 export type RowChangeEdge = {
-  cursor: Scalars['String']['output']
-  node: RowChange
-}
+  cursor: Scalars['String']['output'];
+  node: RowChange;
+};
 
 export type RowChangeRowModel = {
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  data: Scalars['JSON']['output']
-  hash: Scalars['String']['output']
-  id: Scalars['String']['output']
-  meta: Scalars['JSON']['output']
-  publishedAt: Scalars['DateTime']['output']
-  readonly: Scalars['Boolean']['output']
-  schemaHash: Scalars['String']['output']
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-}
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  data: Scalars['JSON']['output'];
+  hash: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  meta: Scalars['JSON']['output'];
+  publishedAt: Scalars['DateTime']['output'];
+  readonly: Scalars['Boolean']['output'];
+  schemaHash: Scalars['String']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+};
 
 export type RowChangeTableModel = {
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  id: Scalars['String']['output']
-  readonly: Scalars['Boolean']['output']
-  system: Scalars['Boolean']['output']
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-}
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  readonly: Scalars['Boolean']['output'];
+  system: Scalars['Boolean']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+};
 
 export type RowChangesConnection = {
-  edges: Array<RowChangeEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<RowChangeEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type RowChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
-  search?: InputMaybe<Scalars['String']['input']>
-  tableId?: InputMaybe<Scalars['String']['input']>
-}
+  changeTypes?: InputMaybe<Array<ChangeType>>;
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  tableId?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type RowModel = {
-  countForeignKeysTo: Scalars['Int']['output']
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  data: Scalars['JSON']['output']
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
-  id: Scalars['String']['output']
-  publishedAt: Scalars['DateTime']['output']
-  readonly: Scalars['Boolean']['output']
-  rowForeignKeysBy: RowsConnection
-  rowForeignKeysTo: RowsConnection
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-}
+  countForeignKeysTo: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  data: Scalars['JSON']['output'];
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
+  id: Scalars['String']['output'];
+  publishedAt: Scalars['DateTime']['output'];
+  readonly: Scalars['Boolean']['output'];
+  rowForeignKeysBy: RowsConnection;
+  rowForeignKeysTo: RowsConnection;
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+};
+
 
 export type RowModelRowForeignKeysByArgs = {
-  data: GetRowForeignKeysInput
-}
+  data: GetRowForeignKeysInput;
+};
+
 
 export type RowModelRowForeignKeysToArgs = {
-  data: GetRowForeignKeysInput
-}
+  data: GetRowForeignKeysInput;
+};
 
 export type RowModelEdge = {
-  cursor: Scalars['String']['output']
-  node: RowModel
-}
+  cursor: Scalars['String']['output'];
+  node: RowModel;
+};
 
 export type RowsConnection = {
-  edges: Array<RowModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<RowModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SchemaFieldChangeModel = {
-  changeType: Scalars['String']['output']
-  fieldPath: Scalars['String']['output']
-  movedFrom?: Maybe<Scalars['String']['output']>
-  movedTo?: Maybe<Scalars['String']['output']>
-  newSchema?: Maybe<Scalars['JSON']['output']>
-  oldSchema?: Maybe<Scalars['JSON']['output']>
-}
+  changeType: Scalars['String']['output'];
+  fieldPath: Scalars['String']['output'];
+  movedFrom?: Maybe<Scalars['String']['output']>;
+  movedTo?: Maybe<Scalars['String']['output']>;
+  newSchema?: Maybe<Scalars['JSON']['output']>;
+  oldSchema?: Maybe<Scalars['JSON']['output']>;
+};
 
 export type SchemaMigrationDetailModel = {
-  historyPatches?: Maybe<Array<HistoryPatchModel>>
-  initialSchema?: Maybe<Scalars['JSON']['output']>
-  migrationId: Scalars['String']['output']
-  migrationType: MigrationType
-  newTableId?: Maybe<Scalars['String']['output']>
-  oldTableId?: Maybe<Scalars['String']['output']>
-  patches?: Maybe<Array<JsonPatchOperationModel>>
-}
+  historyPatches?: Maybe<Array<HistoryPatchModel>>;
+  initialSchema?: Maybe<Scalars['JSON']['output']>;
+  migrationId: Scalars['String']['output'];
+  migrationType: MigrationType;
+  newTableId?: Maybe<Scalars['String']['output']>;
+  oldTableId?: Maybe<Scalars['String']['output']>;
+  patches?: Maybe<Array<JsonPatchOperationModel>>;
+};
 
 export enum SearchIn {
   All = 'all',
@@ -1318,7 +1491,7 @@ export enum SearchIn {
   Keys = 'keys',
   Numbers = 'numbers',
   Strings = 'strings',
-  Values = 'values',
+  Values = 'values'
 }
 
 /** Language for full-text search. Default: simple */
@@ -1351,2442 +1524,1926 @@ export enum SearchLanguage {
   Swedish = 'swedish',
   Tamil = 'tamil',
   Turkish = 'turkish',
-  Yiddish = 'yiddish',
+  Yiddish = 'yiddish'
 }
 
 export type SearchMatch = {
-  highlight?: Maybe<Scalars['String']['output']>
-  path: Scalars['String']['output']
-  value: Scalars['JSON']['output']
-}
+  highlight?: Maybe<Scalars['String']['output']>;
+  path: Scalars['String']['output'];
+  value: Scalars['JSON']['output'];
+};
 
 export type SearchResult = {
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
-  matches: Array<SearchMatch>
-  row: RowModel
-  table: TableModel
-}
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
+  matches: Array<SearchMatch>;
+  row: RowModel;
+  table: TableModel;
+};
 
 export type SearchResultEdge = {
-  cursor: Scalars['String']['output']
-  node: SearchResult
-}
+  cursor: Scalars['String']['output'];
+  node: SearchResult;
+};
 
 export type SearchResultsConnection = {
-  edges: Array<SearchResultEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<SearchResultEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SearchRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first?: InputMaybe<Scalars['Int']['input']>
-  query: Scalars['String']['input']
-  revisionId: Scalars['String']['input']
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  query: Scalars['String']['input'];
+  revisionId: Scalars['String']['input'];
+};
 
 export enum SearchType {
   Phrase = 'phrase',
   Plain = 'plain',
   Prefix = 'prefix',
-  Tsquery = 'tsquery',
+  Tsquery = 'tsquery'
 }
 
 export type SearchUserModel = {
-  email?: Maybe<Scalars['String']['output']>
-  id: Scalars['String']['output']
-  username?: Maybe<Scalars['String']['output']>
-}
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  username?: Maybe<Scalars['String']['output']>;
+};
 
 export type SearchUserModelEdge = {
-  cursor: Scalars['String']['output']
-  node: SearchUserModel
-}
+  cursor: Scalars['String']['output'];
+  node: SearchUserModel;
+};
 
 export type SearchUsersConnection = {
-  edges: Array<SearchUserModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<SearchUserModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SearchUsersInput = {
-  after?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  search?: InputMaybe<Scalars['String']['input']>
-}
+  after?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  search?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SetUsernameInput = {
-  username: Scalars['String']['input']
-}
+  username: Scalars['String']['input'];
+};
 
 export type SignUpInput = {
-  email: Scalars['String']['input']
-  password: Scalars['String']['input']
-  username: Scalars['String']['input']
-}
+  email: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  username: Scalars['String']['input'];
+};
 
 export enum SortOrder {
   Asc = 'asc',
-  Desc = 'desc',
+  Desc = 'desc'
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']['input']>
-  endsWith?: InputMaybe<Scalars['String']['input']>
-  equals?: InputMaybe<Scalars['String']['input']>
-  gt?: InputMaybe<Scalars['String']['input']>
-  gte?: InputMaybe<Scalars['String']['input']>
-  in?: InputMaybe<Array<Scalars['String']['input']>>
-  lt?: InputMaybe<Scalars['String']['input']>
-  lte?: InputMaybe<Scalars['String']['input']>
-  mode?: InputMaybe<QueryMode>
-  not?: InputMaybe<Scalars['String']['input']>
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>
-  startsWith?: InputMaybe<Scalars['String']['input']>
-}
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SubSchemaDataOrderByInput = {
-  nulls?: InputMaybe<NullsPosition>
-  order: SortOrder
-  path: Scalars['JSON']['input']
-}
+  nulls?: InputMaybe<NullsPosition>;
+  order: SortOrder;
+  path: Scalars['JSON']['input'];
+};
 
 export type SubSchemaItemModel = {
-  data: Scalars['JSON']['output']
-  fieldPath: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  data: Scalars['JSON']['output'];
+  fieldPath: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type SubSchemaItemModelEdge = {
-  cursor: Scalars['String']['output']
-  node: SubSchemaItemModel
-}
+  cursor: Scalars['String']['output'];
+  node: SubSchemaItemModel;
+};
 
 export type SubSchemaItemsConnection = {
-  edges: Array<SubSchemaItemModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<SubSchemaItemModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type SubSchemaJsonFilterInput = {
-  equals?: InputMaybe<Scalars['JSON']['input']>
-  gt?: InputMaybe<Scalars['JSON']['input']>
-  gte?: InputMaybe<Scalars['JSON']['input']>
-  in?: InputMaybe<Array<Scalars['JSON']['input']>>
-  lt?: InputMaybe<Scalars['JSON']['input']>
-  lte?: InputMaybe<Scalars['JSON']['input']>
-  mode?: InputMaybe<QueryMode>
-  not?: InputMaybe<Scalars['JSON']['input']>
-  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>
-  path: Scalars['JSON']['input']
-  string_contains?: InputMaybe<Scalars['String']['input']>
-  string_ends_with?: InputMaybe<Scalars['String']['input']>
-  string_starts_with?: InputMaybe<Scalars['String']['input']>
-}
+  equals?: InputMaybe<Scalars['JSON']['input']>;
+  gt?: InputMaybe<Scalars['JSON']['input']>;
+  gte?: InputMaybe<Scalars['JSON']['input']>;
+  in?: InputMaybe<Array<Scalars['JSON']['input']>>;
+  lt?: InputMaybe<Scalars['JSON']['input']>;
+  lte?: InputMaybe<Scalars['JSON']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['JSON']['input']>;
+  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>;
+  path: Scalars['JSON']['input'];
+  string_contains?: InputMaybe<Scalars['String']['input']>;
+  string_ends_with?: InputMaybe<Scalars['String']['input']>;
+  string_starts_with?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SubSchemaOrderByItemInput = {
-  data?: InputMaybe<SubSchemaDataOrderByInput>
-  fieldPath?: InputMaybe<SortOrder>
-  rowCreatedAt?: InputMaybe<SortOrder>
-  rowId?: InputMaybe<SortOrder>
-  tableId?: InputMaybe<SortOrder>
-}
+  data?: InputMaybe<SubSchemaDataOrderByInput>;
+  fieldPath?: InputMaybe<SortOrder>;
+  rowCreatedAt?: InputMaybe<SortOrder>;
+  rowId?: InputMaybe<SortOrder>;
+  tableId?: InputMaybe<SortOrder>;
+};
 
 export type SubSchemaStringFilterInput = {
-  contains?: InputMaybe<Scalars['String']['input']>
-  endsWith?: InputMaybe<Scalars['String']['input']>
-  equals?: InputMaybe<Scalars['String']['input']>
-  gt?: InputMaybe<Scalars['String']['input']>
-  gte?: InputMaybe<Scalars['String']['input']>
-  in?: InputMaybe<Array<Scalars['String']['input']>>
-  lt?: InputMaybe<Scalars['String']['input']>
-  lte?: InputMaybe<Scalars['String']['input']>
-  mode?: InputMaybe<QueryMode>
-  not?: InputMaybe<Scalars['String']['input']>
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>
-  startsWith?: InputMaybe<Scalars['String']['input']>
-}
+  contains?: InputMaybe<Scalars['String']['input']>;
+  endsWith?: InputMaybe<Scalars['String']['input']>;
+  equals?: InputMaybe<Scalars['String']['input']>;
+  gt?: InputMaybe<Scalars['String']['input']>;
+  gte?: InputMaybe<Scalars['String']['input']>;
+  in?: InputMaybe<Array<Scalars['String']['input']>>;
+  lt?: InputMaybe<Scalars['String']['input']>;
+  lte?: InputMaybe<Scalars['String']['input']>;
+  mode?: InputMaybe<QueryMode>;
+  not?: InputMaybe<Scalars['String']['input']>;
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
+  startsWith?: InputMaybe<Scalars['String']['input']>;
+};
 
 export type SubSchemaWhereInput = {
-  AND?: InputMaybe<Array<SubSchemaWhereInput>>
-  NOT?: InputMaybe<SubSchemaWhereInput>
-  OR?: InputMaybe<Array<SubSchemaWhereInput>>
-  data?: InputMaybe<SubSchemaJsonFilterInput>
-  fieldPath?: InputMaybe<SubSchemaStringFilterInput>
-  rowId?: InputMaybe<SubSchemaStringFilterInput>
-  tableId?: InputMaybe<SubSchemaStringFilterInput>
-}
+  AND?: InputMaybe<Array<SubSchemaWhereInput>>;
+  NOT?: InputMaybe<SubSchemaWhereInput>;
+  OR?: InputMaybe<Array<SubSchemaWhereInput>>;
+  data?: InputMaybe<SubSchemaJsonFilterInput>;
+  fieldPath?: InputMaybe<SubSchemaStringFilterInput>;
+  rowId?: InputMaybe<SubSchemaStringFilterInput>;
+  tableId?: InputMaybe<SubSchemaStringFilterInput>;
+};
 
 export type SubscriptionModel = {
-  cancelAt?: Maybe<Scalars['DateTime']['output']>
-  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>
-  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>
-  interval?: Maybe<Scalars['String']['output']>
-  planId: Scalars['String']['output']
-  provider?: Maybe<Scalars['String']['output']>
-  status: BillingStatus
-}
+  cancelAt?: Maybe<Scalars['DateTime']['output']>;
+  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>;
+  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>;
+  interval?: Maybe<Scalars['String']['output']>;
+  planId: Scalars['String']['output'];
+  provider?: Maybe<Scalars['String']['output']>;
+  status: BillingStatus;
+};
 
 export type TableChangeModel = {
-  addedRowsCount: Scalars['Int']['output']
-  changeType: ChangeType
-  fromVersionId?: Maybe<Scalars['String']['output']>
-  modifiedRowsCount: Scalars['Int']['output']
-  newTableId?: Maybe<Scalars['String']['output']>
-  oldTableId?: Maybe<Scalars['String']['output']>
-  removedRowsCount: Scalars['Int']['output']
-  renamedRowsCount: Scalars['Int']['output']
-  rowChangesCount: Scalars['Int']['output']
-  schemaMigrations: Array<SchemaMigrationDetailModel>
-  tableCreatedId: Scalars['String']['output']
-  tableId: Scalars['String']['output']
-  toVersionId?: Maybe<Scalars['String']['output']>
-  viewsChanges: ViewsChangeDetailModel
-}
+  addedRowsCount: Scalars['Int']['output'];
+  changeType: ChangeType;
+  fromVersionId?: Maybe<Scalars['String']['output']>;
+  modifiedRowsCount: Scalars['Int']['output'];
+  newTableId?: Maybe<Scalars['String']['output']>;
+  oldTableId?: Maybe<Scalars['String']['output']>;
+  removedRowsCount: Scalars['Int']['output'];
+  renamedRowsCount: Scalars['Int']['output'];
+  rowChangesCount: Scalars['Int']['output'];
+  schemaMigrations: Array<SchemaMigrationDetailModel>;
+  tableCreatedId: Scalars['String']['output'];
+  tableId: Scalars['String']['output'];
+  toVersionId?: Maybe<Scalars['String']['output']>;
+  viewsChanges: ViewsChangeDetailModel;
+};
 
 export type TableChangeModelEdge = {
-  cursor: Scalars['String']['output']
-  node: TableChangeModel
-}
+  cursor: Scalars['String']['output'];
+  node: TableChangeModel;
+};
 
 export type TableChangesConnection = {
-  edges: Array<TableChangeModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<TableChangeModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type TableChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
-  search?: InputMaybe<Scalars['String']['input']>
-  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>
-}
+  changeTypes?: InputMaybe<Array<ChangeType>>;
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
+  search?: InputMaybe<Scalars['String']['input']>;
+  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>;
+};
 
 export type TableModel = {
-  count: Scalars['Int']['output']
-  countForeignKeysBy: Scalars['Int']['output']
-  countForeignKeysTo: Scalars['Int']['output']
-  createdAt: Scalars['DateTime']['output']
-  createdId: Scalars['String']['output']
-  foreignKeysBy: TablesConnection
-  foreignKeysTo: TablesConnection
-  id: Scalars['String']['output']
-  readonly: Scalars['Boolean']['output']
-  rows: RowsConnection
-  schema: Scalars['JSON']['output']
-  updatedAt: Scalars['DateTime']['output']
-  versionId: Scalars['String']['output']
-  views: TableViewsDataModel
-}
+  count: Scalars['Int']['output'];
+  countForeignKeysBy: Scalars['Int']['output'];
+  countForeignKeysTo: Scalars['Int']['output'];
+  createdAt: Scalars['DateTime']['output'];
+  createdId: Scalars['String']['output'];
+  foreignKeysBy: TablesConnection;
+  foreignKeysTo: TablesConnection;
+  id: Scalars['String']['output'];
+  readonly: Scalars['Boolean']['output'];
+  rows: RowsConnection;
+  schema: Scalars['JSON']['output'];
+  updatedAt: Scalars['DateTime']['output'];
+  versionId: Scalars['String']['output'];
+  views: TableViewsDataModel;
+};
+
 
 export type TableModelForeignKeysByArgs = {
-  data: GetTableForeignKeysInput
-}
+  data: GetTableForeignKeysInput;
+};
+
 
 export type TableModelForeignKeysToArgs = {
-  data: GetTableForeignKeysInput
-}
+  data: GetTableForeignKeysInput;
+};
+
 
 export type TableModelRowsArgs = {
-  data: GetTableRowsInput
-}
+  data: GetTableRowsInput;
+};
 
 export type TableModelEdge = {
-  cursor: Scalars['String']['output']
-  node: TableModel
-}
+  cursor: Scalars['String']['output'];
+  node: TableModel;
+};
 
 export type TableViewsDataInput = {
-  defaultViewId: Scalars['String']['input']
-  version: Scalars['Int']['input']
-  views: Array<ViewInput>
-}
+  defaultViewId: Scalars['String']['input'];
+  version: Scalars['Int']['input'];
+  views: Array<ViewInput>;
+};
 
 export type TableViewsDataModel = {
-  defaultViewId: Scalars['String']['output']
-  version: Scalars['Int']['output']
-  views: Array<ViewModel>
-}
+  defaultViewId: Scalars['String']['output'];
+  version: Scalars['Int']['output'];
+  views: Array<ViewModel>;
+};
 
 export type TablesConnection = {
-  edges: Array<TableModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<TableModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UpdatePasswordInput = {
-  newPassword: Scalars['String']['input']
-  oldPassword: Scalars['String']['input']
-}
+  newPassword: Scalars['String']['input'];
+  oldPassword: Scalars['String']['input'];
+};
 
 export type UpdateProjectInput = {
-  isPublic: Scalars['Boolean']['input']
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-}
+  isPublic: Scalars['Boolean']['input'];
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+};
 
 export type UpdateRowInput = {
-  data: Scalars['JSON']['input']
-  revisionId: Scalars['String']['input']
-  rowId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  revisionId: Scalars['String']['input'];
+  rowId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type UpdateRowResultModel = {
-  previousVersionRowId: Scalars['String']['output']
-  previousVersionTableId: Scalars['String']['output']
-  row: RowModel
-  table: TableModel
-}
+  previousVersionRowId: Scalars['String']['output'];
+  previousVersionTableId: Scalars['String']['output'];
+  row: RowModel;
+  table: TableModel;
+};
 
 export type UpdateRowsInput = {
-  revisionId: Scalars['String']['input']
-  rows: Array<UpdateRowsRowInput>
-  tableId: Scalars['String']['input']
-}
+  revisionId: Scalars['String']['input'];
+  rows: Array<UpdateRowsRowInput>;
+  tableId: Scalars['String']['input'];
+};
 
 export type UpdateRowsResultModel = {
-  previousVersionTableId: Scalars['String']['output']
-  rows: Array<RowModel>
-  table: TableModel
-}
+  previousVersionTableId: Scalars['String']['output'];
+  rows: Array<RowModel>;
+  table: TableModel;
+};
 
 export type UpdateRowsRowInput = {
-  data: Scalars['JSON']['input']
-  rowId: Scalars['String']['input']
-}
+  data: Scalars['JSON']['input'];
+  rowId: Scalars['String']['input'];
+};
 
 export type UpdateTableInput = {
-  patches: Scalars['JSON']['input']
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-}
+  patches: Scalars['JSON']['input'];
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+};
 
 export type UpdateTableResultModel = {
-  previousVersionTableId: Scalars['String']['output']
-  table: TableModel
-}
+  previousVersionTableId: Scalars['String']['output'];
+  table: TableModel;
+};
 
 export type UpdateTableViewsInput = {
-  revisionId: Scalars['String']['input']
-  tableId: Scalars['String']['input']
-  viewsData: TableViewsDataInput
-}
+  revisionId: Scalars['String']['input'];
+  tableId: Scalars['String']['input'];
+  viewsData: TableViewsDataInput;
+};
 
 export type UpdateUserProjectRoleInput = {
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  roleId: UserProjectRoles
-  userId: Scalars['String']['input']
-}
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  roleId: UserProjectRoles;
+  userId: Scalars['String']['input'];
+};
 
 export type UsageMetricModel = {
-  current: Scalars['Float']['output']
-  limit?: Maybe<Scalars['Float']['output']>
-  percentage?: Maybe<Scalars['Float']['output']>
-}
+  current: Scalars['Float']['output'];
+  limit?: Maybe<Scalars['Float']['output']>;
+  percentage?: Maybe<Scalars['Float']['output']>;
+};
 
 export type UsageSummaryModel = {
-  projects: UsageMetricModel
-  rowVersions: UsageMetricModel
-  seats: UsageMetricModel
-  storageBytes: UsageMetricModel
-}
+  projects: UsageMetricModel;
+  rowVersions: UsageMetricModel;
+  seats: UsageMetricModel;
+  storageBytes: UsageMetricModel;
+};
 
 export type UserModel = {
-  email?: Maybe<Scalars['String']['output']>
-  id: Scalars['String']['output']
-  organizationId?: Maybe<Scalars['String']['output']>
-  role: RoleModel
-  roleId: Scalars['String']['output']
-  username?: Maybe<Scalars['String']['output']>
-}
+  email?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  organizationId?: Maybe<Scalars['String']['output']>;
+  role: RoleModel;
+  roleId: Scalars['String']['output'];
+  username?: Maybe<Scalars['String']['output']>;
+};
 
 export type UserModelEdge = {
-  cursor: Scalars['String']['output']
-  node: UserModel
-}
+  cursor: Scalars['String']['output'];
+  node: UserModel;
+};
 
 export enum UserOrganizationRoles {
   Developer = 'developer',
   Editor = 'editor',
   OrganizationAdmin = 'organizationAdmin',
   OrganizationOwner = 'organizationOwner',
-  Reader = 'reader',
+  Reader = 'reader'
 }
 
 export enum UserProjectRoles {
   Developer = 'developer',
   Editor = 'editor',
-  Reader = 'reader',
+  Reader = 'reader'
 }
 
 export enum UserSystemRole {
   SystemAdmin = 'systemAdmin',
   SystemFullApiRead = 'systemFullApiRead',
-  SystemUser = 'systemUser',
+  SystemUser = 'systemUser'
 }
 
 export type UsersConnection = {
-  edges: Array<UserModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<UserModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UsersOrganizationConnection = {
-  edges: Array<UsersOrganizationModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<UsersOrganizationModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UsersOrganizationModel = {
-  id: Scalars['String']['output']
-  role: RoleModel
-  user: UserModel
-}
+  id: Scalars['String']['output'];
+  role: RoleModel;
+  user: UserModel;
+};
 
 export type UsersOrganizationModelEdge = {
-  cursor: Scalars['String']['output']
-  node: UsersOrganizationModel
-}
+  cursor: Scalars['String']['output'];
+  node: UsersOrganizationModel;
+};
 
 export type UsersProjectConnection = {
-  edges: Array<UsersProjectModelEdge>
-  pageInfo: PageInfo
-  totalCount: Scalars['Int']['output']
-}
+  edges: Array<UsersProjectModelEdge>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
 
 export type UsersProjectModel = {
-  id: Scalars['String']['output']
-  role: RoleModel
-  user: UserModel
-}
+  id: Scalars['String']['output'];
+  role: RoleModel;
+  user: UserModel;
+};
 
 export type UsersProjectModelEdge = {
-  cursor: Scalars['String']['output']
-  node: UsersProjectModel
-}
+  cursor: Scalars['String']['output'];
+  node: UsersProjectModel;
+};
 
 export type ViewChangeModel = {
-  changeType: ChangeType
-  oldViewName?: Maybe<Scalars['String']['output']>
-  viewId: Scalars['String']['output']
-  viewName: Scalars['String']['output']
-}
+  changeType: ChangeType;
+  oldViewName?: Maybe<Scalars['String']['output']>;
+  viewId: Scalars['String']['output'];
+  viewName: Scalars['String']['output'];
+};
 
 export type ViewColumnInput = {
-  field: Scalars['String']['input']
-  pinned?: InputMaybe<Scalars['String']['input']>
-  width?: InputMaybe<Scalars['Float']['input']>
-}
+  field: Scalars['String']['input'];
+  pinned?: InputMaybe<Scalars['String']['input']>;
+  width?: InputMaybe<Scalars['Float']['input']>;
+};
 
 export type ViewColumnModel = {
-  field: Scalars['String']['output']
-  pinned?: Maybe<Scalars['String']['output']>
-  width?: Maybe<Scalars['Float']['output']>
-}
+  field: Scalars['String']['output'];
+  pinned?: Maybe<Scalars['String']['output']>;
+  width?: Maybe<Scalars['Float']['output']>;
+};
 
 export type ViewInput = {
-  columns?: InputMaybe<Array<ViewColumnInput>>
-  description?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<Scalars['JSON']['input']>
-  id: Scalars['String']['input']
-  name: Scalars['String']['input']
-  search?: InputMaybe<Scalars['String']['input']>
-  sorts?: InputMaybe<Array<ViewSortInput>>
-}
+  columns?: InputMaybe<Array<ViewColumnInput>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<Scalars['JSON']['input']>;
+  id: Scalars['String']['input'];
+  name: Scalars['String']['input'];
+  search?: InputMaybe<Scalars['String']['input']>;
+  sorts?: InputMaybe<Array<ViewSortInput>>;
+};
 
 export type ViewModel = {
-  columns?: Maybe<Array<ViewColumnModel>>
-  description?: Maybe<Scalars['String']['output']>
-  filters?: Maybe<Scalars['JSON']['output']>
-  id: Scalars['String']['output']
-  name: Scalars['String']['output']
-  search?: Maybe<Scalars['String']['output']>
-  sorts?: Maybe<Array<ViewSortModel>>
-}
+  columns?: Maybe<Array<ViewColumnModel>>;
+  description?: Maybe<Scalars['String']['output']>;
+  filters?: Maybe<Scalars['JSON']['output']>;
+  id: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  search?: Maybe<Scalars['String']['output']>;
+  sorts?: Maybe<Array<ViewSortModel>>;
+};
 
 export type ViewSortInput = {
-  direction: SortOrder
-  field: Scalars['String']['input']
-}
+  direction: SortOrder;
+  field: Scalars['String']['input'];
+};
 
 export type ViewSortModel = {
-  direction: Scalars['String']['output']
-  field: Scalars['String']['output']
-}
+  direction: Scalars['String']['output'];
+  field: Scalars['String']['output'];
+};
 
 export type ViewsChangeDetailModel = {
-  addedCount: Scalars['Int']['output']
-  changes: Array<ViewChangeModel>
-  hasChanges: Scalars['Boolean']['output']
-  modifiedCount: Scalars['Int']['output']
-  removedCount: Scalars['Int']['output']
-  renamedCount: Scalars['Int']['output']
-}
+  addedCount: Scalars['Int']['output'];
+  changes: Array<ViewChangeModel>;
+  hasChanges: Scalars['Boolean']['output'];
+  modifiedCount: Scalars['Int']['output'];
+  removedCount: Scalars['Int']['output'];
+  renamedCount: Scalars['Int']['output'];
+};
 
 export type WhereInput = {
-  AND?: InputMaybe<Array<WhereInput>>
-  NOT?: InputMaybe<Array<WhereInput>>
-  OR?: InputMaybe<Array<WhereInput>>
-  createdAt?: InputMaybe<DateTimeFilter>
-  createdId?: InputMaybe<StringFilter>
-  data?: InputMaybe<JsonFilter>
-  id?: InputMaybe<StringFilter>
-  publishedAt?: InputMaybe<DateTimeFilter>
-  readonly?: InputMaybe<BooleanFilter>
-  updatedAt?: InputMaybe<DateTimeFilter>
-  versionId?: InputMaybe<StringFilter>
-}
+  AND?: InputMaybe<Array<WhereInput>>;
+  NOT?: InputMaybe<Array<WhereInput>>;
+  OR?: InputMaybe<Array<WhereInput>>;
+  createdAt?: InputMaybe<DateTimeFilter>;
+  createdId?: InputMaybe<StringFilter>;
+  data?: InputMaybe<JsonFilter>;
+  id?: InputMaybe<StringFilter>;
+  publishedAt?: InputMaybe<DateTimeFilter>;
+  readonly?: InputMaybe<BooleanFilter>;
+  updatedAt?: InputMaybe<DateTimeFilter>;
+  versionId?: InputMaybe<StringFilter>;
+};
 
-export type BranchLoaderFragmentFragment = {
-  id: string
-  createdAt: string
-  name: string
-  touched: boolean
-  projectId: string
-  head: { id: string }
-  draft: { id: string }
-}
+export type BranchLoaderFragmentFragment = { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } };
 
 export type GetBranchForLoaderQueryVariables = Exact<{
-  data: GetBranchInput
-}>
+  data: GetBranchInput;
+}>;
 
-export type GetBranchForLoaderQuery = {
-  branch: {
-    id: string
-    createdAt: string
-    name: string
-    touched: boolean
-    projectId: string
-    head: { id: string }
-    draft: { id: string }
-  }
-}
 
-export type OrganizationProjectItemFragment = {
-  id: string
-  name: string
-  organizationId: string
-  isPublic: boolean
-  rootBranch: { name: string; touched: boolean }
-}
+export type GetBranchForLoaderQuery = { branch: { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } } };
+
+export type OrganizationProjectItemFragment = { id: string, name: string, organizationId: string, isPublic: boolean, rootBranch: { name: string, touched: boolean } };
 
 export type OrganizationProjectsQueryVariables = Exact<{
-  data: GetProjectsInput
-}>
+  data: GetProjectsInput;
+}>;
 
-export type OrganizationProjectsQuery = {
-  projects: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-    edges: Array<{
-      cursor: string
-      node: {
-        id: string
-        name: string
-        organizationId: string
-        isPublic: boolean
-        rootBranch: { name: string; touched: boolean }
-      }
-    }>
-  }
-}
+
+export type OrganizationProjectsQuery = { projects: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, organizationId: string, isPublic: boolean, rootBranch: { name: string, touched: boolean } } }> } };
 
 export type GetProjectQueryVariables = Exact<{
-  data: GetProjectInput
-}>
+  data: GetProjectInput;
+}>;
 
-export type GetProjectQuery = {
-  project: {
-    id: string
-    organizationId: string
-    createdAt: string
-    name: string
-    isPublic: boolean
-    userProject?: {
-      id: string
-      role: {
-        id: string
-        name: string
-        permissions: Array<{
-          id: string
-          action: string
-          subject: string
-          condition?: { [key: string]: any } | string | number | boolean | null | null
-        }>
-      }
-    } | null
-    organization: {
-      id: string
-      userOrganization?: {
-        id: string
-        role: {
-          id: string
-          name: string
-          permissions: Array<{
-            id: string
-            action: string
-            subject: string
-            condition?: { [key: string]: any } | string | number | boolean | null | null
-          }>
-        }
-      } | null
-    }
-  }
-}
 
-export type BranchFragmentFragment = {
-  id: string
-  createdAt: string
-  name: string
-  touched: boolean
-  projectId: string
-  head: { id: string }
-  draft: { id: string }
-}
+export type GetProjectQuery = { project: { id: string, organizationId: string, createdAt: string, name: string, isPublic: boolean, userProject?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null, organization: { id: string, userOrganization?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } } };
 
-export type ProjectLoaderFragmentFragment = {
-  id: string
-  organizationId: string
-  createdAt: string
-  name: string
-  isPublic: boolean
-  rootBranch: {
-    id: string
-    createdAt: string
-    name: string
-    touched: boolean
-    projectId: string
-    head: { id: string }
-    draft: { id: string }
-  }
-  userProject?: {
-    id: string
-    role: {
-      id: string
-      name: string
-      permissions: Array<{
-        id: string
-        action: string
-        subject: string
-        condition?: { [key: string]: any } | string | number | boolean | null | null
-      }>
-    }
-  } | null
-  organization: {
-    id: string
-    userOrganization?: {
-      id: string
-      role: {
-        id: string
-        name: string
-        permissions: Array<{
-          id: string
-          action: string
-          subject: string
-          condition?: { [key: string]: any } | string | number | boolean | null | null
-        }>
-      }
-    } | null
-  }
-}
+export type BranchFragmentFragment = { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } };
+
+export type ProjectLoaderFragmentFragment = { id: string, organizationId: string, createdAt: string, name: string, isPublic: boolean, rootBranch: { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } }, userProject?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null, organization: { id: string, userOrganization?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } };
 
 export type GetProjectForLoaderQueryVariables = Exact<{
-  data: GetProjectInput
-}>
+  data: GetProjectInput;
+}>;
 
-export type GetProjectForLoaderQuery = {
-  project: {
-    id: string
-    organizationId: string
-    createdAt: string
-    name: string
-    isPublic: boolean
-    rootBranch: {
-      id: string
-      createdAt: string
-      name: string
-      touched: boolean
-      projectId: string
-      head: { id: string }
-      draft: { id: string }
-    }
-    userProject?: {
-      id: string
-      role: {
-        id: string
-        name: string
-        permissions: Array<{
-          id: string
-          action: string
-          subject: string
-          condition?: { [key: string]: any } | string | number | boolean | null | null
-        }>
-      }
-    } | null
-    organization: {
-      id: string
-      userOrganization?: {
-        id: string
-        role: {
-          id: string
-          name: string
-          permissions: Array<{
-            id: string
-            action: string
-            subject: string
-            condition?: { [key: string]: any } | string | number | boolean | null | null
-          }>
-        }
-      } | null
-    }
-  }
-}
+
+export type GetProjectForLoaderQuery = { project: { id: string, organizationId: string, createdAt: string, name: string, isPublic: boolean, rootBranch: { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } }, userProject?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null, organization: { id: string, userOrganization?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } } };
 
 export type GetRevisionForLoaderQueryVariables = Exact<{
-  data: GetRevisionInput
-}>
+  data: GetRevisionInput;
+}>;
 
-export type GetRevisionForLoaderQuery = { revision: { id: string } }
 
-export type RowLoaderFragmentFragment = {
-  createdId: string
-  id: string
-  versionId: string
-  createdAt: string
-  updatedAt: string
-  readonly: boolean
-  data: { [key: string]: any } | string | number | boolean | null
-}
+export type GetRevisionForLoaderQuery = { revision: { id: string } };
+
+export type RowLoaderFragmentFragment = { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null };
 
 export type GetRowForLoaderQueryVariables = Exact<{
-  data: GetRowInput
-}>
+  data: GetRowInput;
+}>;
 
-export type GetRowForLoaderQuery = {
-  row?: {
-    createdId: string
-    id: string
-    versionId: string
-    createdAt: string
-    updatedAt: string
-    readonly: boolean
-    data: { [key: string]: any } | string | number | boolean | null
-  } | null
-}
+
+export type GetRowForLoaderQuery = { row?: { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } | null };
 
 export type GetRowCountForeignKeysToForLoaderQueryVariables = Exact<{
-  data: GetRowInput
-}>
+  data: GetRowInput;
+}>;
 
-export type GetRowCountForeignKeysToForLoaderQuery = { row?: { id: string; countForeignKeysTo: number } | null }
+
+export type GetRowCountForeignKeysToForLoaderQuery = { row?: { id: string, countForeignKeysTo: number } | null };
 
 export type ForeignKeysByQueryVariables = Exact<{
-  tableData: GetTableInput
-  foreignKeyTablesData: GetTableForeignKeysInput
-}>
+  tableData: GetTableInput;
+  foreignKeyTablesData: GetTableForeignKeysInput;
+}>;
 
-export type ForeignKeysByQuery = {
-  table?: {
-    id: string
-    foreignKeysBy: {
-      totalCount: number
-      pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-      edges: Array<{ node: { id: string } }>
-    }
-  } | null
-}
+
+export type ForeignKeysByQuery = { table?: { id: string, foreignKeysBy: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string } }> } } | null };
 
 export type ForeignKeysByRowsQueryVariables = Exact<{
-  rowData: GetRowInput
-  foreignKeyRowsData: GetRowForeignKeysInput
-}>
+  rowData: GetRowInput;
+  foreignKeyRowsData: GetRowForeignKeysInput;
+}>;
 
-export type ForeignKeysByRowsQuery = {
-  row?: {
-    id: string
-    rowForeignKeysBy: {
-      totalCount: number
-      pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-      edges: Array<{
-        node: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
-      }>
-    }
-  } | null
-}
 
-export type TableLoaderFragmentFragment = {
-  createdId: string
-  id: string
-  versionId: string
-  createdAt: string
-  updatedAt: string
-  readonly: boolean
-  count: number
-  schema: { [key: string]: any } | string | number | boolean | null
-}
+export type ForeignKeysByRowsQuery = { row?: { id: string, rowForeignKeysBy: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } }> } } | null };
+
+export type TableLoaderFragmentFragment = { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
 
 export type GetTableForLoaderQueryVariables = Exact<{
-  data: GetTableInput
-}>
+  data: GetTableInput;
+}>;
 
-export type GetTableForLoaderQuery = {
-  table?: {
-    createdId: string
-    id: string
-    versionId: string
-    createdAt: string
-    updatedAt: string
-    readonly: boolean
-    count: number
-    schema: { [key: string]: any } | string | number | boolean | null
-  } | null
-}
+
+export type GetTableForLoaderQuery = { table?: { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } | null };
 
 export type UpdatePasswordMutationVariables = Exact<{
-  data: UpdatePasswordInput
-}>
+  data: UpdatePasswordInput;
+}>;
 
-export type UpdatePasswordMutation = { updatePassword: boolean }
+
+export type UpdatePasswordMutation = { updatePassword: boolean };
+
+export type ApiKeyFieldsFragment = { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null };
+
+export type MyApiKeysQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type MyApiKeysQuery = { myApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null }> };
+
+export type ServiceApiKeysQueryVariables = Exact<{
+  organizationId: Scalars['String']['input'];
+}>;
+
+
+export type ServiceApiKeysQuery = { serviceApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null }> };
+
+export type ApiKeyByIdQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type ApiKeyByIdQuery = { apiKeyById: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } };
+
+export type CreatePersonalApiKeyMutationVariables = Exact<{
+  data: CreatePersonalApiKeyInput;
+}>;
+
+
+export type CreatePersonalApiKeyMutation = { createPersonalApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } } };
+
+export type CreateServiceApiKeyMutationVariables = Exact<{
+  data: CreateServiceApiKeyInput;
+}>;
+
+
+export type CreateServiceApiKeyMutation = { createServiceApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } } };
+
+export type RevokeApiKeyMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type RevokeApiKeyMutation = { revokeApiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } };
+
+export type RotateApiKeyMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type RotateApiKeyMutation = { rotateApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } } };
 
 export type CreateProjectMutationVariables = Exact<{
-  data: CreateProjectInput
-}>
+  data: CreateProjectInput;
+}>;
 
-export type CreateProjectMutation = { createProject: { id: string; name: string; organizationId: string } }
+
+export type CreateProjectMutation = { createProject: { id: string, name: string, organizationId: string } };
 
 export type FindForeignKeyQueryVariables = Exact<{
-  data: GetRowsInput
-}>
+  data: GetRowsInput;
+}>;
 
-export type FindForeignKeyQuery = {
-  rows: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-    edges: Array<{ cursor: string; node: { id: string } }>
-  }
-}
+
+export type FindForeignKeyQuery = { rows: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string } }> } };
 
 export type AdminDashboardStatsQueryVariables = Exact<{
-  first: Scalars['Int']['input']
-}>
+  first: Scalars['Int']['input'];
+}>;
 
-export type AdminDashboardStatsQuery = { searchUsers: { totalCount: number } }
 
-export type AdminUserDetailFragment = {
-  id: string
-  email?: string | null
-  username?: string | null
-  role: { id: string; name: string }
-}
+export type AdminDashboardStatsQuery = { searchUsers: { totalCount: number } };
+
+export type AdminUserDetailFragment = { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } };
 
 export type AdminGetUserQueryVariables = Exact<{
-  userId: Scalars['String']['input']
-}>
+  userId: Scalars['String']['input'];
+}>;
 
-export type AdminGetUserQuery = {
-  adminUser?: { id: string; email?: string | null; username?: string | null; role: { id: string; name: string } } | null
-}
+
+export type AdminGetUserQuery = { adminUser?: { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } } | null };
 
 export type AdminResetPasswordMutationVariables = Exact<{
-  userId: Scalars['String']['input']
-  newPassword: Scalars['String']['input']
-}>
+  userId: Scalars['String']['input'];
+  newPassword: Scalars['String']['input'];
+}>;
 
-export type AdminResetPasswordMutation = { resetPassword: boolean }
 
-export type AdminUserItemFragment = {
-  id: string
-  email?: string | null
-  username?: string | null
-  role: { id: string; name: string }
-}
+export type AdminResetPasswordMutation = { resetPassword: boolean };
+
+export type AdminUserItemFragment = { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } };
 
 export type AdminUsersQueryVariables = Exact<{
-  search?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  after?: InputMaybe<Scalars['String']['input']>
-}>
+  search?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+}>;
 
-export type AdminUsersQuery = {
-  adminUsers: {
-    totalCount: number
-    edges: Array<{
-      cursor: string
-      node: { id: string; email?: string | null; username?: string | null; role: { id: string; name: string } }
-    }>
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-  }
-}
+
+export type AdminUsersQuery = { adminUsers: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } } }>, pageInfo: { hasNextPage: boolean, endCursor?: string | null } } };
 
 export type AdminUserQueryVariables = Exact<{
-  userId: Scalars['String']['input']
-}>
+  userId: Scalars['String']['input'];
+}>;
 
-export type AdminUserQuery = {
-  adminUser?: { id: string; email?: string | null; username?: string | null; role: { id: string; name: string } } | null
-}
 
-export type AssetTableItemFragment = {
-  id: string
-  versionId: string
-  count: number
-  schema: { [key: string]: any } | string | number | boolean | null
-}
+export type AdminUserQuery = { adminUser?: { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } } | null };
+
+export type AssetTableItemFragment = { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null };
 
 export type AssetsTablesDataQueryVariables = Exact<{
-  data: GetTablesInput
-}>
+  data: GetTablesInput;
+}>;
 
-export type AssetsTablesDataQuery = {
-  tables: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-    edges: Array<{
-      node: {
-        id: string
-        versionId: string
-        count: number
-        schema: { [key: string]: any } | string | number | boolean | null
-      }
-    }>
-  }
-}
 
-export type AssetRowItemFragment = {
-  id: string
-  versionId: string
-  data: { [key: string]: any } | string | number | boolean | null
-}
+export type AssetsTablesDataQuery = { tables: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null } }> } };
+
+export type AssetRowItemFragment = { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null };
 
 export type AssetsRowsDataQueryVariables = Exact<{
-  data: GetRowsInput
-}>
+  data: GetRowsInput;
+}>;
 
-export type AssetsRowsDataQuery = {
-  rows: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-    edges: Array<{
-      node: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
-    }>
-  }
-}
 
-export type SubSchemaItemFragment = {
-  fieldPath: string
-  data: { [key: string]: any } | string | number | boolean | null
-  table: { id: string; versionId: string }
-  row: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
-}
+export type AssetsRowsDataQuery = { rows: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } }> } };
+
+export type SubSchemaItemFragment = { fieldPath: string, data: { [key: string]: any } | string | number | boolean | null, table: { id: string, versionId: string }, row: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } };
 
 export type SubSchemaItemsDataQueryVariables = Exact<{
-  data: GetSubSchemaItemsInput
-}>
+  data: GetSubSchemaItemsInput;
+}>;
 
-export type SubSchemaItemsDataQuery = {
-  subSchemaItems: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-    edges: Array<{
-      node: {
-        fieldPath: string
-        data: { [key: string]: any } | string | number | boolean | null
-        table: { id: string; versionId: string }
-        row: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
-      }
-    }>
-  }
-}
 
-export type BranchItemFragment = {
-  id: string
-  name: string
-  isRoot: boolean
-  touched: boolean
-  createdAt: string
-  start: { id: string; createdAt: string }
-  parent?: {
-    revision: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; branch: { id: string; name: string } }
-  } | null
-}
+export type SubSchemaItemsDataQuery = { subSchemaItems: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { fieldPath: string, data: { [key: string]: any } | string | number | boolean | null, table: { id: string, versionId: string }, row: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } } }> } };
+
+export type BranchItemFragment = { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, start: { id: string, createdAt: string }, parent?: { revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } | null };
 
 export type GetProjectBranchesQueryVariables = Exact<{
-  data: GetBranchesInput
-}>
+  data: GetBranchesInput;
+}>;
 
-export type GetProjectBranchesQuery = {
-  branches: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-    edges: Array<{
-      cursor: string
-      node: {
-        id: string
-        name: string
-        isRoot: boolean
-        touched: boolean
-        createdAt: string
-        start: { id: string; createdAt: string }
-        parent?: {
-          revision: {
-            id: string
-            isDraft: boolean
-            isHead: boolean
-            createdAt: string
-            branch: { id: string; name: string }
-          }
-        } | null
-      }
-    }>
-  }
-}
+
+export type GetProjectBranchesQuery = { branches: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, start: { id: string, createdAt: string }, parent?: { revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } | null } }> } };
 
 export type DeleteBranchMutationVariables = Exact<{
-  data: DeleteBranchInput
-}>
+  data: DeleteBranchInput;
+}>;
 
-export type DeleteBranchMutation = { deleteBranch: boolean }
 
-export type RevisionForSelectFragment = {
-  id: string
-  isDraft: boolean
-  isHead: boolean
-  createdAt: string
-  comment: string
-}
+export type DeleteBranchMutation = { deleteBranch: boolean };
+
+export type RevisionForSelectFragment = { id: string, isDraft: boolean, isHead: boolean, createdAt: string, comment: string };
 
 export type GetBranchesForSelectQueryVariables = Exact<{
-  data: GetBranchesInput
-}>
+  data: GetBranchesInput;
+}>;
 
-export type GetBranchesForSelectQuery = {
-  branches: { edges: Array<{ node: { id: string; name: string; isRoot: boolean } }> }
-}
+
+export type GetBranchesForSelectQuery = { branches: { edges: Array<{ node: { id: string, name: string, isRoot: boolean } }> } };
 
 export type GetBranchRevisionsForCreateQueryVariables = Exact<{
-  data: GetBranchInput
-  revisionsData: GetBranchRevisionsInput
-}>
+  data: GetBranchInput;
+  revisionsData: GetBranchRevisionsInput;
+}>;
 
-export type GetBranchRevisionsForCreateQuery = {
-  branch: {
-    id: string
-    revisions: {
-      totalCount: number
-      pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-      edges: Array<{ node: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; comment: string } }>
-    }
-  }
-}
+
+export type GetBranchRevisionsForCreateQuery = { branch: { id: string, revisions: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, comment: string } }> } } };
 
 export type CreateBranchMutationVariables = Exact<{
-  data: CreateBranchInput
-}>
+  data: CreateBranchInput;
+}>;
 
-export type CreateBranchMutation = { createBranch: { id: string; name: string } }
+
+export type CreateBranchMutation = { createBranch: { id: string, name: string } };
 
 export type GetRevisionChangesQueryVariables = Exact<{
-  revisionId: Scalars['String']['input']
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
-}>
+  revisionId: Scalars['String']['input'];
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
 
-export type GetRevisionChangesQuery = {
-  revisionChanges: {
-    revisionId: string
-    parentRevisionId?: string | null
-    totalChanges: number
-    tablesSummary: { added: number; modified: number; removed: number; renamed: number; total: number }
-    rowsSummary: { added: number; modified: number; removed: number; renamed: number; total: number }
-  }
-}
+
+export type GetRevisionChangesQuery = { revisionChanges: { revisionId: string, parentRevisionId?: string | null, totalChanges: number, tablesSummary: { added: number, modified: number, removed: number, renamed: number, total: number }, rowsSummary: { added: number, modified: number, removed: number, renamed: number, total: number } } };
 
 export type GetTableChangesQueryVariables = Exact<{
-  revisionId: Scalars['String']['input']
-  first: Scalars['Int']['input']
-  after?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<TableChangesFiltersInput>
-}>
+  revisionId: Scalars['String']['input'];
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<TableChangesFiltersInput>;
+}>;
 
-export type GetTableChangesQuery = {
-  tableChanges: {
-    totalCount: number
-    edges: Array<{
-      cursor: string
-      node: {
-        tableId: string
-        changeType: ChangeType
-        oldTableId?: string | null
-        newTableId?: string | null
-        rowChangesCount: number
-        addedRowsCount: number
-        modifiedRowsCount: number
-        removedRowsCount: number
-        renamedRowsCount: number
-        schemaMigrations: Array<{
-          migrationType: MigrationType
-          migrationId: string
-          oldTableId?: string | null
-          newTableId?: string | null
-          patches?: Array<{
-            op: JsonPatchOp
-            path: string
-            value?: { [key: string]: any } | string | number | boolean | null | null
-            from?: string | null
-          }> | null
-        }>
-        viewsChanges: {
-          hasChanges: boolean
-          addedCount: number
-          modifiedCount: number
-          removedCount: number
-          renamedCount: number
-          changes: Array<{ viewId: string; viewName: string; changeType: ChangeType; oldViewName?: string | null }>
-        }
-      }
-    }>
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-  }
-}
+
+export type GetTableChangesQuery = { tableChanges: { totalCount: number, edges: Array<{ cursor: string, node: { tableId: string, changeType: ChangeType, oldTableId?: string | null, newTableId?: string | null, rowChangesCount: number, addedRowsCount: number, modifiedRowsCount: number, removedRowsCount: number, renamedRowsCount: number, schemaMigrations: Array<{ migrationType: MigrationType, migrationId: string, oldTableId?: string | null, newTableId?: string | null, patches?: Array<{ op: JsonPatchOp, path: string, value?: { [key: string]: any } | string | number | boolean | null | null, from?: string | null }> | null }>, viewsChanges: { hasChanges: boolean, addedCount: number, modifiedCount: number, removedCount: number, renamedCount: number, changes: Array<{ viewId: string, viewName: string, changeType: ChangeType, oldViewName?: string | null }> } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type ConfirmEmailCodeMutationVariables = Exact<{
-  data: ConfirmEmailCodeInput
-}>
+  data: ConfirmEmailCodeInput;
+}>;
 
-export type ConfirmEmailCodeMutation = { confirmEmailCode: { accessToken: string } }
 
-export type EndpointFragment = {
-  id: string
-  type: EndpointType
-  createdAt: string
-  revisionId: string
-  revision: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; branch: { id: string; name: string } }
-}
+export type ConfirmEmailCodeMutation = { confirmEmailCode: { accessToken: string } };
 
-export type RevisionWithEndpointsFragment = {
-  id: string
-  comment: string
-  isDraft: boolean
-  isHead: boolean
-  isStart: boolean
-  createdAt: string
-  endpoints: Array<{ id: string; type: EndpointType }>
-}
+export type EndpointFragment = { id: string, type: EndpointType, createdAt: string, revisionId: string, revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } };
 
-export type EndpointBranchFragment = {
-  id: string
-  name: string
-  isRoot: boolean
-  head: { id: string }
-  draft: { id: string }
-}
+export type RevisionWithEndpointsFragment = { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, endpoints: Array<{ id: string, type: EndpointType }> };
+
+export type EndpointBranchFragment = { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } };
 
 export type GetEndpointBranchesQueryVariables = Exact<{
-  data: GetBranchesInput
-}>
+  data: GetBranchesInput;
+}>;
 
-export type GetEndpointBranchesQuery = {
-  branches: {
-    totalCount: number
-    edges: Array<{ node: { id: string; name: string; isRoot: boolean; head: { id: string }; draft: { id: string } } }>
-  }
-}
+
+export type GetEndpointBranchesQuery = { branches: { totalCount: number, edges: Array<{ node: { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } } }> } };
 
 export type GetProjectEndpointsQueryVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  first: Scalars['Int']['input']
-  after?: InputMaybe<Scalars['String']['input']>
-  branchId?: InputMaybe<Scalars['String']['input']>
-  type?: InputMaybe<EndpointType>
-}>
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  branchId?: InputMaybe<Scalars['String']['input']>;
+  type?: InputMaybe<EndpointType>;
+}>;
 
-export type GetProjectEndpointsQuery = {
-  projectEndpoints: {
-    totalCount: number
-    edges: Array<{
-      cursor: string
-      node: {
-        id: string
-        type: EndpointType
-        createdAt: string
-        revisionId: string
-        revision: {
-          id: string
-          isDraft: boolean
-          isHead: boolean
-          createdAt: string
-          branch: { id: string; name: string }
-        }
-      }
-    }>
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-  }
-}
+
+export type GetProjectEndpointsQuery = { projectEndpoints: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, type: EndpointType, createdAt: string, revisionId: string, revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type GetBranchRevisionsQueryVariables = Exact<{
-  data: GetBranchInput
-  revisionsData: GetBranchRevisionsInput
-}>
+  data: GetBranchInput;
+  revisionsData: GetBranchRevisionsInput;
+}>;
 
-export type GetBranchRevisionsQuery = {
-  branch: {
-    revisions: {
-      totalCount: number
-      pageInfo: {
-        hasNextPage: boolean
-        hasPreviousPage: boolean
-        startCursor?: string | null
-        endCursor?: string | null
-      }
-      edges: Array<{
-        cursor: string
-        node: {
-          id: string
-          comment: string
-          isDraft: boolean
-          isHead: boolean
-          isStart: boolean
-          createdAt: string
-          endpoints: Array<{ id: string; type: EndpointType }>
-        }
-      }>
-    }
-  }
-}
+
+export type GetBranchRevisionsQuery = { branch: { revisions: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, endpoints: Array<{ id: string, type: EndpointType }> } }> } } };
 
 export type CreateEndpointMutationVariables = Exact<{
-  data: CreateEndpointInput
-}>
+  data: CreateEndpointInput;
+}>;
 
-export type CreateEndpointMutation = {
-  createEndpoint: {
-    id: string
-    type: EndpointType
-    createdAt: string
-    revisionId: string
-    revision: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; branch: { id: string; name: string } }
-  }
-}
+
+export type CreateEndpointMutation = { createEndpoint: { id: string, type: EndpointType, createdAt: string, revisionId: string, revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } };
 
 export type DeleteEndpointMutationVariables = Exact<{
-  data: DeleteEndpointInput
-}>
+  data: DeleteEndpointInput;
+}>;
 
-export type DeleteEndpointMutation = { deleteEndpoint: boolean }
+
+export type DeleteEndpointMutation = { deleteEndpoint: boolean };
 
 export type LoginGithubMutationVariables = Exact<{
-  data: LoginGithubInput
-}>
+  data: LoginGithubInput;
+}>;
 
-export type LoginGithubMutation = { loginGithub: { accessToken: string } }
+
+export type LoginGithubMutation = { loginGithub: { accessToken: string } };
 
 export type LoginGoogleMutationVariables = Exact<{
-  data: LoginGoogleInput
-}>
+  data: LoginGoogleInput;
+}>;
 
-export type LoginGoogleMutation = { loginGoogle: { accessToken: string } }
+
+export type LoginGoogleMutation = { loginGoogle: { accessToken: string } };
 
 export type LoginMutationVariables = Exact<{
-  data: LoginInput
-}>
+  data: LoginInput;
+}>;
 
-export type LoginMutation = { login: { accessToken: string } }
 
-export type MigrationBranchFragment = {
-  id: string
-  name: string
-  isRoot: boolean
-  head: { id: string }
-  draft: { id: string }
-}
+export type LoginMutation = { login: { accessToken: string } };
+
+export type MigrationBranchFragment = { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } };
 
 export type GetMigrationBranchesQueryVariables = Exact<{
-  data: GetBranchesInput
-}>
+  data: GetBranchesInput;
+}>;
 
-export type GetMigrationBranchesQuery = {
-  branches: {
-    totalCount: number
-    edges: Array<{ node: { id: string; name: string; isRoot: boolean; head: { id: string }; draft: { id: string } } }>
-  }
-}
+
+export type GetMigrationBranchesQuery = { branches: { totalCount: number, edges: Array<{ node: { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } } }> } };
 
 export type GetBranchMigrationsQueryVariables = Exact<{
-  data: GetRevisionInput
-}>
+  data: GetRevisionInput;
+}>;
 
-export type GetBranchMigrationsQuery = {
-  revision: { id: string; migrations: Array<{ [key: string]: any } | string | number | boolean | null> }
-}
+
+export type GetBranchMigrationsQuery = { revision: { id: string, migrations: Array<{ [key: string]: any } | string | number | boolean | null> } };
 
 export type ApplyMigrationsMutationVariables = Exact<{
-  data: ApplyMigrationsInput
-}>
+  data: ApplyMigrationsInput;
+}>;
 
-export type ApplyMigrationsMutation = {
-  applyMigrations: Array<{ id: string; status: ApplyMigrationStatus; error?: string | null }>
-}
+
+export type ApplyMigrationsMutation = { applyMigrations: Array<{ id: string, status: ApplyMigrationStatus, error?: string | null }> };
 
 export type GetMigrationsQueryVariables = Exact<{
-  data: GetRevisionInput
-}>
+  data: GetRevisionInput;
+}>;
 
-export type GetMigrationsQuery = {
-  revision: { id: string; migrations: Array<{ [key: string]: any } | string | number | boolean | null> }
-}
+
+export type GetMigrationsQuery = { revision: { id: string, migrations: Array<{ [key: string]: any } | string | number | boolean | null> } };
 
 export type ActivateEarlyAccessMutationVariables = Exact<{
-  data: ActivateEarlyAccessInput
-}>
+  data: ActivateEarlyAccessInput;
+}>;
 
-export type ActivateEarlyAccessMutation = {
-  activateEarlyAccess: {
-    planId: string
-    status: BillingStatus
-    provider?: string | null
-    interval?: string | null
-    currentPeriodStart?: string | null
-    currentPeriodEnd?: string | null
-    cancelAt?: string | null
-  }
-}
+
+export type ActivateEarlyAccessMutation = { activateEarlyAccess: { planId: string, status: BillingStatus, provider?: string | null, interval?: string | null, currentPeriodStart?: string | null, currentPeriodEnd?: string | null, cancelAt?: string | null } };
 
 export type CreateCheckoutMutationVariables = Exact<{
-  data: CreateCheckoutInput
-}>
+  data: CreateCheckoutInput;
+}>;
 
-export type CreateCheckoutMutation = { createCheckout: { checkoutUrl: string } }
+
+export type CreateCheckoutMutation = { createCheckout: { checkoutUrl: string } };
 
 export type CancelSubscriptionMutationVariables = Exact<{
-  data: CancelSubscriptionInput
-}>
+  data: CancelSubscriptionInput;
+}>;
 
-export type CancelSubscriptionMutation = { cancelSubscription: boolean }
 
-export type UsageMetricFragment = { current: number; limit?: number | null; percentage?: number | null }
+export type CancelSubscriptionMutation = { cancelSubscription: boolean };
 
-export type LimitsPageSubscriptionFragment = {
-  planId: string
-  status: BillingStatus
-  provider?: string | null
-  interval?: string | null
-  currentPeriodStart?: string | null
-  currentPeriodEnd?: string | null
-  cancelAt?: string | null
-}
+export type UsageMetricFragment = { current: number, limit?: number | null, percentage?: number | null };
 
-export type LimitsPagePlanFragment = {
-  id: string
-  name: string
-  isPublic: boolean
-  monthlyPriceUsd: number
-  yearlyPriceUsd: number
-  features: { [key: string]: any } | string | number | boolean | null
-  limits: { rowVersions?: number | null; projects?: number | null; seats?: number | null; storageBytes?: number | null }
-}
+export type LimitsPageSubscriptionFragment = { planId: string, status: BillingStatus, provider?: string | null, interval?: string | null, currentPeriodStart?: string | null, currentPeriodEnd?: string | null, cancelAt?: string | null };
+
+export type LimitsPagePlanFragment = { id: string, name: string, isPublic: boolean, monthlyPriceUsd: number, yearlyPriceUsd: number, features: { [key: string]: any } | string | number | boolean | null, limits: { rowVersions?: number | null, projects?: number | null, seats?: number | null, storageBytes?: number | null } };
 
 export type GetLimitsPageDataQueryVariables = Exact<{
-  data: GetOrganizationInput
-}>
+  data: GetOrganizationInput;
+}>;
 
-export type GetLimitsPageDataQuery = {
-  configuration: { billing: { enabled: boolean } }
-  organization: {
-    id: string
-    subscription?: {
-      planId: string
-      status: BillingStatus
-      provider?: string | null
-      interval?: string | null
-      currentPeriodStart?: string | null
-      currentPeriodEnd?: string | null
-      cancelAt?: string | null
-    } | null
-    usage?: {
-      rowVersions: { current: number; limit?: number | null; percentage?: number | null }
-      projects: { current: number; limit?: number | null; percentage?: number | null }
-      seats: { current: number; limit?: number | null; percentage?: number | null }
-      storageBytes: { current: number; limit?: number | null; percentage?: number | null }
-    } | null
-  }
-}
 
-export type GetLimitsPagePlansQueryVariables = Exact<{ [key: string]: never }>
+export type GetLimitsPageDataQuery = { configuration: { billing: { enabled: boolean } }, organization: { id: string, subscription?: { planId: string, status: BillingStatus, provider?: string | null, interval?: string | null, currentPeriodStart?: string | null, currentPeriodEnd?: string | null, cancelAt?: string | null } | null, usage?: { rowVersions: { current: number, limit?: number | null, percentage?: number | null }, projects: { current: number, limit?: number | null, percentage?: number | null }, seats: { current: number, limit?: number | null, percentage?: number | null }, storageBytes: { current: number, limit?: number | null, percentage?: number | null } } | null } };
 
-export type GetLimitsPagePlansQuery = {
-  plans: Array<{
-    id: string
-    name: string
-    isPublic: boolean
-    monthlyPriceUsd: number
-    yearlyPriceUsd: number
-    features: { [key: string]: any } | string | number | boolean | null
-    limits: {
-      rowVersions?: number | null
-      projects?: number | null
-      seats?: number | null
-      storageBytes?: number | null
-    }
-  }>
-}
+export type GetLimitsPagePlansQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type UserOrganizationItemFragment = {
-  id: string
-  user: { id: string; email?: string | null; username?: string | null }
-  role: { id: string; name: string }
-}
+
+export type GetLimitsPagePlansQuery = { plans: Array<{ id: string, name: string, isPublic: boolean, monthlyPriceUsd: number, yearlyPriceUsd: number, features: { [key: string]: any } | string | number | boolean | null, limits: { rowVersions?: number | null, projects?: number | null, seats?: number | null, storageBytes?: number | null } }> };
+
+export type UserOrganizationItemFragment = { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } };
 
 export type GetUsersOrganizationQueryVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  first: Scalars['Int']['input']
-  after?: InputMaybe<Scalars['String']['input']>
-}>
+  organizationId: Scalars['String']['input'];
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+}>;
 
-export type GetUsersOrganizationQuery = {
-  usersOrganization: {
-    totalCount: number
-    edges: Array<{
-      cursor: string
-      node: {
-        id: string
-        user: { id: string; email?: string | null; username?: string | null }
-        role: { id: string; name: string }
-      }
-    }>
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-  }
-}
+
+export type GetUsersOrganizationQuery = { usersOrganization: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type AddUserToOrganizationMutationVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  userId: Scalars['String']['input']
-  roleId: UserOrganizationRoles
-}>
+  organizationId: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+  roleId: UserOrganizationRoles;
+}>;
 
-export type AddUserToOrganizationMutation = { addUserToOrganization: boolean }
+
+export type AddUserToOrganizationMutation = { addUserToOrganization: boolean };
 
 export type RemoveUserFromOrganizationMutationVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}>
+  organizationId: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+}>;
 
-export type RemoveUserFromOrganizationMutation = { removeUserFromOrganization: boolean }
+
+export type RemoveUserFromOrganizationMutation = { removeUserFromOrganization: boolean };
 
 export type UpdateProjectMutationVariables = Exact<{
-  data: UpdateProjectInput
-}>
+  data: UpdateProjectInput;
+}>;
 
-export type UpdateProjectMutation = { updateProject: boolean }
+
+export type UpdateProjectMutation = { updateProject: boolean };
 
 export type DeleteProjectForSettingsMutationVariables = Exact<{
-  data: DeleteProjectInput
-}>
+  data: DeleteProjectInput;
+}>;
 
-export type DeleteProjectForSettingsMutation = { deleteProject: boolean }
+
+export type DeleteProjectForSettingsMutation = { deleteProject: boolean };
 
 export type FetchTableForStackQueryVariables = Exact<{
-  data: GetTableInput
-}>
+  data: GetTableInput;
+}>;
 
-export type FetchTableForStackQuery = {
-  table?: {
-    id: string
-    versionId: string
-    readonly: boolean
-    count: number
-    schema: { [key: string]: any } | string | number | boolean | null
-  } | null
-}
 
-export type TableStackFragmentFragment = {
-  id: string
-  versionId: string
-  readonly: boolean
-  count: number
-  schema: { [key: string]: any } | string | number | boolean | null
-}
+export type FetchTableForStackQuery = { table?: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } | null };
+
+export type TableStackFragmentFragment = { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
 
 export type CreateTableForStackMutationVariables = Exact<{
-  data: CreateTableInput
-}>
+  data: CreateTableInput;
+}>;
 
-export type CreateTableForStackMutation = {
-  createTable: {
-    table: {
-      id: string
-      versionId: string
-      readonly: boolean
-      count: number
-      schema: { [key: string]: any } | string | number | boolean | null
-    }
-  }
-}
+
+export type CreateTableForStackMutation = { createTable: { table: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } } };
 
 export type UpdateTableForStackMutationVariables = Exact<{
-  data: UpdateTableInput
-}>
+  data: UpdateTableInput;
+}>;
 
-export type UpdateTableForStackMutation = {
-  updateTable: {
-    previousVersionTableId: string
-    table: {
-      id: string
-      versionId: string
-      readonly: boolean
-      count: number
-      schema: { [key: string]: any } | string | number | boolean | null
-    }
-  }
-}
+
+export type UpdateTableForStackMutation = { updateTable: { previousVersionTableId: string, table: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } } };
 
 export type RenameTableForStackMutationVariables = Exact<{
-  data: RenameTableInput
-}>
+  data: RenameTableInput;
+}>;
 
-export type RenameTableForStackMutation = {
-  renameTable: {
-    previousVersionTableId: string
-    table: {
-      id: string
-      versionId: string
-      readonly: boolean
-      count: number
-      schema: { [key: string]: any } | string | number | boolean | null
-    }
-  }
-}
+
+export type RenameTableForStackMutation = { renameTable: { previousVersionTableId: string, table: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } } };
 
 export type RowPageDataQueryVariables = Exact<{
-  rowData: GetRowInput
-  tableData: GetTableInput
-  foreignKeysData: GetRowCountForeignKeysByInput
-}>
+  rowData: GetRowInput;
+  tableData: GetTableInput;
+  foreignKeysData: GetRowCountForeignKeysByInput;
+}>;
 
-export type RowPageDataQuery = {
-  getRowCountForeignKeysTo: number
-  row?: { id: string; data: { [key: string]: any } | string | number | boolean | null } | null
-  table?: { id: string; schema: { [key: string]: any } | string | number | boolean | null } | null
-}
+
+export type RowPageDataQuery = { getRowCountForeignKeysTo: number, row?: { id: string, data: { [key: string]: any } | string | number | boolean | null } | null, table?: { id: string, schema: { [key: string]: any } | string | number | boolean | null } | null };
 
 export type SignUpMutationVariables = Exact<{
-  data: SignUpInput
-}>
+  data: SignUpInput;
+}>;
 
-export type SignUpMutation = { signUp: boolean }
+
+export type SignUpMutation = { signUp: boolean };
 
 export type SetUsernameMutationVariables = Exact<{
-  data: SetUsernameInput
-}>
+  data: SetUsernameInput;
+}>;
 
-export type SetUsernameMutation = { setUsername: boolean }
 
-export type UserProjectItemFragment = {
-  id: string
-  user: { id: string; email?: string | null; username?: string | null }
-  role: { id: string; name: string }
-}
+export type SetUsernameMutation = { setUsername: boolean };
+
+export type UserProjectItemFragment = { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } };
 
 export type GetUsersProjectQueryVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  first: Scalars['Int']['input']
-  after?: InputMaybe<Scalars['String']['input']>
-}>
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+}>;
 
-export type GetUsersProjectQuery = {
-  usersProject: {
-    totalCount: number
-    edges: Array<{
-      cursor: string
-      node: {
-        id: string
-        user: { id: string; email?: string | null; username?: string | null }
-        role: { id: string; name: string }
-      }
-    }>
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-  }
-}
+
+export type GetUsersProjectQuery = { usersProject: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type SearchUsersQueryVariables = Exact<{
-  search?: InputMaybe<Scalars['String']['input']>
-  first: Scalars['Int']['input']
-  after?: InputMaybe<Scalars['String']['input']>
-}>
+  search?: InputMaybe<Scalars['String']['input']>;
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+}>;
 
-export type SearchUsersQuery = {
-  searchUsers: {
-    totalCount: number
-    edges: Array<{ cursor: string; node: { id: string; email?: string | null; username?: string | null } }>
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-  }
-}
+
+export type SearchUsersQuery = { searchUsers: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, email?: string | null, username?: string | null } }>, pageInfo: { hasNextPage: boolean, endCursor?: string | null } } };
 
 export type AddUserToProjectMutationVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  userId: Scalars['String']['input']
-  roleId: UserProjectRoles
-}>
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+  roleId: UserProjectRoles;
+}>;
 
-export type AddUserToProjectMutation = { addUserToProject: boolean }
+
+export type AddUserToProjectMutation = { addUserToProject: boolean };
 
 export type RemoveUserFromProjectMutationVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  userId: Scalars['String']['input']
-}>
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+}>;
 
-export type RemoveUserFromProjectMutation = { removeUserFromProject: boolean }
+
+export type RemoveUserFromProjectMutation = { removeUserFromProject: boolean };
 
 export type UpdateUserProjectRoleMutationVariables = Exact<{
-  organizationId: Scalars['String']['input']
-  projectName: Scalars['String']['input']
-  userId: Scalars['String']['input']
-  roleId: UserProjectRoles
-}>
+  organizationId: Scalars['String']['input'];
+  projectName: Scalars['String']['input'];
+  userId: Scalars['String']['input'];
+  roleId: UserProjectRoles;
+}>;
 
-export type UpdateUserProjectRoleMutation = { updateUserProjectRole: boolean }
+
+export type UpdateUserProjectRoleMutation = { updateUserProjectRole: boolean };
 
 export type CreateUserMutationVariables = Exact<{
-  username: Scalars['String']['input']
-  password: Scalars['String']['input']
-  email?: InputMaybe<Scalars['String']['input']>
-  roleId: UserSystemRole
-}>
+  username: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  email?: InputMaybe<Scalars['String']['input']>;
+  roleId: UserSystemRole;
+}>;
 
-export type CreateUserMutation = { createUser: boolean }
 
-export type PageInfoFragment = {
-  hasNextPage: boolean
-  hasPreviousPage: boolean
-  startCursor?: string | null
-  endCursor?: string | null
-}
+export type CreateUserMutation = { createUser: boolean };
 
-export type ConfigurationQueryVariables = Exact<{ [key: string]: never }>
+export type PageInfoFragment = { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null };
 
-export type ConfigurationQuery = {
-  configuration: {
-    availableEmailSignUp: boolean
-    noAuth: boolean
-    billing: { enabled: boolean }
-    google: { available: boolean; clientId?: string | null }
-    github: { available: boolean; clientId?: string | null }
-    plugins: { file: boolean }
-  }
-}
+export type ConfigurationQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type UserFragment = {
-  id: string
-  username?: string | null
-  email?: string | null
-  hasPassword: boolean
-  organizationId?: string | null
-  role?: {
-    id: string
-    name: string
-    permissions: Array<{
-      id: string
-      action: string
-      subject: string
-      condition?: { [key: string]: any } | string | number | boolean | null | null
-    }>
-  } | null
-  organization?: {
-    id: string
-    userOrganization?: {
-      role: {
-        name: string
-        permissions: Array<{
-          id: string
-          action: string
-          subject: string
-          condition?: { [key: string]: any } | string | number | boolean | null | null
-        }>
-      }
-    } | null
-  } | null
-}
 
-export type GetMeQueryVariables = Exact<{ [key: string]: never }>
+export type ConfigurationQuery = { configuration: { availableEmailSignUp: boolean, noAuth: boolean, billing: { enabled: boolean }, google: { available: boolean, clientId?: string | null }, github: { available: boolean, clientId?: string | null }, plugins: { file: boolean } } };
 
-export type GetMeQuery = {
-  me: {
-    id: string
-    username?: string | null
-    email?: string | null
-    hasPassword: boolean
-    organizationId?: string | null
-    role?: {
-      id: string
-      name: string
-      permissions: Array<{
-        id: string
-        action: string
-        subject: string
-        condition?: { [key: string]: any } | string | number | boolean | null | null
-      }>
-    } | null
-    organization?: {
-      id: string
-      userOrganization?: {
-        role: {
-          name: string
-          permissions: Array<{
-            id: string
-            action: string
-            subject: string
-            condition?: { [key: string]: any } | string | number | boolean | null | null
-          }>
-        }
-      } | null
-    } | null
-  }
-}
+export type UserFragment = { id: string, username?: string | null, email?: string | null, hasPassword: boolean, organizationId?: string | null, role?: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } | null, organization?: { id: string, userOrganization?: { role: { name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } | null };
 
-export type RevisionMapRevisionBaseFragment = {
-  id: string
-  comment: string
-  isDraft: boolean
-  isHead: boolean
-  isStart: boolean
-  createdAt: string
-  parent?: { id: string } | null
-  endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-  childBranches: Array<{ branch: { id: string; name: string } }>
-}
+export type GetMeQueryVariables = Exact<{ [key: string]: never; }>;
 
-export type RevisionMapBranchFullFragment = {
-  id: string
-  name: string
-  isRoot: boolean
-  touched: boolean
-  createdAt: string
-  head: {
-    id: string
-    comment: string
-    isDraft: boolean
-    isHead: boolean
-    isStart: boolean
-    createdAt: string
-    parent?: { id: string } | null
-    endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-    childBranches: Array<{ branch: { id: string; name: string } }>
-  }
-  draft: {
-    id: string
-    comment: string
-    isDraft: boolean
-    isHead: boolean
-    isStart: boolean
-    createdAt: string
-    parent?: { id: string } | null
-    endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-    childBranches: Array<{ branch: { id: string; name: string } }>
-  }
-  start: {
-    id: string
-    comment: string
-    isDraft: boolean
-    isHead: boolean
-    isStart: boolean
-    createdAt: string
-    parent?: { id: string } | null
-    endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-    childBranches: Array<{ branch: { id: string; name: string } }>
-  }
-  parent?: {
-    revision: {
-      id: string
-      comment: string
-      isDraft: boolean
-      isHead: boolean
-      isStart: boolean
-      createdAt: string
-      parent?: { id: string } | null
-      endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-      childBranches: Array<{ branch: { id: string; name: string } }>
-    }
-    branch: { id: string; name: string }
-  } | null
-  revisions: { totalCount: number }
-}
+
+export type GetMeQuery = { me: { id: string, username?: string | null, email?: string | null, hasPassword: boolean, organizationId?: string | null, role?: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } | null, organization?: { id: string, userOrganization?: { role: { name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } | null } };
+
+export type RevisionMapRevisionBaseFragment = { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> };
+
+export type RevisionMapBranchFullFragment = { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, head: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, draft: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, start: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, parent?: { revision: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, branch: { id: string, name: string } } | null, revisions: { totalCount: number } };
 
 export type GetProjectGraphQueryVariables = Exact<{
-  data: GetBranchesInput
-}>
+  data: GetBranchesInput;
+}>;
 
-export type GetProjectGraphQuery = {
-  branches: {
-    totalCount: number
-    edges: Array<{
-      node: {
-        id: string
-        name: string
-        isRoot: boolean
-        touched: boolean
-        createdAt: string
-        head: {
-          id: string
-          comment: string
-          isDraft: boolean
-          isHead: boolean
-          isStart: boolean
-          createdAt: string
-          parent?: { id: string } | null
-          endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-          childBranches: Array<{ branch: { id: string; name: string } }>
-        }
-        draft: {
-          id: string
-          comment: string
-          isDraft: boolean
-          isHead: boolean
-          isStart: boolean
-          createdAt: string
-          parent?: { id: string } | null
-          endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-          childBranches: Array<{ branch: { id: string; name: string } }>
-        }
-        start: {
-          id: string
-          comment: string
-          isDraft: boolean
-          isHead: boolean
-          isStart: boolean
-          createdAt: string
-          parent?: { id: string } | null
-          endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-          childBranches: Array<{ branch: { id: string; name: string } }>
-        }
-        parent?: {
-          revision: {
-            id: string
-            comment: string
-            isDraft: boolean
-            isHead: boolean
-            isStart: boolean
-            createdAt: string
-            parent?: { id: string } | null
-            endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
-            childBranches: Array<{ branch: { id: string; name: string } }>
-          }
-          branch: { id: string; name: string }
-        } | null
-        revisions: { totalCount: number }
-      }
-    }>
-  }
-}
 
-export type FindBranchFragment = {
-  id: string
-  name: string
-  isRoot: boolean
-  touched: boolean
-  parent?: { revision: { branch: { id: string } } } | null
-}
+export type GetProjectGraphQuery = { branches: { totalCount: number, edges: Array<{ node: { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, head: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, draft: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, start: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, parent?: { revision: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, branch: { id: string, name: string } } | null, revisions: { totalCount: number } } }> } };
+
+export type FindBranchFragment = { id: string, name: string, isRoot: boolean, touched: boolean, parent?: { revision: { branch: { id: string } } } | null };
 
 export type FindBranchesQueryVariables = Exact<{
-  data: GetBranchesInput
-}>
+  data: GetBranchesInput;
+}>;
 
-export type FindBranchesQuery = {
-  branches: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-    edges: Array<{
-      cursor: string
-      node: {
-        id: string
-        name: string
-        isRoot: boolean
-        touched: boolean
-        parent?: { revision: { branch: { id: string } } } | null
-      }
-    }>
-  }
-}
 
-export type FindRevisionFragment = {
-  id: string
-  comment: string
-  isDraft: boolean
-  isHead: boolean
-  isStart: boolean
-  createdAt: string
-}
+export type FindBranchesQuery = { branches: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, isRoot: boolean, touched: boolean, parent?: { revision: { branch: { id: string } } } | null } }> } };
+
+export type FindRevisionFragment = { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string };
 
 export type FindRevisionsQueryVariables = Exact<{
-  data: GetBranchInput
-  revisionsData: GetBranchRevisionsInput
-}>
+  data: GetBranchInput;
+  revisionsData: GetBranchRevisionsInput;
+}>;
 
-export type FindRevisionsQuery = {
-  branch: {
-    revisions: {
-      totalCount: number
-      pageInfo: {
-        hasNextPage: boolean
-        hasPreviousPage: boolean
-        startCursor?: string | null
-        endCursor?: string | null
-      }
-      edges: Array<{
-        cursor: string
-        node: { id: string; comment: string; isDraft: boolean; isHead: boolean; isStart: boolean; createdAt: string }
-      }>
-    }
-  }
-}
 
-export type MeProjectListItemFragment = {
-  id: string
-  name: string
-  organizationId: string
-  rootBranch: { name: string; touched: boolean }
-}
+export type FindRevisionsQuery = { branch: { revisions: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string } }> } } };
+
+export type MeProjectListItemFragment = { id: string, name: string, organizationId: string, rootBranch: { name: string, touched: boolean } };
 
 export type MeProjectsListQueryVariables = Exact<{
-  data: GetMeProjectsInput
-}>
+  data: GetMeProjectsInput;
+}>;
 
-export type MeProjectsListQuery = {
-  meProjects: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-    edges: Array<{
-      cursor: string
-      node: { id: string; name: string; organizationId: string; rootBranch: { name: string; touched: boolean } }
-    }>
-  }
-}
 
-export type RowChangeRowFieldsFragment = { id: string }
+export type MeProjectsListQuery = { meProjects: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, organizationId: string, rootBranch: { name: string, touched: boolean } } }> } };
 
-export type RowChangeTableFieldsFragment = { id: string }
+export type RowChangeRowFieldsFragment = { id: string };
 
-export type FieldChangeFieldsFragment = {
-  fieldPath: string
-  changeType: RowChangeDetailType
-  oldValue?: { [key: string]: any } | string | number | boolean | null | null
-  newValue?: { [key: string]: any } | string | number | boolean | null | null
-  movedFrom?: string | null
-}
+export type RowChangeTableFieldsFragment = { id: string };
+
+export type FieldChangeFieldsFragment = { fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null };
 
 export type GetRowChangesQueryVariables = Exact<{
-  revisionId: Scalars['String']['input']
-  first: Scalars['Int']['input']
-  after?: InputMaybe<Scalars['String']['input']>
-  filters?: InputMaybe<RowChangesFiltersInput>
-}>
+  revisionId: Scalars['String']['input'];
+  first: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
+  filters?: InputMaybe<RowChangesFiltersInput>;
+}>;
 
-export type GetRowChangesQuery = {
-  rowChanges: {
-    totalCount: number
-    edges: Array<{
-      cursor: string
-      node:
-        | {
-            changeType: ChangeType
-            row: { id: string }
-            table: { id: string }
-            fieldChanges: Array<{
-              fieldPath: string
-              changeType: RowChangeDetailType
-              oldValue?: { [key: string]: any } | string | number | boolean | null | null
-              newValue?: { [key: string]: any } | string | number | boolean | null | null
-              movedFrom?: string | null
-            }>
-          }
-        | {
-            changeType: ChangeType
-            row: { id: string }
-            fromRow: { id: string }
-            table: { id: string }
-            fromTable: { id: string }
-            fieldChanges: Array<{
-              fieldPath: string
-              changeType: RowChangeDetailType
-              oldValue?: { [key: string]: any } | string | number | boolean | null | null
-              newValue?: { [key: string]: any } | string | number | boolean | null | null
-              movedFrom?: string | null
-            }>
-          }
-        | {
-            changeType: ChangeType
-            fromRow: { id: string }
-            fromTable: { id: string }
-            fieldChanges: Array<{
-              fieldPath: string
-              changeType: RowChangeDetailType
-              oldValue?: { [key: string]: any } | string | number | boolean | null | null
-              newValue?: { [key: string]: any } | string | number | boolean | null | null
-              movedFrom?: string | null
-            }>
-          }
-    }>
-    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
-  }
-}
+
+export type GetRowChangesQuery = { rowChanges: { totalCount: number, edges: Array<{ cursor: string, node: { changeType: ChangeType, row: { id: string }, table: { id: string }, fieldChanges: Array<{ fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null }> } | { changeType: ChangeType, row: { id: string }, fromRow: { id: string }, table: { id: string }, fromTable: { id: string }, fieldChanges: Array<{ fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null }> } | { changeType: ChangeType, fromRow: { id: string }, fromTable: { id: string }, fieldChanges: Array<{ fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null }> } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
 
 export type GetTableChangesForFilterQueryVariables = Exact<{
-  revisionId: Scalars['String']['input']
-}>
+  revisionId: Scalars['String']['input'];
+}>;
 
-export type GetTableChangesForFilterQuery = {
-  tableChanges: {
-    edges: Array<{
-      node: {
-        tableId: string
-        changeType: ChangeType
-        oldTableId?: string | null
-        newTableId?: string | null
-        rowChangesCount: number
-      }
-    }>
-  }
-}
 
-export type ForeignKeyTableItemFragment = {
-  id: string
-  versionId: string
-  createdId: string
-  createdAt: string
-  updatedAt: string
-  readonly: boolean
-  count: number
-  schema: { [key: string]: any } | string | number | boolean | null
-}
+export type GetTableChangesForFilterQuery = { tableChanges: { edges: Array<{ node: { tableId: string, changeType: ChangeType, oldTableId?: string | null, newTableId?: string | null, rowChangesCount: number } }> } };
 
-export type ForeignKeyRowItemFragment = {
-  id: string
-  versionId: string
-  createdId: string
-  createdAt: string
-  updatedAt: string
-  readonly: boolean
-  data: { [key: string]: any } | string | number | boolean | null
-}
+export type ForeignKeyTableItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
+
+export type ForeignKeyRowItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null };
 
 export type ForeignKeyTableWithRowsQueryVariables = Exact<{
-  tableData: GetTableInput
-  rowsData: GetRowsInput
-}>
+  tableData: GetTableInput;
+  rowsData: GetRowsInput;
+}>;
 
-export type ForeignKeyTableWithRowsQuery = {
-  table?: {
-    id: string
-    versionId: string
-    createdId: string
-    createdAt: string
-    updatedAt: string
-    readonly: boolean
-    count: number
-    schema: { [key: string]: any } | string | number | boolean | null
-  } | null
-  rows: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-    edges: Array<{
-      node: {
-        id: string
-        versionId: string
-        createdId: string
-        createdAt: string
-        updatedAt: string
-        readonly: boolean
-        data: { [key: string]: any } | string | number | boolean | null
-      }
-    }>
-  }
-}
 
-export type RowMutationItemFragment = {
-  id: string
-  versionId: string
-  createdId: string
-  createdAt: string
-  updatedAt: string
-  readonly: boolean
-  data: { [key: string]: any } | string | number | boolean | null
-}
+export type ForeignKeyTableWithRowsQuery = { table?: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } | null, rows: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } }> } };
 
-export type TableMutationItemFragment = {
-  id: string
-  versionId: string
-  createdId: string
-  createdAt: string
-  updatedAt: string
-  readonly: boolean
-  count: number
-  schema: { [key: string]: any } | string | number | boolean | null
-}
+export type RowMutationItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null };
+
+export type TableMutationItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
 
 export type CreateRowForStackMutationVariables = Exact<{
-  data: CreateRowInput
-}>
+  data: CreateRowInput;
+}>;
 
-export type CreateRowForStackMutation = {
-  createRow: {
-    previousVersionTableId: string
-    table: {
-      id: string
-      versionId: string
-      createdId: string
-      createdAt: string
-      updatedAt: string
-      readonly: boolean
-      count: number
-      schema: { [key: string]: any } | string | number | boolean | null
-    }
-    row: {
-      id: string
-      versionId: string
-      createdId: string
-      createdAt: string
-      updatedAt: string
-      readonly: boolean
-      data: { [key: string]: any } | string | number | boolean | null
-    }
-  }
-}
+
+export type CreateRowForStackMutation = { createRow: { previousVersionTableId: string, table: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null }, row: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } } };
 
 export type UpdateRowForStackMutationVariables = Exact<{
-  data: UpdateRowInput
-}>
+  data: UpdateRowInput;
+}>;
 
-export type UpdateRowForStackMutation = {
-  updateRow: {
-    previousVersionTableId: string
-    previousVersionRowId: string
-    table: {
-      id: string
-      versionId: string
-      createdId: string
-      createdAt: string
-      updatedAt: string
-      readonly: boolean
-      count: number
-      schema: { [key: string]: any } | string | number | boolean | null
-    }
-    row: {
-      id: string
-      versionId: string
-      createdId: string
-      createdAt: string
-      updatedAt: string
-      readonly: boolean
-      data: { [key: string]: any } | string | number | boolean | null
-    }
-  }
-}
+
+export type UpdateRowForStackMutation = { updateRow: { previousVersionTableId: string, previousVersionRowId: string, table: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null }, row: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } } };
 
 export type RenameRowForStackMutationVariables = Exact<{
-  data: RenameRowInput
-}>
+  data: RenameRowInput;
+}>;
 
-export type RenameRowForStackMutation = {
-  renameRow: {
-    previousVersionTableId: string
-    previousVersionRowId: string
-    table: {
-      id: string
-      versionId: string
-      createdId: string
-      createdAt: string
-      updatedAt: string
-      readonly: boolean
-      count: number
-      schema: { [key: string]: any } | string | number | boolean | null
-    }
-    row: {
-      id: string
-      versionId: string
-      createdId: string
-      createdAt: string
-      updatedAt: string
-      readonly: boolean
-      data: { [key: string]: any } | string | number | boolean | null
-    }
-  }
-}
 
-export type RowListItemFragment = {
-  id: string
-  versionId: string
-  readonly: boolean
-  data: { [key: string]: any } | string | number | boolean | null
-  createdAt: string
-  updatedAt: string
-  publishedAt: string
-  createdId: string
-}
+export type RenameRowForStackMutation = { renameRow: { previousVersionTableId: string, previousVersionRowId: string, table: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null }, row: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } } };
+
+export type RowListItemFragment = { id: string, versionId: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null, createdAt: string, updatedAt: string, publishedAt: string, createdId: string };
 
 export type RowListRowsQueryVariables = Exact<{
-  data: GetRowsInput
-}>
+  data: GetRowsInput;
+}>;
 
-export type RowListRowsQuery = {
-  rows: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-    edges: Array<{
-      node: {
-        id: string
-        versionId: string
-        readonly: boolean
-        data: { [key: string]: any } | string | number | boolean | null
-        createdAt: string
-        updatedAt: string
-        publishedAt: string
-        createdId: string
-      }
-    }>
-  }
-}
+
+export type RowListRowsQuery = { rows: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null, createdAt: string, updatedAt: string, publishedAt: string, createdId: string } }> } };
 
 export type DeleteRowMutationVariables = Exact<{
-  data: DeleteRowInput
-}>
+  data: DeleteRowInput;
+}>;
 
-export type DeleteRowMutation = { deleteRow: { branch: { id: string } } }
+
+export type DeleteRowMutation = { deleteRow: { branch: { id: string } } };
 
 export type DeleteRowsMutationVariables = Exact<{
-  data: DeleteRowsInput
-}>
+  data: DeleteRowsInput;
+}>;
 
-export type DeleteRowsMutation = { deleteRows: { branch: { id: string } } }
+
+export type DeleteRowsMutation = { deleteRows: { branch: { id: string } } };
 
 export type PatchRowInlineMutationVariables = Exact<{
-  data: PatchRowInput
-}>
+  data: PatchRowInput;
+}>;
 
-export type PatchRowInlineMutation = {
-  patchRow: {
-    row: {
-      id: string
-      versionId: string
-      readonly: boolean
-      data: { [key: string]: any } | string | number | boolean | null
-      createdAt: string
-      updatedAt: string
-      publishedAt: string
-      createdId: string
-    }
-  }
-}
 
-export type TableViewsDataFragment = {
-  version: number
-  defaultViewId: string
-  views: Array<{
-    id: string
-    name: string
-    description?: string | null
-    filters?: { [key: string]: any } | string | number | boolean | null | null
-    search?: string | null
-    columns?: Array<{ field: string; width?: number | null; pinned?: string | null }> | null
-    sorts?: Array<{ field: string; direction: string }> | null
-  }>
-}
+export type PatchRowInlineMutation = { patchRow: { row: { id: string, versionId: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null, createdAt: string, updatedAt: string, publishedAt: string, createdId: string } } };
+
+export type TableViewsDataFragment = { version: number, defaultViewId: string, views: Array<{ id: string, name: string, description?: string | null, filters?: { [key: string]: any } | string | number | boolean | null | null, search?: string | null, columns?: Array<{ field: string, width?: number | null, pinned?: string | null }> | null, sorts?: Array<{ field: string, direction: string }> | null }> };
 
 export type GetTableViewsQueryVariables = Exact<{
-  data: GetTableInput
-}>
+  data: GetTableInput;
+}>;
 
-export type GetTableViewsQuery = {
-  table?: {
-    id: string
-    views: {
-      version: number
-      defaultViewId: string
-      views: Array<{
-        id: string
-        name: string
-        description?: string | null
-        filters?: { [key: string]: any } | string | number | boolean | null | null
-        search?: string | null
-        columns?: Array<{ field: string; width?: number | null; pinned?: string | null }> | null
-        sorts?: Array<{ field: string; direction: string }> | null
-      }>
-    }
-  } | null
-}
+
+export type GetTableViewsQuery = { table?: { id: string, views: { version: number, defaultViewId: string, views: Array<{ id: string, name: string, description?: string | null, filters?: { [key: string]: any } | string | number | boolean | null | null, search?: string | null, columns?: Array<{ field: string, width?: number | null, pinned?: string | null }> | null, sorts?: Array<{ field: string, direction: string }> | null }> } } | null };
 
 export type UpdateTableViewsMutationVariables = Exact<{
-  data: UpdateTableViewsInput
-}>
+  data: UpdateTableViewsInput;
+}>;
 
-export type UpdateTableViewsMutation = {
-  updateTableViews: {
-    version: number
-    defaultViewId: string
-    views: Array<{
-      id: string
-      name: string
-      description?: string | null
-      filters?: { [key: string]: any } | string | number | boolean | null | null
-      search?: string | null
-      columns?: Array<{ field: string; width?: number | null; pinned?: string | null }> | null
-      sorts?: Array<{ field: string; direction: string }> | null
-    }>
-  }
-}
 
-export type SearchResultFragment = {
-  row: { id: string }
-  table: { id: string }
-  matches: Array<{
-    value: { [key: string]: any } | string | number | boolean | null
-    path: string
-    highlight?: string | null
-  }>
-}
+export type UpdateTableViewsMutation = { updateTableViews: { version: number, defaultViewId: string, views: Array<{ id: string, name: string, description?: string | null, filters?: { [key: string]: any } | string | number | boolean | null | null, search?: string | null, columns?: Array<{ field: string, width?: number | null, pinned?: string | null }> | null, sorts?: Array<{ field: string, direction: string }> | null }> } };
+
+export type SearchResultFragment = { row: { id: string }, table: { id: string }, matches: Array<{ value: { [key: string]: any } | string | number | boolean | null, path: string, highlight?: string | null }> };
 
 export type SearchRowsQueryVariables = Exact<{
-  data: SearchRowsInput
-}>
+  data: SearchRowsInput;
+}>;
 
-export type SearchRowsQuery = {
-  searchRows: {
-    totalCount: number
-    edges: Array<{
-      cursor: string
-      node: {
-        row: { id: string }
-        table: { id: string }
-        matches: Array<{
-          value: { [key: string]: any } | string | number | boolean | null
-          path: string
-          highlight?: string | null
-        }>
-      }
-    }>
-  }
-}
+
+export type SearchRowsQuery = { searchRows: { totalCount: number, edges: Array<{ cursor: string, node: { row: { id: string }, table: { id: string }, matches: Array<{ value: { [key: string]: any } | string | number | boolean | null, path: string, highlight?: string | null }> } }> } };
 
 export type RevertChangesForSidebarMutationVariables = Exact<{
-  data: RevertChangesInput
-}>
+  data: RevertChangesInput;
+}>;
 
-export type RevertChangesForSidebarMutation = { revertChanges: { id: string } }
+
+export type RevertChangesForSidebarMutation = { revertChanges: { id: string } };
 
 export type CreateRevisionForSidebarMutationVariables = Exact<{
-  data: CreateRevisionInput
-}>
+  data: CreateRevisionInput;
+}>;
 
-export type CreateRevisionForSidebarMutation = { createRevision: { id: string } }
+
+export type CreateRevisionForSidebarMutation = { createRevision: { id: string } };
 
 export type CreateBranchForSidebarMutationVariables = Exact<{
-  data: CreateBranchInput
-}>
+  data: CreateBranchInput;
+}>;
 
-export type CreateBranchForSidebarMutation = { createBranch: { id: string } }
+
+export type CreateBranchForSidebarMutation = { createBranch: { id: string } };
 
 export type DeleteTableForListMutationVariables = Exact<{
-  data: DeleteTableInput
-}>
+  data: DeleteTableInput;
+}>;
 
-export type DeleteTableForListMutation = { deleteTable: { branch: { id: string } } }
 
-export type TableListItemFragment = { id: string; versionId: string; readonly: boolean; count: number }
+export type DeleteTableForListMutation = { deleteTable: { branch: { id: string } } };
+
+export type TableListItemFragment = { id: string, versionId: string, readonly: boolean, count: number };
 
 export type TableListDataQueryVariables = Exact<{
-  data: GetTablesInput
-}>
+  data: GetTablesInput;
+}>;
 
-export type TableListDataQuery = {
-  tables: {
-    totalCount: number
-    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
-    edges: Array<{ node: { id: string; versionId: string; readonly: boolean; count: number } }>
-  }
-}
 
-export type TableRelationsItemFragment = {
-  id: string
-  versionId: string
-  count: number
-  schema: { [key: string]: any } | string | number | boolean | null
-}
+export type TableListDataQuery = { tables: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, readonly: boolean, count: number } }> } };
+
+export type TableRelationsItemFragment = { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null };
 
 export type TableRelationsDataQueryVariables = Exact<{
-  data: GetTablesInput
-}>
+  data: GetTablesInput;
+}>;
 
-export type TableRelationsDataQuery = {
-  tables: {
-    totalCount: number
-    edges: Array<{
-      node: {
-        id: string
-        versionId: string
-        count: number
-        schema: { [key: string]: any } | string | number | boolean | null
-      }
-    }>
-  }
-}
+
+export type TableRelationsDataQuery = { tables: { totalCount: number, edges: Array<{ node: { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null } }> } };
 
 export const BranchLoaderFragmentFragmentDoc = gql`
-  fragment BranchLoaderFragment on BranchModel {
+    fragment BranchLoaderFragment on BranchModel {
+  id
+  createdAt
+  name
+  touched
+  projectId
+  head {
     id
-    createdAt
-    name
-    touched
-    projectId
-    head {
-      id
-    }
-    draft {
-      id
-    }
   }
-`
+  draft {
+    id
+  }
+}
+    `;
 export const OrganizationProjectItemFragmentDoc = gql`
-  fragment OrganizationProjectItem on ProjectModel {
-    id
-    name
-    organizationId
-    isPublic
-    rootBranch {
-      name
-      touched
-    }
-  }
-`
-export const BranchFragmentFragmentDoc = gql`
-  fragment BranchFragment on BranchModel {
-    id
-    createdAt
+    fragment OrganizationProjectItem on ProjectModel {
+  id
+  name
+  organizationId
+  isPublic
+  rootBranch {
     name
     touched
-    projectId
-    head {
+  }
+}
+    `;
+export const BranchFragmentFragmentDoc = gql`
+    fragment BranchFragment on BranchModel {
+  id
+  createdAt
+  name
+  touched
+  projectId
+  head {
+    id
+  }
+  draft {
+    id
+  }
+}
+    `;
+export const ProjectLoaderFragmentFragmentDoc = gql`
+    fragment ProjectLoaderFragment on ProjectModel {
+  id
+  organizationId
+  createdAt
+  name
+  isPublic
+  rootBranch {
+    ...BranchFragment
+  }
+  userProject {
+    id
+    role {
       id
-    }
-    draft {
-      id
+      name
+      permissions {
+        id
+        action
+        subject
+        condition
+      }
     }
   }
-`
-export const ProjectLoaderFragmentFragmentDoc = gql`
-  fragment ProjectLoaderFragment on ProjectModel {
+  organization {
+    id
+    userOrganization {
+      id
+      role {
+        id
+        name
+        permissions {
+          id
+          action
+          subject
+          condition
+        }
+      }
+    }
+  }
+}
+    ${BranchFragmentFragmentDoc}`;
+export const RowLoaderFragmentFragmentDoc = gql`
+    fragment RowLoaderFragment on RowModel {
+  createdId
+  id
+  versionId
+  createdAt
+  updatedAt
+  readonly
+  data
+}
+    `;
+export const TableLoaderFragmentFragmentDoc = gql`
+    fragment TableLoaderFragment on TableModel {
+  createdId
+  id
+  versionId
+  createdAt
+  updatedAt
+  readonly
+  count
+  schema
+}
+    `;
+export const ApiKeyFieldsFragmentDoc = gql`
+    fragment ApiKeyFields on ApiKeyModel {
+  id
+  prefix
+  type
+  name
+  organizationId
+  projectIds
+  branchNames
+  tableIds
+  readOnly
+  permissions
+  allowedIps
+  expiresAt
+  lastUsedAt
+  createdAt
+  revokedAt
+}
+    `;
+export const AdminUserDetailFragmentDoc = gql`
+    fragment AdminUserDetail on UserModel {
+  id
+  email
+  username
+  role {
+    id
+    name
+  }
+}
+    `;
+export const AdminUserItemFragmentDoc = gql`
+    fragment AdminUserItem on UserModel {
+  id
+  email
+  username
+  role {
+    id
+    name
+  }
+}
+    `;
+export const AssetTableItemFragmentDoc = gql`
+    fragment AssetTableItem on TableModel {
+  id
+  versionId
+  count
+  schema
+}
+    `;
+export const AssetRowItemFragmentDoc = gql`
+    fragment AssetRowItem on RowModel {
+  id
+  versionId
+  data
+}
+    `;
+export const SubSchemaItemFragmentDoc = gql`
+    fragment SubSchemaItem on SubSchemaItemModel {
+  table {
+    id
+    versionId
+  }
+  row {
+    id
+    versionId
+    data
+  }
+  fieldPath
+  data
+}
+    `;
+export const BranchItemFragmentDoc = gql`
+    fragment BranchItem on BranchModel {
+  id
+  name
+  isRoot
+  touched
+  createdAt
+  start {
+    id
+    createdAt
+  }
+  parent {
+    revision {
+      id
+      isDraft
+      isHead
+      createdAt
+      branch {
+        id
+        name
+      }
+    }
+  }
+}
+    `;
+export const RevisionForSelectFragmentDoc = gql`
+    fragment RevisionForSelect on RevisionModel {
+  id
+  isDraft
+  isHead
+  createdAt
+  comment
+}
+    `;
+export const EndpointFragmentDoc = gql`
+    fragment Endpoint on EndpointModel {
+  id
+  type
+  createdAt
+  revisionId
+  revision {
+    id
+    isDraft
+    isHead
+    createdAt
+    branch {
+      id
+      name
+    }
+  }
+}
+    `;
+export const RevisionWithEndpointsFragmentDoc = gql`
+    fragment RevisionWithEndpoints on RevisionModel {
+  id
+  comment
+  isDraft
+  isHead
+  isStart
+  createdAt
+  endpoints {
+    id
+    type
+  }
+}
+    `;
+export const EndpointBranchFragmentDoc = gql`
+    fragment EndpointBranch on BranchModel {
+  id
+  name
+  isRoot
+  head {
+    id
+  }
+  draft {
+    id
+  }
+}
+    `;
+export const MigrationBranchFragmentDoc = gql`
+    fragment MigrationBranch on BranchModel {
+  id
+  name
+  isRoot
+  head {
+    id
+  }
+  draft {
+    id
+  }
+}
+    `;
+export const UsageMetricFragmentDoc = gql`
+    fragment UsageMetric on UsageMetricModel {
+  current
+  limit
+  percentage
+}
+    `;
+export const LimitsPageSubscriptionFragmentDoc = gql`
+    fragment LimitsPageSubscription on SubscriptionModel {
+  planId
+  status
+  provider
+  interval
+  currentPeriodStart
+  currentPeriodEnd
+  cancelAt
+}
+    `;
+export const LimitsPagePlanFragmentDoc = gql`
+    fragment LimitsPagePlan on PlanModel {
+  id
+  name
+  isPublic
+  monthlyPriceUsd
+  yearlyPriceUsd
+  limits {
+    rowVersions
+    projects
+    seats
+    storageBytes
+  }
+  features
+}
+    `;
+export const UserOrganizationItemFragmentDoc = gql`
+    fragment UserOrganizationItem on UsersOrganizationModel {
+  id
+  user {
+    id
+    email
+    username
+  }
+  role {
+    id
+    name
+  }
+}
+    `;
+export const TableStackFragmentFragmentDoc = gql`
+    fragment TableStackFragment on TableModel {
+  id
+  versionId
+  readonly
+  count
+  schema
+}
+    `;
+export const UserProjectItemFragmentDoc = gql`
+    fragment UserProjectItem on UsersProjectModel {
+  id
+  user {
+    id
+    email
+    username
+  }
+  role {
+    id
+    name
+  }
+}
+    `;
+export const PageInfoFragmentDoc = gql`
+    fragment PageInfo on PageInfo {
+  hasNextPage
+  hasPreviousPage
+  startCursor
+  endCursor
+}
+    `;
+export const UserFragmentDoc = gql`
+    fragment User on MeModel {
+  id
+  username
+  email
+  hasPassword
+  organizationId
+  role {
+    id
+    name
+    permissions {
+      id
+      action
+      subject
+      condition
+    }
+  }
+  organization {
+    id
+    userOrganization {
+      role {
+        name
+        permissions {
+          id
+          action
+          subject
+          condition
+        }
+      }
+    }
+  }
+}
+    `;
+export const RevisionMapRevisionBaseFragmentDoc = gql`
+    fragment RevisionMapRevisionBase on RevisionModel {
+  id
+  comment
+  isDraft
+  isHead
+  isStart
+  createdAt
+  parent {
+    id
+  }
+  endpoints {
+    id
+    type
+    createdAt
+  }
+  childBranches {
+    branch {
+      id
+      name
+    }
+  }
+}
+    `;
+export const RevisionMapBranchFullFragmentDoc = gql`
+    fragment RevisionMapBranchFull on BranchModel {
+  id
+  name
+  isRoot
+  touched
+  createdAt
+  head {
+    ...RevisionMapRevisionBase
+  }
+  draft {
+    ...RevisionMapRevisionBase
+  }
+  start {
+    ...RevisionMapRevisionBase
+  }
+  parent {
+    revision {
+      ...RevisionMapRevisionBase
+    }
+    branch {
+      id
+      name
+    }
+  }
+  revisions(data: {first: 1000}) {
+    totalCount
+  }
+}
+    ${RevisionMapRevisionBaseFragmentDoc}`;
+export const FindBranchFragmentDoc = gql`
+    fragment FindBranch on BranchModel {
+  id
+  name
+  isRoot
+  touched
+  parent {
+    revision {
+      branch {
+        id
+      }
+    }
+  }
+}
+    `;
+export const FindRevisionFragmentDoc = gql`
+    fragment FindRevision on RevisionModel {
+  id
+  comment
+  isDraft
+  isHead
+  isStart
+  createdAt
+}
+    `;
+export const MeProjectListItemFragmentDoc = gql`
+    fragment MeProjectListItem on ProjectModel {
+  id
+  name
+  organizationId
+  rootBranch {
+    name
+    touched
+  }
+}
+    `;
+export const RowChangeRowFieldsFragmentDoc = gql`
+    fragment RowChangeRowFields on RowChangeRowModel {
+  id
+}
+    `;
+export const RowChangeTableFieldsFragmentDoc = gql`
+    fragment RowChangeTableFields on RowChangeTableModel {
+  id
+}
+    `;
+export const FieldChangeFieldsFragmentDoc = gql`
+    fragment FieldChangeFields on FieldChangeModel {
+  fieldPath
+  changeType
+  oldValue
+  newValue
+  movedFrom
+}
+    `;
+export const ForeignKeyTableItemFragmentDoc = gql`
+    fragment ForeignKeyTableItem on TableModel {
+  id
+  versionId
+  createdId
+  createdAt
+  updatedAt
+  readonly
+  count
+  schema
+}
+    `;
+export const ForeignKeyRowItemFragmentDoc = gql`
+    fragment ForeignKeyRowItem on RowModel {
+  id
+  versionId
+  createdId
+  createdAt
+  updatedAt
+  readonly
+  data
+}
+    `;
+export const RowMutationItemFragmentDoc = gql`
+    fragment RowMutationItem on RowModel {
+  id
+  versionId
+  createdId
+  createdAt
+  updatedAt
+  readonly
+  data
+}
+    `;
+export const TableMutationItemFragmentDoc = gql`
+    fragment TableMutationItem on TableModel {
+  id
+  versionId
+  createdId
+  createdAt
+  updatedAt
+  readonly
+  count
+  schema
+}
+    `;
+export const RowListItemFragmentDoc = gql`
+    fragment RowListItem on RowModel {
+  id
+  versionId
+  readonly
+  data
+  createdAt
+  updatedAt
+  publishedAt
+  createdId
+}
+    `;
+export const TableViewsDataFragmentDoc = gql`
+    fragment TableViewsData on TableViewsDataModel {
+  version
+  defaultViewId
+  views {
+    id
+    name
+    description
+    columns {
+      field
+      width
+      pinned
+    }
+    filters
+    sorts {
+      field
+      direction
+    }
+    search
+  }
+}
+    `;
+export const SearchResultFragmentDoc = gql`
+    fragment SearchResult on SearchResult {
+  row {
+    id
+  }
+  table {
+    id
+  }
+  matches {
+    value
+    path
+    highlight
+  }
+}
+    `;
+export const TableListItemFragmentDoc = gql`
+    fragment TableListItem on TableModel {
+  id
+  versionId
+  readonly
+  count
+}
+    `;
+export const TableRelationsItemFragmentDoc = gql`
+    fragment TableRelationsItem on TableModel {
+  id
+  versionId
+  count
+  schema
+}
+    `;
+export const GetBranchForLoaderDocument = gql`
+    query getBranchForLoader($data: GetBranchInput!) {
+  branch(data: $data) {
+    ...BranchLoaderFragment
+  }
+}
+    ${BranchLoaderFragmentFragmentDoc}`;
+export const OrganizationProjectsDocument = gql`
+    query organizationProjects($data: GetProjectsInput!) {
+  projects(data: $data) {
+    totalCount
+    pageInfo {
+      ...PageInfo
+    }
+    edges {
+      cursor
+      node {
+        ...OrganizationProjectItem
+      }
+    }
+  }
+}
+    ${PageInfoFragmentDoc}
+${OrganizationProjectItemFragmentDoc}`;
+export const GetProjectDocument = gql`
+    query getProject($data: GetProjectInput!) {
+  project(data: $data) {
     id
     organizationId
     createdAt
     name
     isPublic
-    rootBranch {
-      ...BranchFragment
-    }
     userProject {
       id
       role {
@@ -3817,767 +3474,303 @@ export const ProjectLoaderFragmentFragmentDoc = gql`
       }
     }
   }
-  ${BranchFragmentFragmentDoc}
-`
-export const RowLoaderFragmentFragmentDoc = gql`
-  fragment RowLoaderFragment on RowModel {
-    createdId
-    id
-    versionId
-    createdAt
-    updatedAt
-    readonly
-    data
-  }
-`
-export const TableLoaderFragmentFragmentDoc = gql`
-  fragment TableLoaderFragment on TableModel {
-    createdId
-    id
-    versionId
-    createdAt
-    updatedAt
-    readonly
-    count
-    schema
-  }
-`
-export const AdminUserDetailFragmentDoc = gql`
-  fragment AdminUserDetail on UserModel {
-    id
-    email
-    username
-    role {
-      id
-      name
-    }
-  }
-`
-export const AdminUserItemFragmentDoc = gql`
-  fragment AdminUserItem on UserModel {
-    id
-    email
-    username
-    role {
-      id
-      name
-    }
-  }
-`
-export const AssetTableItemFragmentDoc = gql`
-  fragment AssetTableItem on TableModel {
-    id
-    versionId
-    count
-    schema
-  }
-`
-export const AssetRowItemFragmentDoc = gql`
-  fragment AssetRowItem on RowModel {
-    id
-    versionId
-    data
-  }
-`
-export const SubSchemaItemFragmentDoc = gql`
-  fragment SubSchemaItem on SubSchemaItemModel {
-    table {
-      id
-      versionId
-    }
-    row {
-      id
-      versionId
-      data
-    }
-    fieldPath
-    data
-  }
-`
-export const BranchItemFragmentDoc = gql`
-  fragment BranchItem on BranchModel {
-    id
-    name
-    isRoot
-    touched
-    createdAt
-    start {
-      id
-      createdAt
-    }
-    parent {
-      revision {
-        id
-        isDraft
-        isHead
-        createdAt
-        branch {
-          id
-          name
-        }
-      }
-    }
-  }
-`
-export const RevisionForSelectFragmentDoc = gql`
-  fragment RevisionForSelect on RevisionModel {
-    id
-    isDraft
-    isHead
-    createdAt
-    comment
-  }
-`
-export const EndpointFragmentDoc = gql`
-  fragment Endpoint on EndpointModel {
-    id
-    type
-    createdAt
-    revisionId
-    revision {
-      id
-      isDraft
-      isHead
-      createdAt
-      branch {
-        id
-        name
-      }
-    }
-  }
-`
-export const RevisionWithEndpointsFragmentDoc = gql`
-  fragment RevisionWithEndpoints on RevisionModel {
-    id
-    comment
-    isDraft
-    isHead
-    isStart
-    createdAt
-    endpoints {
-      id
-      type
-    }
-  }
-`
-export const EndpointBranchFragmentDoc = gql`
-  fragment EndpointBranch on BranchModel {
-    id
-    name
-    isRoot
-    head {
-      id
-    }
-    draft {
-      id
-    }
-  }
-`
-export const MigrationBranchFragmentDoc = gql`
-  fragment MigrationBranch on BranchModel {
-    id
-    name
-    isRoot
-    head {
-      id
-    }
-    draft {
-      id
-    }
-  }
-`
-export const UsageMetricFragmentDoc = gql`
-  fragment UsageMetric on UsageMetricModel {
-    current
-    limit
-    percentage
-  }
-`
-export const LimitsPageSubscriptionFragmentDoc = gql`
-  fragment LimitsPageSubscription on SubscriptionModel {
-    planId
-    status
-    provider
-    interval
-    currentPeriodStart
-    currentPeriodEnd
-    cancelAt
-  }
-`
-export const LimitsPagePlanFragmentDoc = gql`
-  fragment LimitsPagePlan on PlanModel {
-    id
-    name
-    isPublic
-    monthlyPriceUsd
-    yearlyPriceUsd
-    limits {
-      rowVersions
-      projects
-      seats
-      storageBytes
-    }
-    features
-  }
-`
-export const UserOrganizationItemFragmentDoc = gql`
-  fragment UserOrganizationItem on UsersOrganizationModel {
-    id
-    user {
-      id
-      email
-      username
-    }
-    role {
-      id
-      name
-    }
-  }
-`
-export const TableStackFragmentFragmentDoc = gql`
-  fragment TableStackFragment on TableModel {
-    id
-    versionId
-    readonly
-    count
-    schema
-  }
-`
-export const UserProjectItemFragmentDoc = gql`
-  fragment UserProjectItem on UsersProjectModel {
-    id
-    user {
-      id
-      email
-      username
-    }
-    role {
-      id
-      name
-    }
-  }
-`
-export const PageInfoFragmentDoc = gql`
-  fragment PageInfo on PageInfo {
-    hasNextPage
-    hasPreviousPage
-    startCursor
-    endCursor
-  }
-`
-export const UserFragmentDoc = gql`
-  fragment User on MeModel {
-    id
-    username
-    email
-    hasPassword
-    organizationId
-    role {
-      id
-      name
-      permissions {
-        id
-        action
-        subject
-        condition
-      }
-    }
-    organization {
-      id
-      userOrganization {
-        role {
-          name
-          permissions {
-            id
-            action
-            subject
-            condition
-          }
-        }
-      }
-    }
-  }
-`
-export const RevisionMapRevisionBaseFragmentDoc = gql`
-  fragment RevisionMapRevisionBase on RevisionModel {
-    id
-    comment
-    isDraft
-    isHead
-    isStart
-    createdAt
-    parent {
-      id
-    }
-    endpoints {
-      id
-      type
-      createdAt
-    }
-    childBranches {
-      branch {
-        id
-        name
-      }
-    }
-  }
-`
-export const RevisionMapBranchFullFragmentDoc = gql`
-  fragment RevisionMapBranchFull on BranchModel {
-    id
-    name
-    isRoot
-    touched
-    createdAt
-    head {
-      ...RevisionMapRevisionBase
-    }
-    draft {
-      ...RevisionMapRevisionBase
-    }
-    start {
-      ...RevisionMapRevisionBase
-    }
-    parent {
-      revision {
-        ...RevisionMapRevisionBase
-      }
-      branch {
-        id
-        name
-      }
-    }
-    revisions(data: { first: 1000 }) {
-      totalCount
-    }
-  }
-  ${RevisionMapRevisionBaseFragmentDoc}
-`
-export const FindBranchFragmentDoc = gql`
-  fragment FindBranch on BranchModel {
-    id
-    name
-    isRoot
-    touched
-    parent {
-      revision {
-        branch {
-          id
-        }
-      }
-    }
-  }
-`
-export const FindRevisionFragmentDoc = gql`
-  fragment FindRevision on RevisionModel {
-    id
-    comment
-    isDraft
-    isHead
-    isStart
-    createdAt
-  }
-`
-export const MeProjectListItemFragmentDoc = gql`
-  fragment MeProjectListItem on ProjectModel {
-    id
-    name
-    organizationId
-    rootBranch {
-      name
-      touched
-    }
-  }
-`
-export const RowChangeRowFieldsFragmentDoc = gql`
-  fragment RowChangeRowFields on RowChangeRowModel {
-    id
-  }
-`
-export const RowChangeTableFieldsFragmentDoc = gql`
-  fragment RowChangeTableFields on RowChangeTableModel {
-    id
-  }
-`
-export const FieldChangeFieldsFragmentDoc = gql`
-  fragment FieldChangeFields on FieldChangeModel {
-    fieldPath
-    changeType
-    oldValue
-    newValue
-    movedFrom
-  }
-`
-export const ForeignKeyTableItemFragmentDoc = gql`
-  fragment ForeignKeyTableItem on TableModel {
-    id
-    versionId
-    createdId
-    createdAt
-    updatedAt
-    readonly
-    count
-    schema
-  }
-`
-export const ForeignKeyRowItemFragmentDoc = gql`
-  fragment ForeignKeyRowItem on RowModel {
-    id
-    versionId
-    createdId
-    createdAt
-    updatedAt
-    readonly
-    data
-  }
-`
-export const RowMutationItemFragmentDoc = gql`
-  fragment RowMutationItem on RowModel {
-    id
-    versionId
-    createdId
-    createdAt
-    updatedAt
-    readonly
-    data
-  }
-`
-export const TableMutationItemFragmentDoc = gql`
-  fragment TableMutationItem on TableModel {
-    id
-    versionId
-    createdId
-    createdAt
-    updatedAt
-    readonly
-    count
-    schema
-  }
-`
-export const RowListItemFragmentDoc = gql`
-  fragment RowListItem on RowModel {
-    id
-    versionId
-    readonly
-    data
-    createdAt
-    updatedAt
-    publishedAt
-    createdId
-  }
-`
-export const TableViewsDataFragmentDoc = gql`
-  fragment TableViewsData on TableViewsDataModel {
-    version
-    defaultViewId
-    views {
-      id
-      name
-      description
-      columns {
-        field
-        width
-        pinned
-      }
-      filters
-      sorts {
-        field
-        direction
-      }
-      search
-    }
-  }
-`
-export const SearchResultFragmentDoc = gql`
-  fragment SearchResult on SearchResult {
-    row {
-      id
-    }
-    table {
-      id
-    }
-    matches {
-      value
-      path
-      highlight
-    }
-  }
-`
-export const TableListItemFragmentDoc = gql`
-  fragment TableListItem on TableModel {
-    id
-    versionId
-    readonly
-    count
-  }
-`
-export const TableRelationsItemFragmentDoc = gql`
-  fragment TableRelationsItem on TableModel {
-    id
-    versionId
-    count
-    schema
-  }
-`
-export const GetBranchForLoaderDocument = gql`
-  query getBranchForLoader($data: GetBranchInput!) {
-    branch(data: $data) {
-      ...BranchLoaderFragment
-    }
-  }
-  ${BranchLoaderFragmentFragmentDoc}
-`
-export const OrganizationProjectsDocument = gql`
-  query organizationProjects($data: GetProjectsInput!) {
-    projects(data: $data) {
-      totalCount
-      pageInfo {
-        ...PageInfo
-      }
-      edges {
-        cursor
-        node {
-          ...OrganizationProjectItem
-        }
-      }
-    }
-  }
-  ${PageInfoFragmentDoc}
-  ${OrganizationProjectItemFragmentDoc}
-`
-export const GetProjectDocument = gql`
-  query getProject($data: GetProjectInput!) {
-    project(data: $data) {
-      id
-      organizationId
-      createdAt
-      name
-      isPublic
-      userProject {
-        id
-        role {
-          id
-          name
-          permissions {
-            id
-            action
-            subject
-            condition
-          }
-        }
-      }
-      organization {
-        id
-        userOrganization {
-          id
-          role {
-            id
-            name
-            permissions {
-              id
-              action
-              subject
-              condition
-            }
-          }
-        }
-      }
-    }
-  }
-`
+}
+    `;
 export const GetProjectForLoaderDocument = gql`
-  query getProjectForLoader($data: GetProjectInput!) {
-    project(data: $data) {
-      ...ProjectLoaderFragment
-    }
+    query getProjectForLoader($data: GetProjectInput!) {
+  project(data: $data) {
+    ...ProjectLoaderFragment
   }
-  ${ProjectLoaderFragmentFragmentDoc}
-`
+}
+    ${ProjectLoaderFragmentFragmentDoc}`;
 export const GetRevisionForLoaderDocument = gql`
-  query getRevisionForLoader($data: GetRevisionInput!) {
-    revision(data: $data) {
-      id
-    }
+    query getRevisionForLoader($data: GetRevisionInput!) {
+  revision(data: $data) {
+    id
   }
-`
+}
+    `;
 export const GetRowForLoaderDocument = gql`
-  query getRowForLoader($data: GetRowInput!) {
-    row(data: $data) {
-      ...RowLoaderFragment
-    }
+    query getRowForLoader($data: GetRowInput!) {
+  row(data: $data) {
+    ...RowLoaderFragment
   }
-  ${RowLoaderFragmentFragmentDoc}
-`
+}
+    ${RowLoaderFragmentFragmentDoc}`;
 export const GetRowCountForeignKeysToForLoaderDocument = gql`
-  query getRowCountForeignKeysToForLoader($data: GetRowInput!) {
-    row(data: $data) {
-      id
-      countForeignKeysTo
-    }
+    query getRowCountForeignKeysToForLoader($data: GetRowInput!) {
+  row(data: $data) {
+    id
+    countForeignKeysTo
   }
-`
+}
+    `;
 export const ForeignKeysByDocument = gql`
-  query ForeignKeysBy($tableData: GetTableInput!, $foreignKeyTablesData: GetTableForeignKeysInput!) {
-    table(data: $tableData) {
-      id
-      foreignKeysBy(data: $foreignKeyTablesData) {
-        totalCount
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        edges {
-          node {
-            id
-          }
+    query ForeignKeysBy($tableData: GetTableInput!, $foreignKeyTablesData: GetTableForeignKeysInput!) {
+  table(data: $tableData) {
+    id
+    foreignKeysBy(data: $foreignKeyTablesData) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          id
         }
       }
     }
   }
-`
+}
+    `;
 export const ForeignKeysByRowsDocument = gql`
-  query ForeignKeysByRows($rowData: GetRowInput!, $foreignKeyRowsData: GetRowForeignKeysInput!) {
-    row(data: $rowData) {
-      id
-      rowForeignKeysBy(data: $foreignKeyRowsData) {
-        totalCount
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        edges {
-          node {
-            id
-            versionId
-            data
-          }
+    query ForeignKeysByRows($rowData: GetRowInput!, $foreignKeyRowsData: GetRowForeignKeysInput!) {
+  row(data: $rowData) {
+    id
+    rowForeignKeysBy(data: $foreignKeyRowsData) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          id
+          versionId
+          data
         }
       }
     }
   }
-`
+}
+    `;
 export const GetTableForLoaderDocument = gql`
-  query getTableForLoader($data: GetTableInput!) {
-    table(data: $data) {
-      ...TableLoaderFragment
-    }
+    query getTableForLoader($data: GetTableInput!) {
+  table(data: $data) {
+    ...TableLoaderFragment
   }
-  ${TableLoaderFragmentFragmentDoc}
-`
+}
+    ${TableLoaderFragmentFragmentDoc}`;
 export const UpdatePasswordDocument = gql`
-  mutation updatePassword($data: UpdatePasswordInput!) {
-    updatePassword(data: $data)
+    mutation updatePassword($data: UpdatePasswordInput!) {
+  updatePassword(data: $data)
+}
+    `;
+export const MyApiKeysDocument = gql`
+    query myApiKeys {
+  myApiKeys {
+    ...ApiKeyFields
   }
-`
+}
+    ${ApiKeyFieldsFragmentDoc}`;
+export const ServiceApiKeysDocument = gql`
+    query serviceApiKeys($organizationId: String!) {
+  serviceApiKeys(organizationId: $organizationId) {
+    ...ApiKeyFields
+  }
+}
+    ${ApiKeyFieldsFragmentDoc}`;
+export const ApiKeyByIdDocument = gql`
+    query apiKeyById($id: ID!) {
+  apiKeyById(id: $id) {
+    ...ApiKeyFields
+  }
+}
+    ${ApiKeyFieldsFragmentDoc}`;
+export const CreatePersonalApiKeyDocument = gql`
+    mutation createPersonalApiKey($data: CreatePersonalApiKeyInput!) {
+  createPersonalApiKey(data: $data) {
+    apiKey {
+      ...ApiKeyFields
+    }
+    secret
+  }
+}
+    ${ApiKeyFieldsFragmentDoc}`;
+export const CreateServiceApiKeyDocument = gql`
+    mutation createServiceApiKey($data: CreateServiceApiKeyInput!) {
+  createServiceApiKey(data: $data) {
+    apiKey {
+      ...ApiKeyFields
+    }
+    secret
+  }
+}
+    ${ApiKeyFieldsFragmentDoc}`;
+export const RevokeApiKeyDocument = gql`
+    mutation revokeApiKey($id: ID!) {
+  revokeApiKey(id: $id) {
+    ...ApiKeyFields
+  }
+}
+    ${ApiKeyFieldsFragmentDoc}`;
+export const RotateApiKeyDocument = gql`
+    mutation rotateApiKey($id: ID!) {
+  rotateApiKey(id: $id) {
+    apiKey {
+      ...ApiKeyFields
+    }
+    secret
+  }
+}
+    ${ApiKeyFieldsFragmentDoc}`;
 export const CreateProjectDocument = gql`
-  mutation createProject($data: CreateProjectInput!) {
-    createProject(data: $data) {
-      id
-      name
-      organizationId
-    }
+    mutation createProject($data: CreateProjectInput!) {
+  createProject(data: $data) {
+    id
+    name
+    organizationId
   }
-`
+}
+    `;
 export const FindForeignKeyDocument = gql`
-  query findForeignKey($data: GetRowsInput!) {
-    rows(data: $data) {
-      totalCount
-      pageInfo {
-        ...PageInfo
-      }
-      edges {
-        cursor
-        node {
-          id
-        }
+    query findForeignKey($data: GetRowsInput!) {
+  rows(data: $data) {
+    totalCount
+    pageInfo {
+      ...PageInfo
+    }
+    edges {
+      cursor
+      node {
+        id
       }
     }
   }
-  ${PageInfoFragmentDoc}
-`
+}
+    ${PageInfoFragmentDoc}`;
 export const AdminDashboardStatsDocument = gql`
-  query AdminDashboardStats($first: Int!) {
-    searchUsers(data: { first: $first }) {
-      totalCount
-    }
+    query AdminDashboardStats($first: Int!) {
+  searchUsers(data: {first: $first}) {
+    totalCount
   }
-`
+}
+    `;
 export const AdminGetUserDocument = gql`
-  query adminGetUser($userId: String!) {
-    adminUser(data: { userId: $userId }) {
-      ...AdminUserDetail
-    }
+    query adminGetUser($userId: String!) {
+  adminUser(data: {userId: $userId}) {
+    ...AdminUserDetail
   }
-  ${AdminUserDetailFragmentDoc}
-`
+}
+    ${AdminUserDetailFragmentDoc}`;
 export const AdminResetPasswordDocument = gql`
-  mutation adminResetPassword($userId: String!, $newPassword: String!) {
-    resetPassword(data: { userId: $userId, newPassword: $newPassword })
-  }
-`
+    mutation adminResetPassword($userId: String!, $newPassword: String!) {
+  resetPassword(data: {userId: $userId, newPassword: $newPassword})
+}
+    `;
 export const AdminUsersDocument = gql`
-  query adminUsers($search: String, $first: Int!, $after: String) {
-    adminUsers(data: { search: $search, first: $first, after: $after }) {
-      edges {
-        node {
-          ...AdminUserItem
-        }
-        cursor
+    query adminUsers($search: String, $first: Int!, $after: String) {
+  adminUsers(data: {search: $search, first: $first, after: $after}) {
+    edges {
+      node {
+        ...AdminUserItem
       }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      totalCount
+      cursor
     }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    totalCount
   }
-  ${AdminUserItemFragmentDoc}
-`
+}
+    ${AdminUserItemFragmentDoc}`;
 export const AdminUserDocument = gql`
-  query adminUser($userId: String!) {
-    adminUser(data: { userId: $userId }) {
-      ...AdminUserItem
-    }
+    query adminUser($userId: String!) {
+  adminUser(data: {userId: $userId}) {
+    ...AdminUserItem
   }
-  ${AdminUserItemFragmentDoc}
-`
+}
+    ${AdminUserItemFragmentDoc}`;
 export const AssetsTablesDataDocument = gql`
-  query assetsTablesData($data: GetTablesInput!) {
-    tables(data: $data) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          ...AssetTableItem
-        }
+    query assetsTablesData($data: GetTablesInput!) {
+  tables(data: $data) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        ...AssetTableItem
       }
     }
   }
-  ${AssetTableItemFragmentDoc}
-`
+}
+    ${AssetTableItemFragmentDoc}`;
 export const AssetsRowsDataDocument = gql`
-  query assetsRowsData($data: GetRowsInput!) {
-    rows(data: $data) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          ...AssetRowItem
-        }
+    query assetsRowsData($data: GetRowsInput!) {
+  rows(data: $data) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        ...AssetRowItem
       }
     }
   }
-  ${AssetRowItemFragmentDoc}
-`
+}
+    ${AssetRowItemFragmentDoc}`;
 export const SubSchemaItemsDataDocument = gql`
-  query subSchemaItemsData($data: GetSubSchemaItemsInput!) {
-    subSchemaItems(data: $data) {
+    query subSchemaItemsData($data: GetSubSchemaItemsInput!) {
+  subSchemaItems(data: $data) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        ...SubSchemaItem
+      }
+    }
+  }
+}
+    ${SubSchemaItemFragmentDoc}`;
+export const GetProjectBranchesDocument = gql`
+    query getProjectBranches($data: GetBranchesInput!) {
+  branches(data: $data) {
+    totalCount
+    pageInfo {
+      ...PageInfo
+    }
+    edges {
+      cursor
+      node {
+        ...BranchItem
+      }
+    }
+  }
+}
+    ${PageInfoFragmentDoc}
+${BranchItemFragmentDoc}`;
+export const DeleteBranchDocument = gql`
+    mutation deleteBranch($data: DeleteBranchInput!) {
+  deleteBranch(data: $data)
+}
+    `;
+export const GetBranchesForSelectDocument = gql`
+    query getBranchesForSelect($data: GetBranchesInput!) {
+  branches(data: $data) {
+    edges {
+      node {
+        id
+        name
+        isRoot
+      }
+    }
+  }
+}
+    `;
+export const GetBranchRevisionsForCreateDocument = gql`
+    query getBranchRevisionsForCreate($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
+  branch(data: $data) {
+    id
+    revisions(data: $revisionsData) {
       totalCount
       pageInfo {
         hasNextPage
@@ -4585,2254 +3778,1127 @@ export const SubSchemaItemsDataDocument = gql`
       }
       edges {
         node {
-          ...SubSchemaItem
+          ...RevisionForSelect
         }
       }
     }
   }
-  ${SubSchemaItemFragmentDoc}
-`
-export const GetProjectBranchesDocument = gql`
-  query getProjectBranches($data: GetBranchesInput!) {
-    branches(data: $data) {
-      totalCount
-      pageInfo {
-        ...PageInfo
-      }
-      edges {
-        cursor
-        node {
-          ...BranchItem
-        }
-      }
-    }
-  }
-  ${PageInfoFragmentDoc}
-  ${BranchItemFragmentDoc}
-`
-export const DeleteBranchDocument = gql`
-  mutation deleteBranch($data: DeleteBranchInput!) {
-    deleteBranch(data: $data)
-  }
-`
-export const GetBranchesForSelectDocument = gql`
-  query getBranchesForSelect($data: GetBranchesInput!) {
-    branches(data: $data) {
-      edges {
-        node {
-          id
-          name
-          isRoot
-        }
-      }
-    }
-  }
-`
-export const GetBranchRevisionsForCreateDocument = gql`
-  query getBranchRevisionsForCreate($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
-    branch(data: $data) {
-      id
-      revisions(data: $revisionsData) {
-        totalCount
-        pageInfo {
-          hasNextPage
-          endCursor
-        }
-        edges {
-          node {
-            ...RevisionForSelect
-          }
-        }
-      }
-    }
-  }
-  ${RevisionForSelectFragmentDoc}
-`
+}
+    ${RevisionForSelectFragmentDoc}`;
 export const CreateBranchDocument = gql`
-  mutation createBranch($data: CreateBranchInput!) {
-    createBranch(data: $data) {
-      id
-      name
-    }
+    mutation createBranch($data: CreateBranchInput!) {
+  createBranch(data: $data) {
+    id
+    name
   }
-`
+}
+    `;
 export const GetRevisionChangesDocument = gql`
-  query GetRevisionChanges($revisionId: String!, $compareWithRevisionId: String, $includeSystem: Boolean) {
-    revisionChanges(
-      data: { revisionId: $revisionId, compareWithRevisionId: $compareWithRevisionId, includeSystem: $includeSystem }
-    ) {
-      revisionId
-      parentRevisionId
-      totalChanges
-      tablesSummary {
-        added
-        modified
-        removed
-        renamed
-        total
-      }
-      rowsSummary {
-        added
-        modified
-        removed
-        renamed
-        total
-      }
+    query GetRevisionChanges($revisionId: String!, $compareWithRevisionId: String, $includeSystem: Boolean) {
+  revisionChanges(
+    data: {revisionId: $revisionId, compareWithRevisionId: $compareWithRevisionId, includeSystem: $includeSystem}
+  ) {
+    revisionId
+    parentRevisionId
+    totalChanges
+    tablesSummary {
+      added
+      modified
+      removed
+      renamed
+      total
+    }
+    rowsSummary {
+      added
+      modified
+      removed
+      renamed
+      total
     }
   }
-`
+}
+    `;
 export const GetTableChangesDocument = gql`
-  query GetTableChanges($revisionId: String!, $first: Int!, $after: String, $filters: TableChangesFiltersInput) {
-    tableChanges(data: { revisionId: $revisionId, first: $first, after: $after, filters: $filters }) {
-      edges {
-        node {
-          tableId
-          changeType
+    query GetTableChanges($revisionId: String!, $first: Int!, $after: String, $filters: TableChangesFiltersInput) {
+  tableChanges(
+    data: {revisionId: $revisionId, first: $first, after: $after, filters: $filters}
+  ) {
+    edges {
+      node {
+        tableId
+        changeType
+        oldTableId
+        newTableId
+        schemaMigrations {
+          migrationType
+          migrationId
           oldTableId
           newTableId
-          schemaMigrations {
-            migrationType
-            migrationId
-            oldTableId
-            newTableId
-            patches {
-              op
-              path
-              value
-              from
-            }
+          patches {
+            op
+            path
+            value
+            from
           }
-          viewsChanges {
-            hasChanges
-            changes {
-              viewId
-              viewName
-              changeType
-              oldViewName
-            }
-            addedCount
-            modifiedCount
-            removedCount
-            renamedCount
-          }
-          rowChangesCount
-          addedRowsCount
-          modifiedRowsCount
-          removedRowsCount
-          renamedRowsCount
         }
-        cursor
+        viewsChanges {
+          hasChanges
+          changes {
+            viewId
+            viewName
+            changeType
+            oldViewName
+          }
+          addedCount
+          modifiedCount
+          removedCount
+          renamedCount
+        }
+        rowChangesCount
+        addedRowsCount
+        modifiedRowsCount
+        removedRowsCount
+        renamedRowsCount
       }
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
-      totalCount
+      cursor
     }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    totalCount
   }
-`
+}
+    `;
 export const ConfirmEmailCodeDocument = gql`
-  mutation confirmEmailCode($data: ConfirmEmailCodeInput!) {
-    confirmEmailCode(data: $data) {
-      accessToken
-    }
+    mutation confirmEmailCode($data: ConfirmEmailCodeInput!) {
+  confirmEmailCode(data: $data) {
+    accessToken
   }
-`
+}
+    `;
 export const GetEndpointBranchesDocument = gql`
-  query getEndpointBranches($data: GetBranchesInput!) {
-    branches(data: $data) {
-      totalCount
-      edges {
-        node {
-          ...EndpointBranch
-        }
+    query getEndpointBranches($data: GetBranchesInput!) {
+  branches(data: $data) {
+    totalCount
+    edges {
+      node {
+        ...EndpointBranch
       }
     }
   }
-  ${EndpointBranchFragmentDoc}
-`
+}
+    ${EndpointBranchFragmentDoc}`;
 export const GetProjectEndpointsDocument = gql`
-  query getProjectEndpoints(
-    $organizationId: String!
-    $projectName: String!
-    $first: Int!
-    $after: String
-    $branchId: String
-    $type: EndpointType
+    query getProjectEndpoints($organizationId: String!, $projectName: String!, $first: Int!, $after: String, $branchId: String, $type: EndpointType) {
+  projectEndpoints(
+    data: {organizationId: $organizationId, projectName: $projectName, first: $first, after: $after, branchId: $branchId, type: $type}
   ) {
-    projectEndpoints(
-      data: {
-        organizationId: $organizationId
-        projectName: $projectName
-        first: $first
-        after: $after
-        branchId: $branchId
-        type: $type
+    edges {
+      node {
+        ...Endpoint
       }
-    ) {
-      edges {
-        node {
-          ...Endpoint
-        }
-        cursor
-      }
+      cursor
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    totalCount
+  }
+}
+    ${EndpointFragmentDoc}`;
+export const GetBranchRevisionsDocument = gql`
+    query getBranchRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
+  branch(data: $data) {
+    revisions(data: $revisionsData) {
+      totalCount
       pageInfo {
         hasNextPage
         hasPreviousPage
         startCursor
         endCursor
       }
-      totalCount
-    }
-  }
-  ${EndpointFragmentDoc}
-`
-export const GetBranchRevisionsDocument = gql`
-  query getBranchRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
-    branch(data: $data) {
-      revisions(data: $revisionsData) {
-        totalCount
-        pageInfo {
-          hasNextPage
-          hasPreviousPage
-          startCursor
-          endCursor
-        }
-        edges {
-          cursor
-          node {
-            ...RevisionWithEndpoints
-          }
-        }
-      }
-    }
-  }
-  ${RevisionWithEndpointsFragmentDoc}
-`
-export const CreateEndpointDocument = gql`
-  mutation createEndpoint($data: CreateEndpointInput!) {
-    createEndpoint(data: $data) {
-      ...Endpoint
-    }
-  }
-  ${EndpointFragmentDoc}
-`
-export const DeleteEndpointDocument = gql`
-  mutation deleteEndpoint($data: DeleteEndpointInput!) {
-    deleteEndpoint(data: $data)
-  }
-`
-export const LoginGithubDocument = gql`
-  mutation loginGithub($data: LoginGithubInput!) {
-    loginGithub(data: $data) {
-      accessToken
-    }
-  }
-`
-export const LoginGoogleDocument = gql`
-  mutation loginGoogle($data: LoginGoogleInput!) {
-    loginGoogle(data: $data) {
-      accessToken
-    }
-  }
-`
-export const LoginDocument = gql`
-  mutation login($data: LoginInput!) {
-    login(data: $data) {
-      accessToken
-    }
-  }
-`
-export const GetMigrationBranchesDocument = gql`
-  query getMigrationBranches($data: GetBranchesInput!) {
-    branches(data: $data) {
-      totalCount
       edges {
+        cursor
         node {
-          ...MigrationBranch
+          ...RevisionWithEndpoints
         }
       }
     }
   }
-  ${MigrationBranchFragmentDoc}
-`
+}
+    ${RevisionWithEndpointsFragmentDoc}`;
+export const CreateEndpointDocument = gql`
+    mutation createEndpoint($data: CreateEndpointInput!) {
+  createEndpoint(data: $data) {
+    ...Endpoint
+  }
+}
+    ${EndpointFragmentDoc}`;
+export const DeleteEndpointDocument = gql`
+    mutation deleteEndpoint($data: DeleteEndpointInput!) {
+  deleteEndpoint(data: $data)
+}
+    `;
+export const LoginGithubDocument = gql`
+    mutation loginGithub($data: LoginGithubInput!) {
+  loginGithub(data: $data) {
+    accessToken
+  }
+}
+    `;
+export const LoginGoogleDocument = gql`
+    mutation loginGoogle($data: LoginGoogleInput!) {
+  loginGoogle(data: $data) {
+    accessToken
+  }
+}
+    `;
+export const LoginDocument = gql`
+    mutation login($data: LoginInput!) {
+  login(data: $data) {
+    accessToken
+  }
+}
+    `;
+export const GetMigrationBranchesDocument = gql`
+    query getMigrationBranches($data: GetBranchesInput!) {
+  branches(data: $data) {
+    totalCount
+    edges {
+      node {
+        ...MigrationBranch
+      }
+    }
+  }
+}
+    ${MigrationBranchFragmentDoc}`;
 export const GetBranchMigrationsDocument = gql`
-  query getBranchMigrations($data: GetRevisionInput!) {
-    revision(data: $data) {
-      id
-      migrations
-    }
+    query getBranchMigrations($data: GetRevisionInput!) {
+  revision(data: $data) {
+    id
+    migrations
   }
-`
+}
+    `;
 export const ApplyMigrationsDocument = gql`
-  mutation applyMigrations($data: ApplyMigrationsInput!) {
-    applyMigrations(data: $data) {
-      id
-      status
-      error
-    }
+    mutation applyMigrations($data: ApplyMigrationsInput!) {
+  applyMigrations(data: $data) {
+    id
+    status
+    error
   }
-`
+}
+    `;
 export const GetMigrationsDocument = gql`
-  query getMigrations($data: GetRevisionInput!) {
-    revision(data: $data) {
-      id
-      migrations
+    query getMigrations($data: GetRevisionInput!) {
+  revision(data: $data) {
+    id
+    migrations
+  }
+}
+    `;
+export const ActivateEarlyAccessDocument = gql`
+    mutation activateEarlyAccess($data: ActivateEarlyAccessInput!) {
+  activateEarlyAccess(data: $data) {
+    ...LimitsPageSubscription
+  }
+}
+    ${LimitsPageSubscriptionFragmentDoc}`;
+export const CreateCheckoutDocument = gql`
+    mutation createCheckout($data: CreateCheckoutInput!) {
+  createCheckout(data: $data) {
+    checkoutUrl
+  }
+}
+    `;
+export const CancelSubscriptionDocument = gql`
+    mutation cancelSubscription($data: CancelSubscriptionInput!) {
+  cancelSubscription(data: $data)
+}
+    `;
+export const GetLimitsPageDataDocument = gql`
+    query getLimitsPageData($data: GetOrganizationInput!) {
+  configuration {
+    billing {
+      enabled
     }
   }
-`
-export const ActivateEarlyAccessDocument = gql`
-  mutation activateEarlyAccess($data: ActivateEarlyAccessInput!) {
-    activateEarlyAccess(data: $data) {
+  organization(data: $data) {
+    id
+    subscription {
       ...LimitsPageSubscription
     }
-  }
-  ${LimitsPageSubscriptionFragmentDoc}
-`
-export const CreateCheckoutDocument = gql`
-  mutation createCheckout($data: CreateCheckoutInput!) {
-    createCheckout(data: $data) {
-      checkoutUrl
-    }
-  }
-`
-export const CancelSubscriptionDocument = gql`
-  mutation cancelSubscription($data: CancelSubscriptionInput!) {
-    cancelSubscription(data: $data)
-  }
-`
-export const GetLimitsPageDataDocument = gql`
-  query getLimitsPageData($data: GetOrganizationInput!) {
-    configuration {
-      billing {
-        enabled
+    usage {
+      rowVersions {
+        ...UsageMetric
       }
-    }
-    organization(data: $data) {
-      id
-      subscription {
-        ...LimitsPageSubscription
+      projects {
+        ...UsageMetric
       }
-      usage {
-        rowVersions {
-          ...UsageMetric
-        }
-        projects {
-          ...UsageMetric
-        }
-        seats {
-          ...UsageMetric
-        }
-        storageBytes {
-          ...UsageMetric
-        }
+      seats {
+        ...UsageMetric
+      }
+      storageBytes {
+        ...UsageMetric
       }
     }
   }
-  ${LimitsPageSubscriptionFragmentDoc}
-  ${UsageMetricFragmentDoc}
-`
+}
+    ${LimitsPageSubscriptionFragmentDoc}
+${UsageMetricFragmentDoc}`;
 export const GetLimitsPagePlansDocument = gql`
-  query getLimitsPagePlans {
-    plans {
-      ...LimitsPagePlan
-    }
+    query getLimitsPagePlans {
+  plans {
+    ...LimitsPagePlan
   }
-  ${LimitsPagePlanFragmentDoc}
-`
+}
+    ${LimitsPagePlanFragmentDoc}`;
 export const GetUsersOrganizationDocument = gql`
-  query getUsersOrganization($organizationId: String!, $first: Int!, $after: String) {
-    usersOrganization(data: { organizationId: $organizationId, first: $first, after: $after }) {
-      edges {
-        node {
-          ...UserOrganizationItem
-        }
-        cursor
+    query getUsersOrganization($organizationId: String!, $first: Int!, $after: String) {
+  usersOrganization(
+    data: {organizationId: $organizationId, first: $first, after: $after}
+  ) {
+    edges {
+      node {
+        ...UserOrganizationItem
       }
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
-      totalCount
+      cursor
     }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    totalCount
   }
-  ${UserOrganizationItemFragmentDoc}
-`
+}
+    ${UserOrganizationItemFragmentDoc}`;
 export const AddUserToOrganizationDocument = gql`
-  mutation addUserToOrganization($organizationId: String!, $userId: String!, $roleId: UserOrganizationRoles!) {
-    addUserToOrganization(data: { organizationId: $organizationId, userId: $userId, roleId: $roleId })
-  }
-`
+    mutation addUserToOrganization($organizationId: String!, $userId: String!, $roleId: UserOrganizationRoles!) {
+  addUserToOrganization(
+    data: {organizationId: $organizationId, userId: $userId, roleId: $roleId}
+  )
+}
+    `;
 export const RemoveUserFromOrganizationDocument = gql`
-  mutation removeUserFromOrganization($organizationId: String!, $userId: String!) {
-    removeUserFromOrganization(data: { organizationId: $organizationId, userId: $userId })
-  }
-`
+    mutation removeUserFromOrganization($organizationId: String!, $userId: String!) {
+  removeUserFromOrganization(
+    data: {organizationId: $organizationId, userId: $userId}
+  )
+}
+    `;
 export const UpdateProjectDocument = gql`
-  mutation updateProject($data: UpdateProjectInput!) {
-    updateProject(data: $data)
-  }
-`
+    mutation updateProject($data: UpdateProjectInput!) {
+  updateProject(data: $data)
+}
+    `;
 export const DeleteProjectForSettingsDocument = gql`
-  mutation deleteProjectForSettings($data: DeleteProjectInput!) {
-    deleteProject(data: $data)
-  }
-`
+    mutation deleteProjectForSettings($data: DeleteProjectInput!) {
+  deleteProject(data: $data)
+}
+    `;
 export const FetchTableForStackDocument = gql`
-  query fetchTableForStack($data: GetTableInput!) {
-    table(data: $data) {
+    query fetchTableForStack($data: GetTableInput!) {
+  table(data: $data) {
+    ...TableStackFragment
+  }
+}
+    ${TableStackFragmentFragmentDoc}`;
+export const CreateTableForStackDocument = gql`
+    mutation createTableForStack($data: CreateTableInput!) {
+  createTable(data: $data) {
+    table {
       ...TableStackFragment
     }
   }
-  ${TableStackFragmentFragmentDoc}
-`
-export const CreateTableForStackDocument = gql`
-  mutation createTableForStack($data: CreateTableInput!) {
-    createTable(data: $data) {
-      table {
-        ...TableStackFragment
-      }
-    }
-  }
-  ${TableStackFragmentFragmentDoc}
-`
+}
+    ${TableStackFragmentFragmentDoc}`;
 export const UpdateTableForStackDocument = gql`
-  mutation updateTableForStack($data: UpdateTableInput!) {
-    updateTable(data: $data) {
-      table {
-        ...TableStackFragment
-      }
-      previousVersionTableId
+    mutation updateTableForStack($data: UpdateTableInput!) {
+  updateTable(data: $data) {
+    table {
+      ...TableStackFragment
     }
+    previousVersionTableId
   }
-  ${TableStackFragmentFragmentDoc}
-`
+}
+    ${TableStackFragmentFragmentDoc}`;
 export const RenameTableForStackDocument = gql`
-  mutation renameTableForStack($data: RenameTableInput!) {
-    renameTable(data: $data) {
-      table {
-        ...TableStackFragment
-      }
-      previousVersionTableId
+    mutation renameTableForStack($data: RenameTableInput!) {
+  renameTable(data: $data) {
+    table {
+      ...TableStackFragment
     }
+    previousVersionTableId
   }
-  ${TableStackFragmentFragmentDoc}
-`
+}
+    ${TableStackFragmentFragmentDoc}`;
 export const RowPageDataDocument = gql`
-  query rowPageData(
-    $rowData: GetRowInput!
-    $tableData: GetTableInput!
-    $foreignKeysData: GetRowCountForeignKeysByInput!
-  ) {
-    row(data: $rowData) {
-      id
-      data
-    }
-    table(data: $tableData) {
-      id
-      schema
-    }
-    getRowCountForeignKeysTo(data: $foreignKeysData)
+    query rowPageData($rowData: GetRowInput!, $tableData: GetTableInput!, $foreignKeysData: GetRowCountForeignKeysByInput!) {
+  row(data: $rowData) {
+    id
+    data
   }
-`
+  table(data: $tableData) {
+    id
+    schema
+  }
+  getRowCountForeignKeysTo(data: $foreignKeysData)
+}
+    `;
 export const SignUpDocument = gql`
-  mutation signUp($data: SignUpInput!) {
-    signUp(data: $data)
-  }
-`
+    mutation signUp($data: SignUpInput!) {
+  signUp(data: $data)
+}
+    `;
 export const SetUsernameDocument = gql`
-  mutation setUsername($data: SetUsernameInput!) {
-    setUsername(data: $data)
-  }
-`
+    mutation setUsername($data: SetUsernameInput!) {
+  setUsername(data: $data)
+}
+    `;
 export const GetUsersProjectDocument = gql`
-  query getUsersProject($organizationId: String!, $projectName: String!, $first: Int!, $after: String) {
-    usersProject(data: { organizationId: $organizationId, projectName: $projectName, first: $first, after: $after }) {
-      edges {
-        node {
-          ...UserProjectItem
-        }
-        cursor
+    query getUsersProject($organizationId: String!, $projectName: String!, $first: Int!, $after: String) {
+  usersProject(
+    data: {organizationId: $organizationId, projectName: $projectName, first: $first, after: $after}
+  ) {
+    edges {
+      node {
+        ...UserProjectItem
       }
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
-      totalCount
+      cursor
     }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    totalCount
   }
-  ${UserProjectItemFragmentDoc}
-`
+}
+    ${UserProjectItemFragmentDoc}`;
 export const SearchUsersDocument = gql`
-  query searchUsers($search: String, $first: Int!, $after: String) {
-    searchUsers(data: { search: $search, first: $first, after: $after }) {
-      edges {
-        node {
-          id
-          email
-          username
-        }
-        cursor
+    query searchUsers($search: String, $first: Int!, $after: String) {
+  searchUsers(data: {search: $search, first: $first, after: $after}) {
+    edges {
+      node {
+        id
+        email
+        username
       }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      totalCount
+      cursor
     }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    totalCount
   }
-`
+}
+    `;
 export const AddUserToProjectDocument = gql`
-  mutation addUserToProject(
-    $organizationId: String!
-    $projectName: String!
-    $userId: String!
-    $roleId: UserProjectRoles!
-  ) {
-    addUserToProject(
-      data: { organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId }
-    )
-  }
-`
+    mutation addUserToProject($organizationId: String!, $projectName: String!, $userId: String!, $roleId: UserProjectRoles!) {
+  addUserToProject(
+    data: {organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId}
+  )
+}
+    `;
 export const RemoveUserFromProjectDocument = gql`
-  mutation removeUserFromProject($organizationId: String!, $projectName: String!, $userId: String!) {
-    removeUserFromProject(data: { organizationId: $organizationId, projectName: $projectName, userId: $userId })
-  }
-`
+    mutation removeUserFromProject($organizationId: String!, $projectName: String!, $userId: String!) {
+  removeUserFromProject(
+    data: {organizationId: $organizationId, projectName: $projectName, userId: $userId}
+  )
+}
+    `;
 export const UpdateUserProjectRoleDocument = gql`
-  mutation updateUserProjectRole(
-    $organizationId: String!
-    $projectName: String!
-    $userId: String!
-    $roleId: UserProjectRoles!
-  ) {
-    updateUserProjectRole(
-      data: { organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId }
-    )
-  }
-`
+    mutation updateUserProjectRole($organizationId: String!, $projectName: String!, $userId: String!, $roleId: UserProjectRoles!) {
+  updateUserProjectRole(
+    data: {organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId}
+  )
+}
+    `;
 export const CreateUserDocument = gql`
-  mutation createUser($username: String!, $password: String!, $email: String, $roleId: UserSystemRole!) {
-    createUser(data: { username: $username, password: $password, email: $email, roleId: $roleId })
-  }
-`
+    mutation createUser($username: String!, $password: String!, $email: String, $roleId: UserSystemRole!) {
+  createUser(
+    data: {username: $username, password: $password, email: $email, roleId: $roleId}
+  )
+}
+    `;
 export const ConfigurationDocument = gql`
-  query configuration {
-    configuration {
-      availableEmailSignUp
-      noAuth
-      billing {
-        enabled
-      }
-      google {
-        available
-        clientId
-      }
-      github {
-        available
-        clientId
-      }
-      plugins {
-        file
-      }
+    query configuration {
+  configuration {
+    availableEmailSignUp
+    noAuth
+    billing {
+      enabled
+    }
+    google {
+      available
+      clientId
+    }
+    github {
+      available
+      clientId
+    }
+    plugins {
+      file
     }
   }
-`
+}
+    `;
 export const GetMeDocument = gql`
-  query getMe {
-    me {
-      ...User
-    }
+    query getMe {
+  me {
+    ...User
   }
-  ${UserFragmentDoc}
-`
+}
+    ${UserFragmentDoc}`;
 export const GetProjectGraphDocument = gql`
-  query getProjectGraph($data: GetBranchesInput!) {
-    branches(data: $data) {
-      totalCount
-      edges {
-        node {
-          ...RevisionMapBranchFull
-        }
+    query getProjectGraph($data: GetBranchesInput!) {
+  branches(data: $data) {
+    totalCount
+    edges {
+      node {
+        ...RevisionMapBranchFull
       }
     }
   }
-  ${RevisionMapBranchFullFragmentDoc}
-`
+}
+    ${RevisionMapBranchFullFragmentDoc}`;
 export const FindBranchesDocument = gql`
-  query findBranches($data: GetBranchesInput!) {
-    branches(data: $data) {
-      totalCount
-      pageInfo {
-        ...PageInfo
-      }
-      edges {
-        cursor
-        node {
-          ...FindBranch
-        }
+    query findBranches($data: GetBranchesInput!) {
+  branches(data: $data) {
+    totalCount
+    pageInfo {
+      ...PageInfo
+    }
+    edges {
+      cursor
+      node {
+        ...FindBranch
       }
     }
   }
-  ${PageInfoFragmentDoc}
-  ${FindBranchFragmentDoc}
-`
+}
+    ${PageInfoFragmentDoc}
+${FindBranchFragmentDoc}`;
 export const FindRevisionsDocument = gql`
-  query findRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
-    branch(data: $data) {
-      revisions(data: $revisionsData) {
-        totalCount
-        pageInfo {
-          hasNextPage
-          hasPreviousPage
-          startCursor
-          endCursor
-        }
-        edges {
-          cursor
-          node {
-            ...FindRevision
-          }
-        }
-      }
-    }
-  }
-  ${FindRevisionFragmentDoc}
-`
-export const MeProjectsListDocument = gql`
-  query meProjectsList($data: GetMeProjectsInput!) {
-    meProjects(data: $data) {
+    query findRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
+  branch(data: $data) {
+    revisions(data: $revisionsData) {
       totalCount
-      pageInfo {
-        ...PageInfo
-      }
-      edges {
-        cursor
-        node {
-          ...MeProjectListItem
-        }
-      }
-    }
-  }
-  ${PageInfoFragmentDoc}
-  ${MeProjectListItemFragmentDoc}
-`
-export const GetRowChangesDocument = gql`
-  query GetRowChanges($revisionId: String!, $first: Int!, $after: String, $filters: RowChangesFiltersInput) {
-    rowChanges(data: { revisionId: $revisionId, first: $first, after: $after, filters: $filters }) {
-      edges {
-        node {
-          ... on AddedRowChangeModel {
-            changeType
-            row {
-              ...RowChangeRowFields
-            }
-            table {
-              ...RowChangeTableFields
-            }
-            fieldChanges {
-              ...FieldChangeFields
-            }
-          }
-          ... on RemovedRowChangeModel {
-            changeType
-            fromRow {
-              ...RowChangeRowFields
-            }
-            fromTable {
-              ...RowChangeTableFields
-            }
-            fieldChanges {
-              ...FieldChangeFields
-            }
-          }
-          ... on ModifiedRowChangeModel {
-            changeType
-            row {
-              ...RowChangeRowFields
-            }
-            fromRow {
-              ...RowChangeRowFields
-            }
-            table {
-              ...RowChangeTableFields
-            }
-            fromTable {
-              ...RowChangeTableFields
-            }
-            fieldChanges {
-              ...FieldChangeFields
-            }
-          }
-        }
-        cursor
-      }
       pageInfo {
         hasNextPage
         hasPreviousPage
         startCursor
         endCursor
       }
-      totalCount
+      edges {
+        cursor
+        node {
+          ...FindRevision
+        }
+      }
     }
   }
-  ${RowChangeRowFieldsFragmentDoc}
-  ${RowChangeTableFieldsFragmentDoc}
-  ${FieldChangeFieldsFragmentDoc}
-`
-export const GetTableChangesForFilterDocument = gql`
-  query GetTableChangesForFilter($revisionId: String!) {
-    tableChanges(data: { revisionId: $revisionId, first: 1000, filters: { includeSystem: true } }) {
-      edges {
-        node {
-          tableId
+}
+    ${FindRevisionFragmentDoc}`;
+export const MeProjectsListDocument = gql`
+    query meProjectsList($data: GetMeProjectsInput!) {
+  meProjects(data: $data) {
+    totalCount
+    pageInfo {
+      ...PageInfo
+    }
+    edges {
+      cursor
+      node {
+        ...MeProjectListItem
+      }
+    }
+  }
+}
+    ${PageInfoFragmentDoc}
+${MeProjectListItemFragmentDoc}`;
+export const GetRowChangesDocument = gql`
+    query GetRowChanges($revisionId: String!, $first: Int!, $after: String, $filters: RowChangesFiltersInput) {
+  rowChanges(
+    data: {revisionId: $revisionId, first: $first, after: $after, filters: $filters}
+  ) {
+    edges {
+      node {
+        ... on AddedRowChangeModel {
           changeType
-          oldTableId
-          newTableId
-          rowChangesCount
+          row {
+            ...RowChangeRowFields
+          }
+          table {
+            ...RowChangeTableFields
+          }
+          fieldChanges {
+            ...FieldChangeFields
+          }
         }
+        ... on RemovedRowChangeModel {
+          changeType
+          fromRow {
+            ...RowChangeRowFields
+          }
+          fromTable {
+            ...RowChangeTableFields
+          }
+          fieldChanges {
+            ...FieldChangeFields
+          }
+        }
+        ... on ModifiedRowChangeModel {
+          changeType
+          row {
+            ...RowChangeRowFields
+          }
+          fromRow {
+            ...RowChangeRowFields
+          }
+          table {
+            ...RowChangeTableFields
+          }
+          fromTable {
+            ...RowChangeTableFields
+          }
+          fieldChanges {
+            ...FieldChangeFields
+          }
+        }
+      }
+      cursor
+    }
+    pageInfo {
+      hasNextPage
+      hasPreviousPage
+      startCursor
+      endCursor
+    }
+    totalCount
+  }
+}
+    ${RowChangeRowFieldsFragmentDoc}
+${RowChangeTableFieldsFragmentDoc}
+${FieldChangeFieldsFragmentDoc}`;
+export const GetTableChangesForFilterDocument = gql`
+    query GetTableChangesForFilter($revisionId: String!) {
+  tableChanges(
+    data: {revisionId: $revisionId, first: 1000, filters: {includeSystem: true}}
+  ) {
+    edges {
+      node {
+        tableId
+        changeType
+        oldTableId
+        newTableId
+        rowChangesCount
       }
     }
   }
-`
+}
+    `;
 export const ForeignKeyTableWithRowsDocument = gql`
-  query foreignKeyTableWithRows($tableData: GetTableInput!, $rowsData: GetRowsInput!) {
-    table(data: $tableData) {
-      ...ForeignKeyTableItem
+    query foreignKeyTableWithRows($tableData: GetTableInput!, $rowsData: GetRowsInput!) {
+  table(data: $tableData) {
+    ...ForeignKeyTableItem
+  }
+  rows(data: $rowsData) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
     }
-    rows(data: $rowsData) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          ...ForeignKeyRowItem
-        }
+    edges {
+      node {
+        ...ForeignKeyRowItem
       }
     }
   }
-  ${ForeignKeyTableItemFragmentDoc}
-  ${ForeignKeyRowItemFragmentDoc}
-`
+}
+    ${ForeignKeyTableItemFragmentDoc}
+${ForeignKeyRowItemFragmentDoc}`;
 export const CreateRowForStackDocument = gql`
-  mutation createRowForStack($data: CreateRowInput!) {
-    createRow(data: $data) {
-      table {
-        ...TableMutationItem
-      }
-      previousVersionTableId
-      row {
-        ...RowMutationItem
-      }
+    mutation createRowForStack($data: CreateRowInput!) {
+  createRow(data: $data) {
+    table {
+      ...TableMutationItem
+    }
+    previousVersionTableId
+    row {
+      ...RowMutationItem
     }
   }
-  ${TableMutationItemFragmentDoc}
-  ${RowMutationItemFragmentDoc}
-`
+}
+    ${TableMutationItemFragmentDoc}
+${RowMutationItemFragmentDoc}`;
 export const UpdateRowForStackDocument = gql`
-  mutation updateRowForStack($data: UpdateRowInput!) {
-    updateRow(data: $data) {
-      table {
-        ...TableMutationItem
-      }
-      previousVersionTableId
-      row {
-        ...RowMutationItem
-      }
-      previousVersionRowId
+    mutation updateRowForStack($data: UpdateRowInput!) {
+  updateRow(data: $data) {
+    table {
+      ...TableMutationItem
     }
+    previousVersionTableId
+    row {
+      ...RowMutationItem
+    }
+    previousVersionRowId
   }
-  ${TableMutationItemFragmentDoc}
-  ${RowMutationItemFragmentDoc}
-`
+}
+    ${TableMutationItemFragmentDoc}
+${RowMutationItemFragmentDoc}`;
 export const RenameRowForStackDocument = gql`
-  mutation renameRowForStack($data: RenameRowInput!) {
-    renameRow(data: $data) {
-      table {
-        ...TableMutationItem
-      }
-      previousVersionTableId
-      row {
-        ...RowMutationItem
-      }
-      previousVersionRowId
+    mutation renameRowForStack($data: RenameRowInput!) {
+  renameRow(data: $data) {
+    table {
+      ...TableMutationItem
     }
+    previousVersionTableId
+    row {
+      ...RowMutationItem
+    }
+    previousVersionRowId
   }
-  ${TableMutationItemFragmentDoc}
-  ${RowMutationItemFragmentDoc}
-`
+}
+    ${TableMutationItemFragmentDoc}
+${RowMutationItemFragmentDoc}`;
 export const RowListRowsDocument = gql`
-  query RowListRows($data: GetRowsInput!) {
-    rows(data: $data) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          ...RowListItem
-        }
-      }
+    query RowListRows($data: GetRowsInput!) {
+  rows(data: $data) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
     }
-  }
-  ${RowListItemFragmentDoc}
-`
-export const DeleteRowDocument = gql`
-  mutation DeleteRow($data: DeleteRowInput!) {
-    deleteRow(data: $data) {
-      branch {
-        id
-      }
-    }
-  }
-`
-export const DeleteRowsDocument = gql`
-  mutation DeleteRows($data: DeleteRowsInput!) {
-    deleteRows(data: $data) {
-      branch {
-        id
-      }
-    }
-  }
-`
-export const PatchRowInlineDocument = gql`
-  mutation PatchRowInline($data: PatchRowInput!) {
-    patchRow(data: $data) {
-      row {
+    edges {
+      node {
         ...RowListItem
       }
     }
   }
-  ${RowListItemFragmentDoc}
-`
-export const GetTableViewsDocument = gql`
-  query GetTableViews($data: GetTableInput!) {
-    table(data: $data) {
+}
+    ${RowListItemFragmentDoc}`;
+export const DeleteRowDocument = gql`
+    mutation DeleteRow($data: DeleteRowInput!) {
+  deleteRow(data: $data) {
+    branch {
       id
-      views {
-        ...TableViewsData
-      }
     }
   }
-  ${TableViewsDataFragmentDoc}
-`
-export const UpdateTableViewsDocument = gql`
-  mutation UpdateTableViews($data: UpdateTableViewsInput!) {
-    updateTableViews(data: $data) {
+}
+    `;
+export const DeleteRowsDocument = gql`
+    mutation DeleteRows($data: DeleteRowsInput!) {
+  deleteRows(data: $data) {
+    branch {
+      id
+    }
+  }
+}
+    `;
+export const PatchRowInlineDocument = gql`
+    mutation PatchRowInline($data: PatchRowInput!) {
+  patchRow(data: $data) {
+    row {
+      ...RowListItem
+    }
+  }
+}
+    ${RowListItemFragmentDoc}`;
+export const GetTableViewsDocument = gql`
+    query GetTableViews($data: GetTableInput!) {
+  table(data: $data) {
+    id
+    views {
       ...TableViewsData
     }
   }
-  ${TableViewsDataFragmentDoc}
-`
+}
+    ${TableViewsDataFragmentDoc}`;
+export const UpdateTableViewsDocument = gql`
+    mutation UpdateTableViews($data: UpdateTableViewsInput!) {
+  updateTableViews(data: $data) {
+    ...TableViewsData
+  }
+}
+    ${TableViewsDataFragmentDoc}`;
 export const SearchRowsDocument = gql`
-  query searchRows($data: SearchRowsInput!) {
-    searchRows(data: $data) {
-      edges {
-        cursor
-        node {
-          ...SearchResult
-        }
+    query searchRows($data: SearchRowsInput!) {
+  searchRows(data: $data) {
+    edges {
+      cursor
+      node {
+        ...SearchResult
       }
-      totalCount
     }
+    totalCount
   }
-  ${SearchResultFragmentDoc}
-`
+}
+    ${SearchResultFragmentDoc}`;
 export const RevertChangesForSidebarDocument = gql`
-  mutation revertChangesForSidebar($data: RevertChangesInput!) {
-    revertChanges(data: $data) {
-      id
-    }
+    mutation revertChangesForSidebar($data: RevertChangesInput!) {
+  revertChanges(data: $data) {
+    id
   }
-`
+}
+    `;
 export const CreateRevisionForSidebarDocument = gql`
-  mutation createRevisionForSidebar($data: CreateRevisionInput!) {
-    createRevision(data: $data) {
-      id
-    }
+    mutation createRevisionForSidebar($data: CreateRevisionInput!) {
+  createRevision(data: $data) {
+    id
   }
-`
+}
+    `;
 export const CreateBranchForSidebarDocument = gql`
-  mutation createBranchForSidebar($data: CreateBranchInput!) {
-    createBranch(data: $data) {
+    mutation createBranchForSidebar($data: CreateBranchInput!) {
+  createBranch(data: $data) {
+    id
+  }
+}
+    `;
+export const DeleteTableForListDocument = gql`
+    mutation deleteTableForList($data: DeleteTableInput!) {
+  deleteTable(data: $data) {
+    branch {
       id
     }
   }
-`
-export const DeleteTableForListDocument = gql`
-  mutation deleteTableForList($data: DeleteTableInput!) {
-    deleteTable(data: $data) {
-      branch {
-        id
-      }
-    }
-  }
-`
+}
+    `;
 export const TableListDataDocument = gql`
-  query tableListData($data: GetTablesInput!) {
-    tables(data: $data) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          ...TableListItem
-        }
+    query tableListData($data: GetTablesInput!) {
+  tables(data: $data) {
+    totalCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        ...TableListItem
       }
     }
   }
-  ${TableListItemFragmentDoc}
-`
+}
+    ${TableListItemFragmentDoc}`;
 export const TableRelationsDataDocument = gql`
-  query tableRelationsData($data: GetTablesInput!) {
-    tables(data: $data) {
-      totalCount
-      edges {
-        node {
-          ...TableRelationsItem
-        }
+    query tableRelationsData($data: GetTablesInput!) {
+  tables(data: $data) {
+    totalCount
+    edges {
+      node {
+        ...TableRelationsItem
       }
     }
   }
-  ${TableRelationsItemFragmentDoc}
-`
+}
+    ${TableRelationsItemFragmentDoc}`;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string,
-  variables?: any,
-) => Promise<T>
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action()
+
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    getBranchForLoader(
-      variables: GetBranchForLoaderQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetBranchForLoaderQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetBranchForLoaderQuery>(GetBranchForLoaderDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getBranchForLoader',
-        'query',
-        variables,
-      )
+    getBranchForLoader(variables: GetBranchForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchForLoaderQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchForLoaderQuery>(GetBranchForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchForLoader', 'query', variables);
     },
-    organizationProjects(
-      variables: OrganizationProjectsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<OrganizationProjectsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<OrganizationProjectsQuery>(OrganizationProjectsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'organizationProjects',
-        'query',
-        variables,
-      )
+    organizationProjects(variables: OrganizationProjectsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<OrganizationProjectsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<OrganizationProjectsQuery>(OrganizationProjectsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'organizationProjects', 'query', variables);
     },
-    getProject(
-      variables: GetProjectQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetProjectQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetProjectQuery>(GetProjectDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getProject',
-        'query',
-        variables,
-      )
+    getProject(variables: GetProjectQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectQuery>(GetProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProject', 'query', variables);
     },
-    getProjectForLoader(
-      variables: GetProjectForLoaderQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetProjectForLoaderQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetProjectForLoaderQuery>(GetProjectForLoaderDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getProjectForLoader',
-        'query',
-        variables,
-      )
+    getProjectForLoader(variables: GetProjectForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectForLoaderQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectForLoaderQuery>(GetProjectForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectForLoader', 'query', variables);
     },
-    getRevisionForLoader(
-      variables: GetRevisionForLoaderQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetRevisionForLoaderQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetRevisionForLoaderQuery>(GetRevisionForLoaderDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getRevisionForLoader',
-        'query',
-        variables,
-      )
+    getRevisionForLoader(variables: GetRevisionForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRevisionForLoaderQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetRevisionForLoaderQuery>(GetRevisionForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getRevisionForLoader', 'query', variables);
     },
-    getRowForLoader(
-      variables: GetRowForLoaderQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetRowForLoaderQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetRowForLoaderQuery>(GetRowForLoaderDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getRowForLoader',
-        'query',
-        variables,
-      )
+    getRowForLoader(variables: GetRowForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRowForLoaderQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetRowForLoaderQuery>(GetRowForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getRowForLoader', 'query', variables);
     },
-    getRowCountForeignKeysToForLoader(
-      variables: GetRowCountForeignKeysToForLoaderQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetRowCountForeignKeysToForLoaderQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetRowCountForeignKeysToForLoaderQuery>(GetRowCountForeignKeysToForLoaderDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getRowCountForeignKeysToForLoader',
-        'query',
-        variables,
-      )
+    getRowCountForeignKeysToForLoader(variables: GetRowCountForeignKeysToForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRowCountForeignKeysToForLoaderQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetRowCountForeignKeysToForLoaderQuery>(GetRowCountForeignKeysToForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getRowCountForeignKeysToForLoader', 'query', variables);
     },
-    ForeignKeysBy(
-      variables: ForeignKeysByQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<ForeignKeysByQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ForeignKeysByQuery>(ForeignKeysByDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'ForeignKeysBy',
-        'query',
-        variables,
-      )
+    ForeignKeysBy(variables: ForeignKeysByQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ForeignKeysByQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ForeignKeysByQuery>(ForeignKeysByDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'ForeignKeysBy', 'query', variables);
     },
-    ForeignKeysByRows(
-      variables: ForeignKeysByRowsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<ForeignKeysByRowsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ForeignKeysByRowsQuery>(ForeignKeysByRowsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'ForeignKeysByRows',
-        'query',
-        variables,
-      )
+    ForeignKeysByRows(variables: ForeignKeysByRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ForeignKeysByRowsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ForeignKeysByRowsQuery>(ForeignKeysByRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'ForeignKeysByRows', 'query', variables);
     },
-    getTableForLoader(
-      variables: GetTableForLoaderQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetTableForLoaderQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetTableForLoaderQuery>(GetTableForLoaderDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getTableForLoader',
-        'query',
-        variables,
-      )
+    getTableForLoader(variables: GetTableForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableForLoaderQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetTableForLoaderQuery>(GetTableForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTableForLoader', 'query', variables);
     },
-    updatePassword(
-      variables: UpdatePasswordMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<UpdatePasswordMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<UpdatePasswordMutation>(UpdatePasswordDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'updatePassword',
-        'mutation',
-        variables,
-      )
+    updatePassword(variables: UpdatePasswordMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdatePasswordMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpdatePasswordMutation>(UpdatePasswordDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updatePassword', 'mutation', variables);
     },
-    createProject(
-      variables: CreateProjectMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateProjectMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateProjectMutation>(CreateProjectDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createProject',
-        'mutation',
-        variables,
-      )
+    myApiKeys(variables?: MyApiKeysQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MyApiKeysQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<MyApiKeysQuery>(MyApiKeysDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'myApiKeys', 'query', variables);
     },
-    findForeignKey(
-      variables: FindForeignKeyQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<FindForeignKeyQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<FindForeignKeyQuery>(FindForeignKeyDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'findForeignKey',
-        'query',
-        variables,
-      )
+    serviceApiKeys(variables: ServiceApiKeysQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ServiceApiKeysQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ServiceApiKeysQuery>(ServiceApiKeysDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'serviceApiKeys', 'query', variables);
     },
-    AdminDashboardStats(
-      variables: AdminDashboardStatsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AdminDashboardStatsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AdminDashboardStatsQuery>(AdminDashboardStatsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'AdminDashboardStats',
-        'query',
-        variables,
-      )
+    apiKeyById(variables: ApiKeyByIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ApiKeyByIdQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ApiKeyByIdQuery>(ApiKeyByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'apiKeyById', 'query', variables);
     },
-    adminGetUser(
-      variables: AdminGetUserQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AdminGetUserQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AdminGetUserQuery>(AdminGetUserDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'adminGetUser',
-        'query',
-        variables,
-      )
+    createPersonalApiKey(variables: CreatePersonalApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreatePersonalApiKeyMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreatePersonalApiKeyMutation>(CreatePersonalApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createPersonalApiKey', 'mutation', variables);
     },
-    adminResetPassword(
-      variables: AdminResetPasswordMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AdminResetPasswordMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AdminResetPasswordMutation>(AdminResetPasswordDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'adminResetPassword',
-        'mutation',
-        variables,
-      )
+    createServiceApiKey(variables: CreateServiceApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateServiceApiKeyMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateServiceApiKeyMutation>(CreateServiceApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createServiceApiKey', 'mutation', variables);
     },
-    adminUsers(
-      variables: AdminUsersQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AdminUsersQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AdminUsersQuery>(AdminUsersDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'adminUsers',
-        'query',
-        variables,
-      )
+    revokeApiKey(variables: RevokeApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RevokeApiKeyMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RevokeApiKeyMutation>(RevokeApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'revokeApiKey', 'mutation', variables);
     },
-    adminUser(
-      variables: AdminUserQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AdminUserQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AdminUserQuery>(AdminUserDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
-        'adminUser',
-        'query',
-        variables,
-      )
+    rotateApiKey(variables: RotateApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RotateApiKeyMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RotateApiKeyMutation>(RotateApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'rotateApiKey', 'mutation', variables);
     },
-    assetsTablesData(
-      variables: AssetsTablesDataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AssetsTablesDataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AssetsTablesDataQuery>(AssetsTablesDataDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'assetsTablesData',
-        'query',
-        variables,
-      )
+    createProject(variables: CreateProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateProjectMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateProjectMutation>(CreateProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createProject', 'mutation', variables);
     },
-    assetsRowsData(
-      variables: AssetsRowsDataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AssetsRowsDataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AssetsRowsDataQuery>(AssetsRowsDataDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'assetsRowsData',
-        'query',
-        variables,
-      )
+    findForeignKey(variables: FindForeignKeyQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FindForeignKeyQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<FindForeignKeyQuery>(FindForeignKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'findForeignKey', 'query', variables);
     },
-    subSchemaItemsData(
-      variables: SubSchemaItemsDataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<SubSchemaItemsDataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<SubSchemaItemsDataQuery>(SubSchemaItemsDataDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'subSchemaItemsData',
-        'query',
-        variables,
-      )
+    AdminDashboardStats(variables: AdminDashboardStatsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminDashboardStatsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AdminDashboardStatsQuery>(AdminDashboardStatsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'AdminDashboardStats', 'query', variables);
     },
-    getProjectBranches(
-      variables: GetProjectBranchesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetProjectBranchesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetProjectBranchesQuery>(GetProjectBranchesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getProjectBranches',
-        'query',
-        variables,
-      )
+    adminGetUser(variables: AdminGetUserQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminGetUserQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AdminGetUserQuery>(AdminGetUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminGetUser', 'query', variables);
     },
-    deleteBranch(
-      variables: DeleteBranchMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<DeleteBranchMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<DeleteBranchMutation>(DeleteBranchDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'deleteBranch',
-        'mutation',
-        variables,
-      )
+    adminResetPassword(variables: AdminResetPasswordMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminResetPasswordMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AdminResetPasswordMutation>(AdminResetPasswordDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminResetPassword', 'mutation', variables);
     },
-    getBranchesForSelect(
-      variables: GetBranchesForSelectQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetBranchesForSelectQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetBranchesForSelectQuery>(GetBranchesForSelectDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getBranchesForSelect',
-        'query',
-        variables,
-      )
+    adminUsers(variables: AdminUsersQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminUsersQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AdminUsersQuery>(AdminUsersDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminUsers', 'query', variables);
     },
-    getBranchRevisionsForCreate(
-      variables: GetBranchRevisionsForCreateQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetBranchRevisionsForCreateQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetBranchRevisionsForCreateQuery>(GetBranchRevisionsForCreateDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getBranchRevisionsForCreate',
-        'query',
-        variables,
-      )
+    adminUser(variables: AdminUserQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminUserQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AdminUserQuery>(AdminUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminUser', 'query', variables);
     },
-    createBranch(
-      variables: CreateBranchMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateBranchMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateBranchMutation>(CreateBranchDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createBranch',
-        'mutation',
-        variables,
-      )
+    assetsTablesData(variables: AssetsTablesDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetsTablesDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AssetsTablesDataQuery>(AssetsTablesDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetsTablesData', 'query', variables);
     },
-    GetRevisionChanges(
-      variables: GetRevisionChangesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetRevisionChangesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetRevisionChangesQuery>(GetRevisionChangesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'GetRevisionChanges',
-        'query',
-        variables,
-      )
+    assetsRowsData(variables: AssetsRowsDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetsRowsDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AssetsRowsDataQuery>(AssetsRowsDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetsRowsData', 'query', variables);
     },
-    GetTableChanges(
-      variables: GetTableChangesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetTableChangesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetTableChangesQuery>(GetTableChangesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'GetTableChanges',
-        'query',
-        variables,
-      )
+    subSchemaItemsData(variables: SubSchemaItemsDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SubSchemaItemsDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SubSchemaItemsDataQuery>(SubSchemaItemsDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'subSchemaItemsData', 'query', variables);
     },
-    confirmEmailCode(
-      variables: ConfirmEmailCodeMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<ConfirmEmailCodeMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ConfirmEmailCodeMutation>(ConfirmEmailCodeDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'confirmEmailCode',
-        'mutation',
-        variables,
-      )
+    getProjectBranches(variables: GetProjectBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectBranchesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectBranchesQuery>(GetProjectBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectBranches', 'query', variables);
     },
-    getEndpointBranches(
-      variables: GetEndpointBranchesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetEndpointBranchesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetEndpointBranchesQuery>(GetEndpointBranchesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getEndpointBranches',
-        'query',
-        variables,
-      )
+    deleteBranch(variables: DeleteBranchMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteBranchMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteBranchMutation>(DeleteBranchDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteBranch', 'mutation', variables);
     },
-    getProjectEndpoints(
-      variables: GetProjectEndpointsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetProjectEndpointsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetProjectEndpointsQuery>(GetProjectEndpointsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getProjectEndpoints',
-        'query',
-        variables,
-      )
+    getBranchesForSelect(variables: GetBranchesForSelectQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchesForSelectQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchesForSelectQuery>(GetBranchesForSelectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchesForSelect', 'query', variables);
     },
-    getBranchRevisions(
-      variables: GetBranchRevisionsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetBranchRevisionsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetBranchRevisionsQuery>(GetBranchRevisionsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getBranchRevisions',
-        'query',
-        variables,
-      )
+    getBranchRevisionsForCreate(variables: GetBranchRevisionsForCreateQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchRevisionsForCreateQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchRevisionsForCreateQuery>(GetBranchRevisionsForCreateDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchRevisionsForCreate', 'query', variables);
     },
-    createEndpoint(
-      variables: CreateEndpointMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateEndpointMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateEndpointMutation>(CreateEndpointDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createEndpoint',
-        'mutation',
-        variables,
-      )
+    createBranch(variables: CreateBranchMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateBranchMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateBranchMutation>(CreateBranchDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createBranch', 'mutation', variables);
     },
-    deleteEndpoint(
-      variables: DeleteEndpointMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<DeleteEndpointMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<DeleteEndpointMutation>(DeleteEndpointDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'deleteEndpoint',
-        'mutation',
-        variables,
-      )
+    GetRevisionChanges(variables: GetRevisionChangesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRevisionChangesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetRevisionChangesQuery>(GetRevisionChangesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetRevisionChanges', 'query', variables);
     },
-    loginGithub(
-      variables: LoginGithubMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<LoginGithubMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<LoginGithubMutation>(LoginGithubDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'loginGithub',
-        'mutation',
-        variables,
-      )
+    GetTableChanges(variables: GetTableChangesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableChangesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetTableChangesQuery>(GetTableChangesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTableChanges', 'query', variables);
     },
-    loginGoogle(
-      variables: LoginGoogleMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<LoginGoogleMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<LoginGoogleMutation>(LoginGoogleDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'loginGoogle',
-        'mutation',
-        variables,
-      )
+    confirmEmailCode(variables: ConfirmEmailCodeMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ConfirmEmailCodeMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ConfirmEmailCodeMutation>(ConfirmEmailCodeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'confirmEmailCode', 'mutation', variables);
+    },
+    getEndpointBranches(variables: GetEndpointBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetEndpointBranchesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetEndpointBranchesQuery>(GetEndpointBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getEndpointBranches', 'query', variables);
+    },
+    getProjectEndpoints(variables: GetProjectEndpointsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectEndpointsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectEndpointsQuery>(GetProjectEndpointsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectEndpoints', 'query', variables);
+    },
+    getBranchRevisions(variables: GetBranchRevisionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchRevisionsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchRevisionsQuery>(GetBranchRevisionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchRevisions', 'query', variables);
+    },
+    createEndpoint(variables: CreateEndpointMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateEndpointMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateEndpointMutation>(CreateEndpointDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createEndpoint', 'mutation', variables);
+    },
+    deleteEndpoint(variables: DeleteEndpointMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteEndpointMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteEndpointMutation>(DeleteEndpointDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteEndpoint', 'mutation', variables);
+    },
+    loginGithub(variables: LoginGithubMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<LoginGithubMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<LoginGithubMutation>(LoginGithubDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'loginGithub', 'mutation', variables);
+    },
+    loginGoogle(variables: LoginGoogleMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<LoginGoogleMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<LoginGoogleMutation>(LoginGoogleDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'loginGoogle', 'mutation', variables);
     },
     login(variables: LoginMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<LoginMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<LoginMutation>(LoginDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
-        'login',
-        'mutation',
-        variables,
-      )
+      return withWrapper((wrappedRequestHeaders) => client.request<LoginMutation>(LoginDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'login', 'mutation', variables);
     },
-    getMigrationBranches(
-      variables: GetMigrationBranchesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetMigrationBranchesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetMigrationBranchesQuery>(GetMigrationBranchesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getMigrationBranches',
-        'query',
-        variables,
-      )
+    getMigrationBranches(variables: GetMigrationBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetMigrationBranchesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetMigrationBranchesQuery>(GetMigrationBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getMigrationBranches', 'query', variables);
     },
-    getBranchMigrations(
-      variables: GetBranchMigrationsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetBranchMigrationsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetBranchMigrationsQuery>(GetBranchMigrationsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getBranchMigrations',
-        'query',
-        variables,
-      )
+    getBranchMigrations(variables: GetBranchMigrationsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchMigrationsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchMigrationsQuery>(GetBranchMigrationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchMigrations', 'query', variables);
     },
-    applyMigrations(
-      variables: ApplyMigrationsMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<ApplyMigrationsMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ApplyMigrationsMutation>(ApplyMigrationsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'applyMigrations',
-        'mutation',
-        variables,
-      )
+    applyMigrations(variables: ApplyMigrationsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ApplyMigrationsMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ApplyMigrationsMutation>(ApplyMigrationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'applyMigrations', 'mutation', variables);
     },
-    getMigrations(
-      variables: GetMigrationsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetMigrationsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetMigrationsQuery>(GetMigrationsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getMigrations',
-        'query',
-        variables,
-      )
+    getMigrations(variables: GetMigrationsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetMigrationsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetMigrationsQuery>(GetMigrationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getMigrations', 'query', variables);
     },
-    activateEarlyAccess(
-      variables: ActivateEarlyAccessMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<ActivateEarlyAccessMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ActivateEarlyAccessMutation>(ActivateEarlyAccessDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'activateEarlyAccess',
-        'mutation',
-        variables,
-      )
+    activateEarlyAccess(variables: ActivateEarlyAccessMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ActivateEarlyAccessMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ActivateEarlyAccessMutation>(ActivateEarlyAccessDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'activateEarlyAccess', 'mutation', variables);
     },
-    createCheckout(
-      variables: CreateCheckoutMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateCheckoutMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateCheckoutMutation>(CreateCheckoutDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createCheckout',
-        'mutation',
-        variables,
-      )
+    createCheckout(variables: CreateCheckoutMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateCheckoutMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateCheckoutMutation>(CreateCheckoutDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createCheckout', 'mutation', variables);
     },
-    cancelSubscription(
-      variables: CancelSubscriptionMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CancelSubscriptionMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CancelSubscriptionMutation>(CancelSubscriptionDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'cancelSubscription',
-        'mutation',
-        variables,
-      )
+    cancelSubscription(variables: CancelSubscriptionMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CancelSubscriptionMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CancelSubscriptionMutation>(CancelSubscriptionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'cancelSubscription', 'mutation', variables);
     },
-    getLimitsPageData(
-      variables: GetLimitsPageDataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetLimitsPageDataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetLimitsPageDataQuery>(GetLimitsPageDataDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getLimitsPageData',
-        'query',
-        variables,
-      )
+    getLimitsPageData(variables: GetLimitsPageDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetLimitsPageDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetLimitsPageDataQuery>(GetLimitsPageDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getLimitsPageData', 'query', variables);
     },
-    getLimitsPagePlans(
-      variables?: GetLimitsPagePlansQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetLimitsPagePlansQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetLimitsPagePlansQuery>(GetLimitsPagePlansDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getLimitsPagePlans',
-        'query',
-        variables,
-      )
+    getLimitsPagePlans(variables?: GetLimitsPagePlansQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetLimitsPagePlansQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetLimitsPagePlansQuery>(GetLimitsPagePlansDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getLimitsPagePlans', 'query', variables);
     },
-    getUsersOrganization(
-      variables: GetUsersOrganizationQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetUsersOrganizationQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetUsersOrganizationQuery>(GetUsersOrganizationDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getUsersOrganization',
-        'query',
-        variables,
-      )
+    getUsersOrganization(variables: GetUsersOrganizationQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetUsersOrganizationQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetUsersOrganizationQuery>(GetUsersOrganizationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUsersOrganization', 'query', variables);
     },
-    addUserToOrganization(
-      variables: AddUserToOrganizationMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AddUserToOrganizationMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AddUserToOrganizationMutation>(AddUserToOrganizationDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'addUserToOrganization',
-        'mutation',
-        variables,
-      )
+    addUserToOrganization(variables: AddUserToOrganizationMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AddUserToOrganizationMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AddUserToOrganizationMutation>(AddUserToOrganizationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'addUserToOrganization', 'mutation', variables);
     },
-    removeUserFromOrganization(
-      variables: RemoveUserFromOrganizationMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RemoveUserFromOrganizationMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RemoveUserFromOrganizationMutation>(RemoveUserFromOrganizationDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'removeUserFromOrganization',
-        'mutation',
-        variables,
-      )
+    removeUserFromOrganization(variables: RemoveUserFromOrganizationMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RemoveUserFromOrganizationMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RemoveUserFromOrganizationMutation>(RemoveUserFromOrganizationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'removeUserFromOrganization', 'mutation', variables);
     },
-    updateProject(
-      variables: UpdateProjectMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<UpdateProjectMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<UpdateProjectMutation>(UpdateProjectDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'updateProject',
-        'mutation',
-        variables,
-      )
+    updateProject(variables: UpdateProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateProjectMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpdateProjectMutation>(UpdateProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateProject', 'mutation', variables);
     },
-    deleteProjectForSettings(
-      variables: DeleteProjectForSettingsMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<DeleteProjectForSettingsMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<DeleteProjectForSettingsMutation>(DeleteProjectForSettingsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'deleteProjectForSettings',
-        'mutation',
-        variables,
-      )
+    deleteProjectForSettings(variables: DeleteProjectForSettingsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteProjectForSettingsMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteProjectForSettingsMutation>(DeleteProjectForSettingsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteProjectForSettings', 'mutation', variables);
     },
-    fetchTableForStack(
-      variables: FetchTableForStackQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<FetchTableForStackQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<FetchTableForStackQuery>(FetchTableForStackDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'fetchTableForStack',
-        'query',
-        variables,
-      )
+    fetchTableForStack(variables: FetchTableForStackQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FetchTableForStackQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<FetchTableForStackQuery>(FetchTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'fetchTableForStack', 'query', variables);
     },
-    createTableForStack(
-      variables: CreateTableForStackMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateTableForStackMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateTableForStackMutation>(CreateTableForStackDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createTableForStack',
-        'mutation',
-        variables,
-      )
+    createTableForStack(variables: CreateTableForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateTableForStackMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateTableForStackMutation>(CreateTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createTableForStack', 'mutation', variables);
     },
-    updateTableForStack(
-      variables: UpdateTableForStackMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<UpdateTableForStackMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<UpdateTableForStackMutation>(UpdateTableForStackDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'updateTableForStack',
-        'mutation',
-        variables,
-      )
+    updateTableForStack(variables: UpdateTableForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateTableForStackMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpdateTableForStackMutation>(UpdateTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateTableForStack', 'mutation', variables);
     },
-    renameTableForStack(
-      variables: RenameTableForStackMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RenameTableForStackMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RenameTableForStackMutation>(RenameTableForStackDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'renameTableForStack',
-        'mutation',
-        variables,
-      )
+    renameTableForStack(variables: RenameTableForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RenameTableForStackMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RenameTableForStackMutation>(RenameTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'renameTableForStack', 'mutation', variables);
     },
-    rowPageData(
-      variables: RowPageDataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RowPageDataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RowPageDataQuery>(RowPageDataDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'rowPageData',
-        'query',
-        variables,
-      )
+    rowPageData(variables: RowPageDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RowPageDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RowPageDataQuery>(RowPageDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'rowPageData', 'query', variables);
     },
     signUp(variables: SignUpMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SignUpMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<SignUpMutation>(SignUpDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
-        'signUp',
-        'mutation',
-        variables,
-      )
+      return withWrapper((wrappedRequestHeaders) => client.request<SignUpMutation>(SignUpDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'signUp', 'mutation', variables);
     },
-    setUsername(
-      variables: SetUsernameMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<SetUsernameMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<SetUsernameMutation>(SetUsernameDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'setUsername',
-        'mutation',
-        variables,
-      )
+    setUsername(variables: SetUsernameMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SetUsernameMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SetUsernameMutation>(SetUsernameDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'setUsername', 'mutation', variables);
     },
-    getUsersProject(
-      variables: GetUsersProjectQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetUsersProjectQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetUsersProjectQuery>(GetUsersProjectDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getUsersProject',
-        'query',
-        variables,
-      )
+    getUsersProject(variables: GetUsersProjectQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetUsersProjectQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetUsersProjectQuery>(GetUsersProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUsersProject', 'query', variables);
     },
-    searchUsers(
-      variables: SearchUsersQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<SearchUsersQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<SearchUsersQuery>(SearchUsersDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'searchUsers',
-        'query',
-        variables,
-      )
+    searchUsers(variables: SearchUsersQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SearchUsersQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SearchUsersQuery>(SearchUsersDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'searchUsers', 'query', variables);
     },
-    addUserToProject(
-      variables: AddUserToProjectMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<AddUserToProjectMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<AddUserToProjectMutation>(AddUserToProjectDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'addUserToProject',
-        'mutation',
-        variables,
-      )
+    addUserToProject(variables: AddUserToProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AddUserToProjectMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AddUserToProjectMutation>(AddUserToProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'addUserToProject', 'mutation', variables);
     },
-    removeUserFromProject(
-      variables: RemoveUserFromProjectMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RemoveUserFromProjectMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RemoveUserFromProjectMutation>(RemoveUserFromProjectDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'removeUserFromProject',
-        'mutation',
-        variables,
-      )
+    removeUserFromProject(variables: RemoveUserFromProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RemoveUserFromProjectMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RemoveUserFromProjectMutation>(RemoveUserFromProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'removeUserFromProject', 'mutation', variables);
     },
-    updateUserProjectRole(
-      variables: UpdateUserProjectRoleMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<UpdateUserProjectRoleMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<UpdateUserProjectRoleMutation>(UpdateUserProjectRoleDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'updateUserProjectRole',
-        'mutation',
-        variables,
-      )
+    updateUserProjectRole(variables: UpdateUserProjectRoleMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateUserProjectRoleMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpdateUserProjectRoleMutation>(UpdateUserProjectRoleDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateUserProjectRole', 'mutation', variables);
     },
-    createUser(
-      variables: CreateUserMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateUserMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateUserMutation>(CreateUserDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createUser',
-        'mutation',
-        variables,
-      )
+    createUser(variables: CreateUserMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateUserMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateUserMutation>(CreateUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createUser', 'mutation', variables);
     },
-    configuration(
-      variables?: ConfigurationQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<ConfigurationQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ConfigurationQuery>(ConfigurationDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'configuration',
-        'query',
-        variables,
-      )
+    configuration(variables?: ConfigurationQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ConfigurationQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ConfigurationQuery>(ConfigurationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'configuration', 'query', variables);
     },
     getMe(variables?: GetMeQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetMeQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetMeQuery>(GetMeDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
-        'getMe',
-        'query',
-        variables,
-      )
+      return withWrapper((wrappedRequestHeaders) => client.request<GetMeQuery>(GetMeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getMe', 'query', variables);
     },
-    getProjectGraph(
-      variables: GetProjectGraphQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetProjectGraphQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetProjectGraphQuery>(GetProjectGraphDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'getProjectGraph',
-        'query',
-        variables,
-      )
+    getProjectGraph(variables: GetProjectGraphQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectGraphQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectGraphQuery>(GetProjectGraphDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectGraph', 'query', variables);
     },
-    findBranches(
-      variables: FindBranchesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<FindBranchesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<FindBranchesQuery>(FindBranchesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'findBranches',
-        'query',
-        variables,
-      )
+    findBranches(variables: FindBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FindBranchesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<FindBranchesQuery>(FindBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'findBranches', 'query', variables);
     },
-    findRevisions(
-      variables: FindRevisionsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<FindRevisionsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<FindRevisionsQuery>(FindRevisionsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'findRevisions',
-        'query',
-        variables,
-      )
+    findRevisions(variables: FindRevisionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FindRevisionsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<FindRevisionsQuery>(FindRevisionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'findRevisions', 'query', variables);
     },
-    meProjectsList(
-      variables: MeProjectsListQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<MeProjectsListQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<MeProjectsListQuery>(MeProjectsListDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'meProjectsList',
-        'query',
-        variables,
-      )
+    meProjectsList(variables: MeProjectsListQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MeProjectsListQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<MeProjectsListQuery>(MeProjectsListDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'meProjectsList', 'query', variables);
     },
-    GetRowChanges(
-      variables: GetRowChangesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetRowChangesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetRowChangesQuery>(GetRowChangesDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'GetRowChanges',
-        'query',
-        variables,
-      )
+    GetRowChanges(variables: GetRowChangesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRowChangesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetRowChangesQuery>(GetRowChangesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetRowChanges', 'query', variables);
     },
-    GetTableChangesForFilter(
-      variables: GetTableChangesForFilterQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetTableChangesForFilterQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetTableChangesForFilterQuery>(GetTableChangesForFilterDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'GetTableChangesForFilter',
-        'query',
-        variables,
-      )
+    GetTableChangesForFilter(variables: GetTableChangesForFilterQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableChangesForFilterQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetTableChangesForFilterQuery>(GetTableChangesForFilterDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTableChangesForFilter', 'query', variables);
     },
-    foreignKeyTableWithRows(
-      variables: ForeignKeyTableWithRowsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<ForeignKeyTableWithRowsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ForeignKeyTableWithRowsQuery>(ForeignKeyTableWithRowsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'foreignKeyTableWithRows',
-        'query',
-        variables,
-      )
+    foreignKeyTableWithRows(variables: ForeignKeyTableWithRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ForeignKeyTableWithRowsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ForeignKeyTableWithRowsQuery>(ForeignKeyTableWithRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'foreignKeyTableWithRows', 'query', variables);
     },
-    createRowForStack(
-      variables: CreateRowForStackMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateRowForStackMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateRowForStackMutation>(CreateRowForStackDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createRowForStack',
-        'mutation',
-        variables,
-      )
+    createRowForStack(variables: CreateRowForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateRowForStackMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateRowForStackMutation>(CreateRowForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createRowForStack', 'mutation', variables);
     },
-    updateRowForStack(
-      variables: UpdateRowForStackMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<UpdateRowForStackMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<UpdateRowForStackMutation>(UpdateRowForStackDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'updateRowForStack',
-        'mutation',
-        variables,
-      )
+    updateRowForStack(variables: UpdateRowForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateRowForStackMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpdateRowForStackMutation>(UpdateRowForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateRowForStack', 'mutation', variables);
     },
-    renameRowForStack(
-      variables: RenameRowForStackMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RenameRowForStackMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RenameRowForStackMutation>(RenameRowForStackDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'renameRowForStack',
-        'mutation',
-        variables,
-      )
+    renameRowForStack(variables: RenameRowForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RenameRowForStackMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RenameRowForStackMutation>(RenameRowForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'renameRowForStack', 'mutation', variables);
     },
-    RowListRows(
-      variables: RowListRowsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RowListRowsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RowListRowsQuery>(RowListRowsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'RowListRows',
-        'query',
-        variables,
-      )
+    RowListRows(variables: RowListRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RowListRowsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RowListRowsQuery>(RowListRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'RowListRows', 'query', variables);
     },
-    DeleteRow(
-      variables: DeleteRowMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<DeleteRowMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<DeleteRowMutation>(DeleteRowDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'DeleteRow',
-        'mutation',
-        variables,
-      )
+    DeleteRow(variables: DeleteRowMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteRowMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteRowMutation>(DeleteRowDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'DeleteRow', 'mutation', variables);
     },
-    DeleteRows(
-      variables: DeleteRowsMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<DeleteRowsMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<DeleteRowsMutation>(DeleteRowsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'DeleteRows',
-        'mutation',
-        variables,
-      )
+    DeleteRows(variables: DeleteRowsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteRowsMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteRowsMutation>(DeleteRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'DeleteRows', 'mutation', variables);
     },
-    PatchRowInline(
-      variables: PatchRowInlineMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<PatchRowInlineMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PatchRowInlineMutation>(PatchRowInlineDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'PatchRowInline',
-        'mutation',
-        variables,
-      )
+    PatchRowInline(variables: PatchRowInlineMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PatchRowInlineMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PatchRowInlineMutation>(PatchRowInlineDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PatchRowInline', 'mutation', variables);
     },
-    GetTableViews(
-      variables: GetTableViewsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<GetTableViewsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<GetTableViewsQuery>(GetTableViewsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'GetTableViews',
-        'query',
-        variables,
-      )
+    GetTableViews(variables: GetTableViewsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableViewsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetTableViewsQuery>(GetTableViewsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTableViews', 'query', variables);
     },
-    UpdateTableViews(
-      variables: UpdateTableViewsMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<UpdateTableViewsMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<UpdateTableViewsMutation>(UpdateTableViewsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'UpdateTableViews',
-        'mutation',
-        variables,
-      )
+    UpdateTableViews(variables: UpdateTableViewsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateTableViewsMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpdateTableViewsMutation>(UpdateTableViewsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'UpdateTableViews', 'mutation', variables);
     },
-    searchRows(
-      variables: SearchRowsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<SearchRowsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<SearchRowsQuery>(SearchRowsDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'searchRows',
-        'query',
-        variables,
-      )
+    searchRows(variables: SearchRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SearchRowsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SearchRowsQuery>(SearchRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'searchRows', 'query', variables);
     },
-    revertChangesForSidebar(
-      variables: RevertChangesForSidebarMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<RevertChangesForSidebarMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<RevertChangesForSidebarMutation>(RevertChangesForSidebarDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'revertChangesForSidebar',
-        'mutation',
-        variables,
-      )
+    revertChangesForSidebar(variables: RevertChangesForSidebarMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RevertChangesForSidebarMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RevertChangesForSidebarMutation>(RevertChangesForSidebarDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'revertChangesForSidebar', 'mutation', variables);
     },
-    createRevisionForSidebar(
-      variables: CreateRevisionForSidebarMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateRevisionForSidebarMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateRevisionForSidebarMutation>(CreateRevisionForSidebarDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createRevisionForSidebar',
-        'mutation',
-        variables,
-      )
+    createRevisionForSidebar(variables: CreateRevisionForSidebarMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateRevisionForSidebarMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateRevisionForSidebarMutation>(CreateRevisionForSidebarDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createRevisionForSidebar', 'mutation', variables);
     },
-    createBranchForSidebar(
-      variables: CreateBranchForSidebarMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<CreateBranchForSidebarMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<CreateBranchForSidebarMutation>(CreateBranchForSidebarDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'createBranchForSidebar',
-        'mutation',
-        variables,
-      )
+    createBranchForSidebar(variables: CreateBranchForSidebarMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateBranchForSidebarMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<CreateBranchForSidebarMutation>(CreateBranchForSidebarDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createBranchForSidebar', 'mutation', variables);
     },
-    deleteTableForList(
-      variables: DeleteTableForListMutationVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<DeleteTableForListMutation> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<DeleteTableForListMutation>(DeleteTableForListDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'deleteTableForList',
-        'mutation',
-        variables,
-      )
+    deleteTableForList(variables: DeleteTableForListMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteTableForListMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<DeleteTableForListMutation>(DeleteTableForListDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteTableForList', 'mutation', variables);
     },
-    tableListData(
-      variables: TableListDataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<TableListDataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<TableListDataQuery>(TableListDataDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'tableListData',
-        'query',
-        variables,
-      )
+    tableListData(variables: TableListDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<TableListDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<TableListDataQuery>(TableListDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'tableListData', 'query', variables);
     },
-    tableRelationsData(
-      variables: TableRelationsDataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<TableRelationsDataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<TableRelationsDataQuery>(TableRelationsDataDocument, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'tableRelationsData',
-        'query',
-        variables,
-      )
-    },
-  }
+    tableRelationsData(variables: TableRelationsDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<TableRelationsDataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<TableRelationsDataQuery>(TableRelationsDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'tableRelationsData', 'query', variables);
+    }
+  };
 }
-export type Sdk = ReturnType<typeof getSdk>
+export type Sdk = ReturnType<typeof getSdk>;

--- a/src/__generated__/schema.graphql
+++ b/src/__generated__/schema.graphql
@@ -37,15 +37,42 @@ input AdminUserInput {
   userId: String!
 }
 
+type ApiKeyModel {
+  allowedIps: [String!]!
+  branchNames: [String!]!
+  createdAt: DateTime!
+  expiresAt: DateTime
+  id: ID!
+  lastUsedAt: DateTime
+  name: String!
+  organizationId: String
+  permissions: JSON
+  prefix: String!
+  projectIds: [String!]!
+  readOnly: Boolean!
+  revokedAt: DateTime
+  tableIds: [String!]!
+  type: ApiKeyType!
+}
+
+enum ApiKeyType {
+  INTERNAL
+  PERSONAL
+  SERVICE
+}
+
+type ApiKeyWithSecretModel {
+  apiKey: ApiKeyModel!
+  secret: String!
+}
+
 type ApplyMigrationResultModel {
   error: String
   id: String!
   status: ApplyMigrationStatus!
 }
 
-"""
-Status of migration application
-"""
+"""Status of migration application"""
 enum ApplyMigrationStatus {
   applied
   failed
@@ -105,6 +132,18 @@ input CancelSubscriptionInput {
   organizationId: ID!
 }
 
+input CaslPermissionsInput {
+  rules: [CaslRuleInput!]!
+}
+
+input CaslRuleInput {
+  action: [String!]!
+  conditions: JSONObject
+  fields: [String!]
+  inverted: Boolean
+  subject: [String!]!
+}
+
 enum ChangeType {
   ADDED
   MODIFIED
@@ -156,6 +195,17 @@ input CreateEndpointInput {
   type: EndpointType!
 }
 
+input CreatePersonalApiKeyInput {
+  allowedIps: [String!]
+  branchNames: [String!]
+  expiresAt: DateTime
+  name: String!
+  organizationId: String
+  projectIds: [String!]
+  readOnly: Boolean = false
+  tableIds: [String!]
+}
+
 input CreateProjectInput {
   branchName: String
   fromRevisionId: String
@@ -199,6 +249,18 @@ type CreateRowsResultModel {
 input CreateRowsRowInput {
   data: JSON!
   rowId: String!
+}
+
+input CreateServiceApiKeyInput {
+  allowedIps: [String!]
+  branchNames: [String!]
+  expiresAt: DateTime
+  name: String!
+  organizationId: String!
+  permissions: CaslPermissionsInput!
+  projectIds: [String!]
+  readOnly: Boolean = false
+  tableIds: [String!]
 }
 
 input CreateTableInput {
@@ -333,9 +395,7 @@ input GetBranchRevisionsInput {
   comment: String
   first: Int!
   inclusive: Boolean
-  """
-  Sort order: asc (default) or desc
-  """
+  """Sort order: asc (default) or desc"""
   sort: SortOrder
 }
 
@@ -506,6 +566,11 @@ The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://
 """
 scalar JSON
 
+"""
+The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+"""
+scalar JSONObject
+
 input JsonFilter {
   array_contains: [JSON!]
   array_ends_with: JSON
@@ -519,9 +584,7 @@ input JsonFilter {
   path: [String!]
   search: String
   searchIn: SearchIn
-  """
-  Default: simple
-  """
+  """Default: simple"""
   searchLanguage: SearchLanguage
   searchType: SearchType
   string_contains: String
@@ -598,10 +661,12 @@ type Mutation {
   createBranch(data: CreateBranchInput!): BranchModel!
   createCheckout(data: CreateCheckoutInput!): CheckoutResultModel!
   createEndpoint(data: CreateEndpointInput!): EndpointModel!
+  createPersonalApiKey(data: CreatePersonalApiKeyInput!): ApiKeyWithSecretModel!
   createProject(data: CreateProjectInput!): ProjectModel!
   createRevision(data: CreateRevisionInput!): RevisionModel!
   createRow(data: CreateRowInput!): CreateRowResultModel!
   createRows(data: CreateRowsInput!): CreateRowsResultModel!
+  createServiceApiKey(data: CreateServiceApiKeyInput!): ApiKeyWithSecretModel!
   createTable(data: CreateTableInput!): CreateTableResultModel!
   createUser(data: CreateUserInput!): Boolean!
   deleteBranch(data: DeleteBranchInput!): Boolean!
@@ -621,6 +686,8 @@ type Mutation {
   renameTable(data: RenameTableInput!): RenameTableResultModel!
   resetPassword(data: ResetPasswordInput!): Boolean!
   revertChanges(data: RevertChangesInput!): BranchModel!
+  revokeApiKey(id: ID!): ApiKeyModel!
+  rotateApiKey(id: ID!): ApiKeyWithSecretModel!
   setUsername(data: SetUsernameInput!): Boolean!
   signUp(data: SignUpInput!): Boolean!
   updatePassword(data: UpdatePasswordInput!): Boolean!
@@ -746,10 +813,13 @@ type PermissionModel {
 
 type PlanLimitsModel {
   apiCallsPerDay: Int
+  branchesPerProject: Int
   projects: Int
   rowVersions: Int
+  rowsPerTable: Int
   seats: Int
   storageBytes: Float
+  tablesPerRevision: Int
 }
 
 type PlanModel {
@@ -792,14 +862,15 @@ type ProjectsConnection {
 type Query {
   adminUser(data: AdminUserInput!): UserModel
   adminUsers(data: SearchUsersInput!): UsersConnection!
+  apiKeyById(id: ID!): ApiKeyModel!
   availableProviders(country: String, method: String): [PaymentProviderModel!]!
   branch(data: GetBranchInput!): BranchModel!
   branches(data: GetBranchesInput!): BranchesConnection!
   configuration: ConfigurationModel!
-  getRowCountForeignKeysTo(data: GetRowCountForeignKeysByInput!): Int!
-    @deprecated(reason: "use RowModel.rowForeignKeysBy.totalCount")
+  getRowCountForeignKeysTo(data: GetRowCountForeignKeysByInput!): Int! @deprecated(reason: "use RowModel.rowForeignKeysBy.totalCount")
   me: MeModel!
   meProjects(data: GetMeProjectsInput!): ProjectsConnection!
+  myApiKeys: [ApiKeyModel!]!
   organization(data: GetOrganizationInput!): OrganizationModel!
   plans: [PlanModel!]!
   project(data: GetProjectInput!): ProjectModel!
@@ -812,6 +883,7 @@ type Query {
   rows(data: GetRowsInput!): RowsConnection!
   searchRows(data: SearchRowsInput!): SearchResultsConnection!
   searchUsers(data: SearchUsersInput!): SearchUsersConnection!
+  serviceApiKeys(organizationId: String!): [ApiKeyModel!]!
   subSchemaItems(data: GetSubSchemaItemsInput!): SubSchemaItemsConnection!
   table(data: GetTableInput!): TableModel
   tableChanges(data: GetTableChangesInput!): TableChangesConnection!
@@ -1037,9 +1109,7 @@ enum SearchIn {
   values
 }
 
-"""
-Language for full-text search. Default: simple
-"""
+"""Language for full-text search. Default: simple"""
 enum SearchLanguage {
   arabic
   armenian

--- a/src/app/config/rootRoutes.tsx
+++ b/src/app/config/rootRoutes.tsx
@@ -24,6 +24,7 @@ import { OrganizationSettingsPage } from 'src/pages/OrganizationSettingsPage'
 import { OrganizationMembersPage } from 'src/pages/OrganizationMembersPage'
 import { OrganizationLimitsPage } from 'src/pages/OrganizationLimitsPage'
 import { ProjectLayout } from 'src/pages/ProjectLayout'
+import { ProjectApiKeysPage } from 'src/pages/ProjectApiKeysPage'
 import { ProjectSettingsPage } from 'src/pages/ProjectSettingsPage'
 import { UsersPage } from 'src/pages/UsersPage'
 
@@ -216,7 +217,7 @@ const organizationRouteObject = {
         },
         {
           path: PROJECT_API_KEYS_ROUTE,
-          element: <div>Project API Keys Page</div>,
+          element: <ProjectApiKeysPage />,
           id: RouteIds.ProjectApiKeys,
         },
         {

--- a/src/entities/ApiKey/index.ts
+++ b/src/entities/ApiKey/index.ts
@@ -1,0 +1,3 @@
+export { ApiKeyModel, type ResolvedProject } from './model/ApiKeyModel.ts'
+export { ApiKeyStatusBadge } from './ui/ApiKeyStatusBadge.tsx'
+export { ApiKeyRow } from './ui/ApiKeyRow.tsx'

--- a/src/entities/ApiKey/model/ApiKeyModel.ts
+++ b/src/entities/ApiKey/model/ApiKeyModel.ts
@@ -1,0 +1,119 @@
+import { makeAutoObservable } from 'mobx'
+import { ApiKeyFieldsFragment } from 'src/__generated__/graphql-request.ts'
+
+export interface ResolvedProject {
+  id: string
+  name: string
+}
+
+export class ApiKeyModel {
+  private _projectNameResolver: ((id: string) => string) | null = null
+
+  constructor(public readonly data: ApiKeyFieldsFragment) {
+    makeAutoObservable(this)
+  }
+
+  public setProjectNameResolver(resolver: (id: string) => string): void {
+    this._projectNameResolver = resolver
+  }
+
+  public get id(): string {
+    return this.data.id
+  }
+
+  public get name(): string {
+    return this.data.name
+  }
+
+  public get prefix(): string {
+    return this.data.prefix
+  }
+
+  public get type(): string {
+    return this.data.type
+  }
+
+  public get isExpired(): boolean {
+    if (!this.data.expiresAt) {
+      return false
+    }
+    return new Date(this.data.expiresAt) < new Date()
+  }
+
+  public get isRevoked(): boolean {
+    return this.data.revokedAt !== null
+  }
+
+  public get isActive(): boolean {
+    return !this.isExpired && !this.isRevoked
+  }
+
+  public get statusLabel(): 'Active' | 'Expired' | 'Revoked' {
+    if (this.isRevoked) {
+      return 'Revoked'
+    }
+    if (this.isExpired) {
+      return 'Expired'
+    }
+    return 'Active'
+  }
+
+  public get lastUsedAt(): string | null {
+    return this.data.lastUsedAt ?? null
+  }
+
+  public get createdAt(): string {
+    return this.data.createdAt
+  }
+
+  public get expiresAt(): string | null {
+    return this.data.expiresAt ?? null
+  }
+
+  public get readOnly(): boolean {
+    return this.data.readOnly
+  }
+
+  public get organizationId(): string | null {
+    return this.data.organizationId ?? null
+  }
+
+  public get projectIds(): string[] {
+    return this.data.projectIds
+  }
+
+  public get resolvedProjects(): ResolvedProject[] {
+    return this.data.projectIds.map((id) => ({
+      id,
+      name: this._projectNameResolver?.(id) ?? id,
+    }))
+  }
+
+  public get permissionLabel(): string {
+    if (this.data.type === 'PERSONAL') {
+      return this.data.readOnly ? 'Read only' : 'Full access'
+    }
+
+    const permissions = this.data.permissions as { rules?: { action?: string[] }[] } | null
+    const actions = permissions?.rules?.[0]?.action ?? []
+
+    if (actions.includes('delete')) {
+      return 'Full access'
+    }
+    if (actions.includes('create') || actions.includes('update')) {
+      return 'Read & Write'
+    }
+    return 'Read only'
+  }
+
+  public get permissionColorPalette(): string {
+    switch (this.permissionLabel) {
+      case 'Full access':
+        return 'orange'
+      case 'Read & Write':
+        return 'blue'
+      default:
+        return 'gray'
+    }
+  }
+}

--- a/src/entities/ApiKey/ui/ApiKeyRow.tsx
+++ b/src/entities/ApiKey/ui/ApiKeyRow.tsx
@@ -1,0 +1,95 @@
+import { Badge, Box, Flex, HStack, Text } from '@chakra-ui/react'
+import { FC, ReactNode } from 'react'
+import { ResolvedProject } from 'src/entities/ApiKey/model/ApiKeyModel.ts'
+import { formatDate } from 'src/shared/lib/helpers'
+import { formatRelativeTime } from 'src/shared/lib/helpers/formatRelativeTime.ts'
+import { ApiKeyStatusBadge } from './ApiKeyStatusBadge.tsx'
+
+interface ApiKeyRowProps {
+  name: string
+  prefix: string
+  status: 'Active' | 'Expired' | 'Revoked'
+  permissionLabel: string
+  permissionColor: string
+  projects: ResolvedProject[]
+  lastUsedAt: string | null
+  createdAt: string
+  expiresAt: string | null
+  actions?: ReactNode
+}
+
+export const ApiKeyRow: FC<ApiKeyRowProps> = ({
+  name,
+  prefix,
+  status,
+  permissionLabel,
+  permissionColor,
+  projects,
+  lastUsedAt,
+  createdAt,
+  expiresAt,
+  actions,
+}) => {
+  return (
+    <Box
+      width="100%"
+      p={4}
+      borderWidth="1px"
+      borderColor="gray.200"
+      borderRadius="lg"
+      bg="white"
+      transition="all 0.2s"
+      _hover={{ borderColor: 'gray.300' }}
+    >
+      <Flex justify="space-between" align="center">
+        <Flex flexDirection="column" gap={1} flex={1} minWidth={0}>
+          <HStack gap={2}>
+            <Text fontSize="sm" fontWeight="600" color="gray.700" truncate>
+              {name}
+            </Text>
+            {status !== 'Active' && <ApiKeyStatusBadge status={status} />}
+            <Badge variant="outline" colorPalette={permissionColor} size="sm">
+              {permissionLabel}
+            </Badge>
+          </HStack>
+
+          <HStack gap={2}>
+            <Text fontSize="xs" fontFamily="mono" color="gray.400">
+              {prefix}
+            </Text>
+            {projects.length > 0 && (
+              <HStack gap={1}>
+                {projects.map((p) => (
+                  <Badge key={p.id} variant="outline" colorPalette="gray" size="sm">
+                    {p.name}
+                  </Badge>
+                ))}
+              </HStack>
+            )}
+            {projects.length === 0 && (
+              <Badge variant="outline" colorPalette="gray" size="sm">
+                All projects
+              </Badge>
+            )}
+          </HStack>
+
+          <HStack gap={4} mt={1} flexWrap="wrap">
+            <Text fontSize="xs" color="gray.500">
+              Created {formatDate(createdAt)}
+            </Text>
+            {expiresAt && (
+              <Text fontSize="xs" color="gray.500">
+                Expires {formatDate(expiresAt)}
+              </Text>
+            )}
+            <Text fontSize="xs" color="gray.500">
+              {lastUsedAt ? `Last used ${formatRelativeTime(lastUsedAt)}` : 'Never used'}
+            </Text>
+          </HStack>
+        </Flex>
+
+        {actions && <HStack gap={1}>{actions}</HStack>}
+      </Flex>
+    </Box>
+  )
+}

--- a/src/entities/ApiKey/ui/ApiKeyStatusBadge.tsx
+++ b/src/entities/ApiKey/ui/ApiKeyStatusBadge.tsx
@@ -1,0 +1,22 @@
+import { Badge } from '@chakra-ui/react'
+import { FC } from 'react'
+
+interface ApiKeyStatusBadgeProps {
+  status: 'Active' | 'Expired' | 'Revoked'
+}
+
+const statusConfig = {
+  Active: { colorPalette: 'green' },
+  Expired: { colorPalette: 'yellow' },
+  Revoked: { colorPalette: 'gray' },
+} as const
+
+export const ApiKeyStatusBadge: FC<ApiKeyStatusBadgeProps> = ({ status }) => {
+  const config = statusConfig[status]
+
+  return (
+    <Badge variant="subtle" colorPalette={config.colorPalette} size="sm">
+      {status}
+    </Badge>
+  )
+}

--- a/src/entities/Navigation/model/LinkMaker.ts
+++ b/src/entities/Navigation/model/LinkMaker.ts
@@ -9,6 +9,8 @@ import {
   ENDPOINTS_ROUTE,
   MIGRATIONS_ROUTE,
   ORGANIZATION_ROUTE,
+  ORGANIZATION_SETTINGS_ROUTE,
+  PROJECT_API_KEYS_ROUTE,
   PROJECT_MCP_ROUTE,
   PROJECT_ROUTE,
   PROJECT_SETTINGS_ROUTE,
@@ -126,6 +128,25 @@ export class LinkMaker {
     return generatePath(`/${APP_ROUTE}/${ORGANIZATION_ROUTE}/${PROJECT_ROUTE}/${PROJECT_MCP_ROUTE}`, {
       organizationId: this.organizationId,
       projectName: this.projectName,
+    })
+  }
+
+  public makeProjectApiKeysLink(): string {
+    if (!this.organizationId || !this.projectName) {
+      return ''
+    }
+    return generatePath(`/${APP_ROUTE}/${ORGANIZATION_ROUTE}/${PROJECT_ROUTE}/${PROJECT_API_KEYS_ROUTE}`, {
+      organizationId: this.organizationId,
+      projectName: this.projectName,
+    })
+  }
+
+  public makeOrganizationSettingsLink(): string {
+    if (!this.organizationId) {
+      return ''
+    }
+    return generatePath(`/${APP_ROUTE}/${ORGANIZATION_ROUTE}/${ORGANIZATION_SETTINGS_ROUTE}`, {
+      organizationId: this.organizationId,
     })
   }
 

--- a/src/features/AccountSettings/model/AccountSettingsViewModel.ts
+++ b/src/features/AccountSettings/model/AccountSettingsViewModel.ts
@@ -1,15 +1,17 @@
 import { makeAutoObservable } from 'mobx'
+import { ApiKeyManagerViewModel } from 'src/features/ApiKeyManager'
 import { IViewModel } from 'src/shared/config/types.ts'
 import { LOGOUT_ROUTE } from 'src/shared/config/routes.ts'
 import { container } from 'src/shared/lib/DIContainer.ts'
 import { AuthService } from 'src/shared/model'
 import { AccountSettingsDataSource } from './AccountSettingsDataSource.ts'
 
-type ActiveTab = 'account' | 'password'
+type ActiveTab = 'account' | 'password' | 'api-keys'
 
 export class AccountSettingsViewModel implements IViewModel {
   private _isOpen = false
   private _activeTab: ActiveTab = 'account'
+  public readonly apiKeyManager: ApiKeyManagerViewModel
 
   public oldPassword = ''
   public newPassword = ''
@@ -18,8 +20,11 @@ export class AccountSettingsViewModel implements IViewModel {
   constructor(
     private readonly dataSource: AccountSettingsDataSource,
     private readonly authService: AuthService,
+    apiKeyManager: ApiKeyManagerViewModel,
   ) {
     makeAutoObservable(this, {}, { autoBind: true })
+    this.apiKeyManager = apiKeyManager
+    this.apiKeyManager.configure({ mode: 'personal' })
   }
 
   public get isOpen(): boolean {
@@ -142,6 +147,7 @@ export class AccountSettingsViewModel implements IViewModel {
 
   public dispose(): void {
     this.dataSource.dispose()
+    this.apiKeyManager.dispose()
   }
 }
 
@@ -150,7 +156,8 @@ container.register(
   () => {
     const dataSource = container.get(AccountSettingsDataSource)
     const authService = container.get(AuthService)
-    return new AccountSettingsViewModel(dataSource, authService)
+    const apiKeyManager = container.get(ApiKeyManagerViewModel)
+    return new AccountSettingsViewModel(dataSource, authService, apiKeyManager)
   },
   { scope: 'singleton' },
 )

--- a/src/features/AccountSettings/ui/AccountSettingsDialog/AccountSettingsDialog.tsx
+++ b/src/features/AccountSettings/ui/AccountSettingsDialog/AccountSettingsDialog.tsx
@@ -11,7 +11,8 @@ import {
 } from '@chakra-ui/react/dialog'
 import { observer } from 'mobx-react-lite'
 import { FC, useCallback } from 'react'
-import { PiSignOutLight, PiUserLight, PiLockLight } from 'react-icons/pi'
+import { PiKeyLight, PiSignOutLight, PiUserLight, PiLockLight } from 'react-icons/pi'
+import { ApiKeyList } from 'src/features/ApiKeyManager'
 import { toaster } from 'src/shared/ui'
 import { AccountSettingsViewModel } from '../../model/AccountSettingsViewModel.ts'
 
@@ -40,7 +41,9 @@ export const AccountSettingsDialog: FC<AccountSettingsDialogProps> = observer(({
             <DialogBody>
               <Tabs.Root
                 value={model.activeTab}
-                onValueChange={({ value }) => model.setActiveTab(value as 'account' | 'password')}
+                onValueChange={({ value }) => model.setActiveTab(value as 'account' | 'password' | 'api-keys')}
+                lazyMount
+                unmountOnExit
               >
                 <Tabs.List marginBottom="1rem">
                   <Tabs.Trigger value="account">
@@ -50,6 +53,10 @@ export const AccountSettingsDialog: FC<AccountSettingsDialogProps> = observer(({
                   <Tabs.Trigger value="password">
                     <PiLockLight />
                     Password
+                  </Tabs.Trigger>
+                  <Tabs.Trigger value="api-keys">
+                    <PiKeyLight />
+                    Personal Tokens
                   </Tabs.Trigger>
                 </Tabs.List>
 
@@ -146,6 +153,21 @@ export const AccountSettingsDialog: FC<AccountSettingsDialogProps> = observer(({
                         {model.hasPassword ? 'Update Password' : 'Set Password'}
                       </Button>
                     </Flex>
+                  </VStack>
+                </Tabs.Content>
+
+                <Tabs.Content value="api-keys">
+                  <VStack align="stretch" gap="1rem">
+                    <Box>
+                      <Text fontSize="sm" fontWeight="500" color="gray.700">
+                        Personal Access Keys
+                      </Text>
+                      <Text fontSize="xs" color="gray.500" mt={1}>
+                        Personal keys act on your behalf and inherit your permissions. Use them for scripts, CLI tools,
+                        or any programmatic access to your data.
+                      </Text>
+                    </Box>
+                    <ApiKeyList model={model.apiKeyManager} />
                   </VStack>
                 </Tabs.Content>
               </Tabs.Root>

--- a/src/features/ApiKeyManager/api/api-key.graphql
+++ b/src/features/ApiKeyManager/api/api-key.graphql
@@ -1,0 +1,68 @@
+fragment ApiKeyFields on ApiKeyModel {
+  id
+  prefix
+  type
+  name
+  organizationId
+  projectIds
+  branchNames
+  tableIds
+  readOnly
+  permissions
+  allowedIps
+  expiresAt
+  lastUsedAt
+  createdAt
+  revokedAt
+}
+
+query myApiKeys {
+  myApiKeys {
+    ...ApiKeyFields
+  }
+}
+
+query serviceApiKeys($organizationId: String!) {
+  serviceApiKeys(organizationId: $organizationId) {
+    ...ApiKeyFields
+  }
+}
+
+query apiKeyById($id: ID!) {
+  apiKeyById(id: $id) {
+    ...ApiKeyFields
+  }
+}
+
+mutation createPersonalApiKey($data: CreatePersonalApiKeyInput!) {
+  createPersonalApiKey(data: $data) {
+    apiKey {
+      ...ApiKeyFields
+    }
+    secret
+  }
+}
+
+mutation createServiceApiKey($data: CreateServiceApiKeyInput!) {
+  createServiceApiKey(data: $data) {
+    apiKey {
+      ...ApiKeyFields
+    }
+    secret
+  }
+}
+
+mutation revokeApiKey($id: ID!) {
+  revokeApiKey(id: $id) {
+    ...ApiKeyFields
+  }
+}
+
+mutation rotateApiKey($id: ID!) {
+  rotateApiKey(id: $id) {
+    apiKey {
+      ...ApiKeyFields
+    }
+    secret
+  }
+}

--- a/src/features/ApiKeyManager/index.ts
+++ b/src/features/ApiKeyManager/index.ts
@@ -1,0 +1,3 @@
+export { ApiKeyList } from './ui/ApiKeyList/ApiKeyList.tsx'
+export { ApiKeyManagerViewModel, type ApiKeyManagerConfig } from './model/ApiKeyManagerViewModel.ts'
+export { ApiKeyManagerDataSource } from './model/ApiKeyManagerDataSource.ts'

--- a/src/features/ApiKeyManager/model/ApiKeyManagerDataSource.ts
+++ b/src/features/ApiKeyManager/model/ApiKeyManagerDataSource.ts
@@ -1,0 +1,96 @@
+import { makeAutoObservable } from 'mobx'
+import { container } from 'src/shared/lib'
+import { ObservableRequest } from 'src/shared/lib/ObservableRequest.ts'
+import { client } from 'src/shared/model/ApiService.ts'
+
+export class ApiKeyManagerDataSource {
+  public readonly myKeysRequest = ObservableRequest.of(client.myApiKeys, { skipResetting: true })
+  public readonly serviceKeysRequest = ObservableRequest.of(client.serviceApiKeys, { skipResetting: true })
+  private readonly createPersonalRequest = ObservableRequest.of(client.createPersonalApiKey)
+  private readonly createServiceRequest = ObservableRequest.of(client.createServiceApiKey)
+  private readonly revokeRequest = ObservableRequest.of(client.revokeApiKey)
+  private readonly rotateRequest = ObservableRequest.of(client.rotateApiKey)
+
+  constructor() {
+    makeAutoObservable(this)
+  }
+
+  public get isLoading(): boolean {
+    return this.myKeysRequest.isLoading || this.serviceKeysRequest.isLoading
+  }
+
+  public get error(): string | null {
+    return this.myKeysRequest.errorMessage ?? this.serviceKeysRequest.errorMessage ?? null
+  }
+
+  public get isMutating(): boolean {
+    return (
+      this.createPersonalRequest.isLoading ||
+      this.createServiceRequest.isLoading ||
+      this.revokeRequest.isLoading ||
+      this.rotateRequest.isLoading
+    )
+  }
+
+  public fetchPersonalKeys() {
+    return this.myKeysRequest.fetch()
+  }
+
+  public fetchServiceKeys(organizationId: string) {
+    return this.serviceKeysRequest.fetch({ organizationId })
+  }
+
+  public async fetchProjectNames(organizationId: string): Promise<Map<string, string>> {
+    const map = new Map<string, string>()
+    const result = await client.organizationProjects({
+      data: { organizationId, first: 100 },
+    })
+    for (const edge of result.projects.edges) {
+      map.set(edge.node.id, edge.node.name)
+    }
+    return map
+  }
+
+  public async createPersonalKey(data: Parameters<typeof client.createPersonalApiKey>[0]['data']) {
+    const result = await this.createPersonalRequest.fetch({ data })
+    if (result.isRight) {
+      return result.data.createPersonalApiKey
+    }
+    return null
+  }
+
+  public async createServiceKey(data: Parameters<typeof client.createServiceApiKey>[0]['data']) {
+    const result = await this.createServiceRequest.fetch({ data })
+    if (result.isRight) {
+      return result.data.createServiceApiKey
+    }
+    return null
+  }
+
+  public async revokeKey(id: string) {
+    const result = await this.revokeRequest.fetch({ id })
+    if (result.isRight) {
+      return result.data.revokeApiKey
+    }
+    return null
+  }
+
+  public async rotateKey(id: string) {
+    const result = await this.rotateRequest.fetch({ id })
+    if (result.isRight) {
+      return result.data.rotateApiKey
+    }
+    return null
+  }
+
+  public dispose(): void {
+    this.myKeysRequest.abort()
+    this.serviceKeysRequest.abort()
+    this.createPersonalRequest.abort()
+    this.createServiceRequest.abort()
+    this.revokeRequest.abort()
+    this.rotateRequest.abort()
+  }
+}
+
+container.register(ApiKeyManagerDataSource, () => new ApiKeyManagerDataSource(), { scope: 'request' })

--- a/src/features/ApiKeyManager/model/ApiKeyManagerViewModel.ts
+++ b/src/features/ApiKeyManager/model/ApiKeyManagerViewModel.ts
@@ -1,0 +1,395 @@
+import { makeAutoObservable, runInAction } from 'mobx'
+import {
+  CaslRuleInput,
+  CreatePersonalApiKeyInput,
+  CreateServiceApiKeyInput,
+} from 'src/__generated__/graphql-request.ts'
+import { ApiKeyModel } from 'src/entities/ApiKey'
+import { IViewModel } from 'src/shared/config/types.ts'
+import { container, isAborted } from 'src/shared/lib'
+import { ApiKeyManagerDataSource } from './ApiKeyManagerDataSource.ts'
+
+export interface ApiKeyManagerConfig {
+  mode: 'personal' | 'service'
+  organizationId?: string
+  defaultProjectId?: string
+  defaultProjectName?: string
+  filterByProjectId?: string
+}
+
+type PermissionPreset = 'read-only' | 'read-write' | 'full-access'
+
+const PERMISSION_PRESETS: Record<PermissionPreset, CaslRuleInput[]> = {
+  'read-only': [{ action: ['read'], subject: ['all'] }],
+  'read-write': [{ action: ['read', 'create', 'update'], subject: ['all'] }],
+  'full-access': [{ action: ['read', 'create', 'update', 'delete'], subject: ['all'] }],
+}
+
+export class ApiKeyManagerViewModel implements IViewModel {
+  private _config: ApiKeyManagerConfig = { mode: 'personal' }
+  private _items: ApiKeyModel[] = []
+  private _isLoaded = false
+  private _projectNames: Map<string, string> = new Map()
+
+  private _isCreateDialogOpen = false
+  private _isSecretDialogOpen = false
+  private _isRevokeDialogOpen = false
+  private _isRotateDialogOpen = false
+
+  private _selectedKeyId: string | null = null
+  private _lastSecret: string | null = null
+  private _lastCreatedKeyName: string | null = null
+
+  public createKeyName = ''
+  public createKeyReadOnly = false
+  public createKeyExpiresAt: string | null = null
+  public createKeyExpirationPreset: string = 'none'
+  public createKeyPermissionPreset: PermissionPreset = 'read-only'
+
+  constructor(private readonly dataSource: ApiKeyManagerDataSource) {
+    makeAutoObservable(this, {}, { autoBind: true })
+  }
+
+  public get mode(): 'personal' | 'service' {
+    return this._config.mode
+  }
+
+  public get organizationId(): string | undefined {
+    return this._config.organizationId
+  }
+
+  public get defaultProjectId(): string | undefined {
+    return this._config.defaultProjectId
+  }
+
+  public get filterByProjectId(): string | undefined {
+    return this._config.filterByProjectId
+  }
+
+  public get projectNames(): Map<string, string> {
+    return this._projectNames
+  }
+
+  public resolveProjectName(projectId: string): string {
+    return this._projectNames.get(projectId) ?? projectId
+  }
+
+  public get items(): ApiKeyModel[] {
+    return this._items
+  }
+
+  public get filteredItems(): ApiKeyModel[] {
+    if (!this._config.filterByProjectId) {
+      return this._items
+    }
+    const projectId = this._config.filterByProjectId
+    return this._items.filter((item) => item.projectIds.includes(projectId))
+  }
+
+  public get sortedItems(): ApiKeyModel[] {
+    return [...this.filteredItems].sort((a, b) => {
+      const statusOrder = { Active: 0, Expired: 1, Revoked: 2 }
+      const statusDiff = statusOrder[a.statusLabel] - statusOrder[b.statusLabel]
+      if (statusDiff !== 0) {
+        return statusDiff
+      }
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    })
+  }
+
+  public get isLoading(): boolean {
+    return this.dataSource.isLoading
+  }
+
+  public get isLoaded(): boolean {
+    return this._isLoaded
+  }
+
+  public get isMutating(): boolean {
+    return this.dataSource.isMutating
+  }
+
+  public get error(): string | null {
+    return this.dataSource.error
+  }
+
+  public get isEmpty(): boolean {
+    return this.filteredItems.length === 0
+  }
+
+  public get isCreateDialogOpen(): boolean {
+    return this._isCreateDialogOpen
+  }
+
+  public get isSecretDialogOpen(): boolean {
+    return this._isSecretDialogOpen
+  }
+
+  public get isRevokeDialogOpen(): boolean {
+    return this._isRevokeDialogOpen
+  }
+
+  public get isRotateDialogOpen(): boolean {
+    return this._isRotateDialogOpen
+  }
+
+  public get selectedKeyId(): string | null {
+    return this._selectedKeyId
+  }
+
+  public get lastSecret(): string | null {
+    return this._lastSecret
+  }
+
+  public get lastCreatedKeyName(): string | null {
+    return this._lastCreatedKeyName
+  }
+
+  public get selectedKey(): ApiKeyModel | undefined {
+    return this._items.find((item) => item.id === this._selectedKeyId)
+  }
+
+  public get canCreateKey(): boolean {
+    return this.createKeyName.trim().length > 0 && !this.isMutating
+  }
+
+  public get emptyStateMessage(): string {
+    if (this._config.mode === 'personal') {
+      return 'No API keys yet. Create one for programmatic access to your data.'
+    }
+    return 'No integration keys for this organization.'
+  }
+
+  public configure(config: ApiKeyManagerConfig): void {
+    this._config = config
+  }
+
+  public init(): void {}
+
+  public dispose(): void {
+    this.dataSource.dispose()
+  }
+
+  public reset(): void {
+    this._items = []
+    this._isLoaded = false
+  }
+
+  public async loadKeys(): Promise<void> {
+    if (this._config.mode === 'personal') {
+      const result = await this.dataSource.fetchPersonalKeys()
+
+      if (!result.isRight) {
+        if (isAborted(result)) {
+          return
+        }
+        runInAction(() => {
+          this._isLoaded = true
+        })
+        return
+      }
+
+      runInAction(() => {
+        this._items = result.data.myApiKeys.filter((k) => k.type !== 'INTERNAL').map((k) => new ApiKeyModel(k))
+        this._isLoaded = true
+      })
+    } else if (this._config.organizationId) {
+      const [result, projectNames] = await Promise.all([
+        this.dataSource.fetchServiceKeys(this._config.organizationId),
+        this.dataSource.fetchProjectNames(this._config.organizationId),
+      ])
+
+      if (!result.isRight) {
+        if (isAborted(result)) {
+          return
+        }
+        runInAction(() => {
+          this._isLoaded = true
+        })
+        return
+      }
+
+      runInAction(() => {
+        this._projectNames = projectNames
+        this._items = result.data.serviceApiKeys
+          .filter((k) => k.type !== 'INTERNAL')
+          .map((k) => {
+            const model = new ApiKeyModel(k)
+            model.setProjectNameResolver(this.resolveProjectName)
+            return model
+          })
+        this._isLoaded = true
+      })
+    }
+  }
+
+  public openCreateDialog(): void {
+    this._isCreateDialogOpen = true
+    this.createKeyName = ''
+    this.createKeyReadOnly = false
+    this.createKeyExpiresAt = null
+    this.createKeyExpirationPreset = 'none'
+    this.createKeyPermissionPreset = 'read-only'
+  }
+
+  public closeCreateDialog(): void {
+    this._isCreateDialogOpen = false
+  }
+
+  public setCreateKeyName(value: string): void {
+    this.createKeyName = value
+  }
+
+  public setCreateKeyReadOnly(value: boolean): void {
+    this.createKeyReadOnly = value
+  }
+
+  public setExpirationPreset(preset: string): void {
+    this.createKeyExpirationPreset = preset
+    const now = new Date()
+
+    switch (preset) {
+      case '30d':
+        now.setDate(now.getDate() + 30)
+        this.createKeyExpiresAt = now.toISOString()
+        break
+      case '60d':
+        now.setDate(now.getDate() + 60)
+        this.createKeyExpiresAt = now.toISOString()
+        break
+      case '90d':
+        now.setDate(now.getDate() + 90)
+        this.createKeyExpiresAt = now.toISOString()
+        break
+      case '1y':
+        now.setFullYear(now.getFullYear() + 1)
+        this.createKeyExpiresAt = now.toISOString()
+        break
+      case 'none':
+        this.createKeyExpiresAt = null
+        break
+    }
+  }
+
+  public setPermissionPreset(preset: PermissionPreset): void {
+    this.createKeyPermissionPreset = preset
+  }
+
+  public async createKey(): Promise<void> {
+    if (!this.canCreateKey) {
+      return
+    }
+
+    if (this._config.mode === 'personal') {
+      const input: CreatePersonalApiKeyInput = {
+        name: this.createKeyName.trim(),
+        readOnly: this.createKeyReadOnly,
+        expiresAt: this.createKeyExpiresAt ?? undefined,
+        projectIds: this._config.defaultProjectId ? [this._config.defaultProjectId] : undefined,
+      }
+
+      const result = await this.dataSource.createPersonalKey(input)
+      if (result) {
+        runInAction(() => {
+          this._lastSecret = result.secret
+          this._lastCreatedKeyName = result.apiKey.name
+          this._isCreateDialogOpen = false
+          this._isSecretDialogOpen = true
+        })
+        await this.loadKeys()
+      }
+    } else if (this._config.organizationId) {
+      const input: CreateServiceApiKeyInput = {
+        name: this.createKeyName.trim(),
+        organizationId: this._config.organizationId,
+        readOnly: this.createKeyReadOnly,
+        expiresAt: this.createKeyExpiresAt ?? undefined,
+        projectIds: this._config.defaultProjectId ? [this._config.defaultProjectId] : undefined,
+        permissions: {
+          rules: PERMISSION_PRESETS[this.createKeyPermissionPreset],
+        },
+      }
+
+      const result = await this.dataSource.createServiceKey(input)
+      if (result) {
+        runInAction(() => {
+          this._lastSecret = result.secret
+          this._lastCreatedKeyName = result.apiKey.name
+          this._isCreateDialogOpen = false
+          this._isSecretDialogOpen = true
+        })
+        await this.loadKeys()
+      }
+    }
+  }
+
+  public closeSecretDialog(): void {
+    this._isSecretDialogOpen = false
+    this._lastSecret = null
+    this._lastCreatedKeyName = null
+  }
+
+  public openRevokeDialog(keyId: string): void {
+    this._selectedKeyId = keyId
+    this._isRevokeDialogOpen = true
+  }
+
+  public closeRevokeDialog(): void {
+    this._isRevokeDialogOpen = false
+    this._selectedKeyId = null
+  }
+
+  public async revokeKey(): Promise<void> {
+    if (!this._selectedKeyId) {
+      return
+    }
+
+    const result = await this.dataSource.revokeKey(this._selectedKeyId)
+
+    if (result) {
+      runInAction(() => {
+        this._isRevokeDialogOpen = false
+        this._selectedKeyId = null
+      })
+      await this.loadKeys()
+    }
+  }
+
+  public openRotateDialog(keyId: string): void {
+    this._selectedKeyId = keyId
+    this._isRotateDialogOpen = true
+  }
+
+  public closeRotateDialog(): void {
+    this._isRotateDialogOpen = false
+    this._selectedKeyId = null
+  }
+
+  public async rotateKey(): Promise<void> {
+    if (!this._selectedKeyId) {
+      return
+    }
+
+    const result = await this.dataSource.rotateKey(this._selectedKeyId)
+
+    if (result) {
+      runInAction(() => {
+        this._lastSecret = result.secret
+        this._lastCreatedKeyName = result.apiKey.name
+        this._isRotateDialogOpen = false
+        this._selectedKeyId = null
+        this._isSecretDialogOpen = true
+      })
+      await this.loadKeys()
+    }
+  }
+}
+
+container.register(
+  ApiKeyManagerViewModel,
+  () => {
+    const dataSource = container.get(ApiKeyManagerDataSource)
+    return new ApiKeyManagerViewModel(dataSource)
+  },
+  { scope: 'request' },
+)

--- a/src/features/ApiKeyManager/ui/ApiKeyList/ApiKeyList.tsx
+++ b/src/features/ApiKeyManager/ui/ApiKeyList/ApiKeyList.tsx
@@ -1,0 +1,134 @@
+import { Box, Button, Flex, HStack, Spinner, Text, VStack } from '@chakra-ui/react'
+import { observer } from 'mobx-react-lite'
+import { FC, useEffect } from 'react'
+import { PiArrowClockwiseLight, PiPlusLight, PiTrashLight } from 'react-icons/pi'
+import { ApiKeyRow } from 'src/entities/ApiKey'
+import { ApiKeyManagerViewModel } from '../../model/ApiKeyManagerViewModel.ts'
+import { CreateKeyDialog } from '../CreateKeyDialog/CreateKeyDialog.tsx'
+import { RevokeConfirmDialog } from '../RevokeConfirmDialog/RevokeConfirmDialog.tsx'
+import { RotateConfirmDialog } from '../RotateConfirmDialog/RotateConfirmDialog.tsx'
+import { SecretRevealDialog } from '../SecretRevealDialog/SecretRevealDialog.tsx'
+
+interface ApiKeyListProps {
+  model: ApiKeyManagerViewModel
+  showCreateButton?: boolean
+}
+
+export const ApiKeyList: FC<ApiKeyListProps> = observer(({ model, showCreateButton = true }) => {
+  useEffect(() => {
+    void model.loadKeys()
+    return () => model.reset()
+  }, [model])
+
+  if (!model.isLoaded) {
+    return (
+      <Flex justify="center" py={8}>
+        <Spinner size="md" color="gray.400" />
+      </Flex>
+    )
+  }
+
+  if (model.error) {
+    return (
+      <Box p={4} bg="red.50" borderRadius="md" borderWidth="1px" borderColor="red.200">
+        <Text fontSize="sm" color="red.600">
+          {model.error}
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <VStack align="stretch" gap={3}>
+      {showCreateButton && !model.isEmpty && (
+        <Flex justify="space-between" align="center">
+          <Text fontSize="sm" color="gray.500">
+            {`${model.sortedItems.length} key${model.sortedItems.length === 1 ? '' : 's'}`}
+          </Text>
+          <Button size="sm" onClick={model.openCreateDialog}>
+            <PiPlusLight />
+            Create key
+          </Button>
+        </Flex>
+      )}
+
+      {model.isEmpty && model.isLoaded && (
+        <Box p={6} textAlign="center" borderWidth="1px" borderColor="gray.200" borderRadius="lg" bg="gray.50">
+          <Text fontSize="sm" color="gray.500">
+            {model.emptyStateMessage}
+          </Text>
+          {showCreateButton && (
+            <Button size="sm" mt={3} onClick={model.openCreateDialog}>
+              <PiPlusLight />
+              Create your first key
+            </Button>
+          )}
+        </Box>
+      )}
+
+      {model.sortedItems.map((item) => (
+        <ApiKeyRow
+          key={item.id}
+          name={item.name}
+          prefix={item.prefix}
+          status={item.statusLabel}
+          permissionLabel={item.permissionLabel}
+          permissionColor={item.permissionColorPalette}
+          projects={item.resolvedProjects}
+          lastUsedAt={item.lastUsedAt}
+          createdAt={item.createdAt}
+          expiresAt={item.expiresAt}
+          actions={
+            item.isActive ? (
+              <HStack gap={1}>
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  color="gray.500"
+                  _hover={{ color: 'orange.600', bg: 'orange.50' }}
+                  onClick={() => model.openRotateDialog(item.id)}
+                >
+                  <PiArrowClockwiseLight />
+                </Button>
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  color="gray.500"
+                  _hover={{ color: 'red.600', bg: 'red.50' }}
+                  onClick={() => model.openRevokeDialog(item.id)}
+                >
+                  <PiTrashLight />
+                </Button>
+              </HStack>
+            ) : undefined
+          }
+        />
+      ))}
+
+      <CreateKeyDialog model={model} />
+
+      <SecretRevealDialog
+        isOpen={model.isSecretDialogOpen}
+        secret={model.lastSecret}
+        keyName={model.lastCreatedKeyName}
+        onClose={model.closeSecretDialog}
+      />
+
+      <RevokeConfirmDialog
+        isOpen={model.isRevokeDialogOpen}
+        keyName={model.selectedKey?.name}
+        isLoading={model.isMutating}
+        onConfirm={model.revokeKey}
+        onClose={model.closeRevokeDialog}
+      />
+
+      <RotateConfirmDialog
+        isOpen={model.isRotateDialogOpen}
+        keyName={model.selectedKey?.name}
+        isLoading={model.isMutating}
+        onConfirm={model.rotateKey}
+        onClose={model.closeRotateDialog}
+      />
+    </VStack>
+  )
+})

--- a/src/features/ApiKeyManager/ui/CreateKeyDialog/CreateKeyDialog.tsx
+++ b/src/features/ApiKeyManager/ui/CreateKeyDialog/CreateKeyDialog.tsx
@@ -1,0 +1,192 @@
+import { Box, Button, Flex, HStack, Input, Portal, Text, VStack } from '@chakra-ui/react'
+import {
+  DialogActionTrigger,
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+} from '@chakra-ui/react/dialog'
+import { observer } from 'mobx-react-lite'
+import { FC } from 'react'
+import { ApiKeyManagerViewModel } from '../../model/ApiKeyManagerViewModel.ts'
+
+interface CreateKeyDialogProps {
+  model: ApiKeyManagerViewModel
+}
+
+const expirationOptions = [
+  { value: '30d', label: '30 days' },
+  { value: '60d', label: '60 days' },
+  { value: '90d', label: '90 days' },
+  { value: '1y', label: '1 year' },
+  { value: 'none', label: 'No expiration' },
+]
+
+const permissionOptions = [
+  { value: 'read-only' as const, label: 'Read only', description: 'Can only read data' },
+  { value: 'read-write' as const, label: 'Read & Write', description: 'Can read, create, and update data' },
+  { value: 'full-access' as const, label: 'Full access', description: 'Can read, create, update, and delete data' },
+]
+
+export const CreateKeyDialog: FC<CreateKeyDialogProps> = observer(({ model }) => {
+  return (
+    <DialogRoot
+      open={model.isCreateDialogOpen}
+      onOpenChange={({ open }) => !open && model.closeCreateDialog()}
+      size="md"
+    >
+      <Portal>
+        <DialogBackdrop />
+        <DialogPositioner>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>
+                {model.mode === 'personal' ? 'Create Personal API Key' : 'Create Service API Key'}
+              </DialogTitle>
+            </DialogHeader>
+
+            <DialogBody>
+              <VStack align="stretch" gap="1rem">
+                <Flex flexDirection="column" gap="0.5rem">
+                  <Text fontSize="sm" fontWeight="500" color="gray.600">
+                    Name
+                  </Text>
+                  <Input
+                    placeholder="e.g., CI/CD pipeline, Data sync..."
+                    value={model.createKeyName}
+                    onChange={(e) => model.setCreateKeyName(e.target.value)}
+                    autoFocus
+                  />
+                </Flex>
+
+                <Flex flexDirection="column" gap="0.5rem">
+                  <Text fontSize="sm" fontWeight="500" color="gray.600">
+                    Expiration
+                  </Text>
+                  <HStack gap={2} flexWrap="wrap">
+                    {expirationOptions.map((option) => (
+                      <Button
+                        key={option.value}
+                        size="sm"
+                        variant={model.createKeyExpirationPreset === option.value ? 'solid' : 'outline'}
+                        onClick={() => model.setExpirationPreset(option.value)}
+                      >
+                        {option.label}
+                      </Button>
+                    ))}
+                  </HStack>
+                </Flex>
+
+                {model.mode === 'personal' && (
+                  <Flex flexDirection="column" gap="0.5rem">
+                    <HStack gap={2}>
+                      <Box
+                        as="button"
+                        onClick={() => model.setCreateKeyReadOnly(!model.createKeyReadOnly)}
+                        display="flex"
+                        alignItems="center"
+                        gap={2}
+                        cursor="pointer"
+                      >
+                        <Box
+                          width="18px"
+                          height="18px"
+                          borderWidth="1px"
+                          borderColor={model.createKeyReadOnly ? 'blue.500' : 'gray.300'}
+                          borderRadius="sm"
+                          bg={model.createKeyReadOnly ? 'blue.500' : 'transparent'}
+                          display="flex"
+                          alignItems="center"
+                          justifyContent="center"
+                          transition="all 0.2s"
+                        >
+                          {model.createKeyReadOnly && (
+                            <Text color="white" fontSize="xs" fontWeight="bold" lineHeight={1}>
+                              ✓
+                            </Text>
+                          )}
+                        </Box>
+                        <Text fontSize="sm" color="gray.700">
+                          Read only
+                        </Text>
+                      </Box>
+                    </HStack>
+                    <Text fontSize="xs" color="gray.500" pl="26px">
+                      Key can only read data, not modify it
+                    </Text>
+                  </Flex>
+                )}
+
+                {model.mode === 'service' && (
+                  <Flex flexDirection="column" gap="0.5rem">
+                    <Text fontSize="sm" fontWeight="500" color="gray.600">
+                      Permissions
+                    </Text>
+                    <VStack align="stretch" gap={2}>
+                      {permissionOptions.map((option) => (
+                        <Box
+                          key={option.value}
+                          as="button"
+                          onClick={() => model.setPermissionPreset(option.value)}
+                          width="100%"
+                          p={3}
+                          borderWidth="1px"
+                          borderColor={model.createKeyPermissionPreset === option.value ? 'blue.400' : 'gray.200'}
+                          borderRadius="md"
+                          bg={model.createKeyPermissionPreset === option.value ? 'blue.50' : 'white'}
+                          cursor="pointer"
+                          textAlign="left"
+                          transition="all 0.2s"
+                          _hover={{ borderColor: 'blue.300' }}
+                        >
+                          <Text fontSize="sm" fontWeight="500" color="gray.700">
+                            {option.label}
+                          </Text>
+                          <Text fontSize="xs" color="gray.500">
+                            {option.description}
+                          </Text>
+                        </Box>
+                      ))}
+                    </VStack>
+                  </Flex>
+                )}
+
+                {model.defaultProjectId && (
+                  <Flex
+                    align="center"
+                    gap={2}
+                    p={3}
+                    bg="blue.50"
+                    borderRadius="md"
+                    borderWidth="1px"
+                    borderColor="blue.200"
+                  >
+                    <Text fontSize="sm" color="blue.700">
+                      This key will be scoped to project <strong>{model.defaultProjectId}</strong>
+                    </Text>
+                  </Flex>
+                )}
+              </VStack>
+            </DialogBody>
+
+            <DialogFooter>
+              <DialogActionTrigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </DialogActionTrigger>
+              <Button onClick={model.createKey} disabled={!model.canCreateKey} loading={model.isMutating}>
+                Create key
+              </Button>
+            </DialogFooter>
+
+            <DialogCloseTrigger />
+          </DialogContent>
+        </DialogPositioner>
+      </Portal>
+    </DialogRoot>
+  )
+})

--- a/src/features/ApiKeyManager/ui/RevokeConfirmDialog/RevokeConfirmDialog.tsx
+++ b/src/features/ApiKeyManager/ui/RevokeConfirmDialog/RevokeConfirmDialog.tsx
@@ -1,0 +1,64 @@
+import { Button, Portal, Text, VStack } from '@chakra-ui/react'
+import {
+  DialogActionTrigger,
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+} from '@chakra-ui/react/dialog'
+import { observer } from 'mobx-react-lite'
+import { FC } from 'react'
+
+interface RevokeConfirmDialogProps {
+  isOpen: boolean
+  keyName: string | undefined
+  isLoading: boolean
+  onConfirm: () => void
+  onClose: () => void
+}
+
+export const RevokeConfirmDialog: FC<RevokeConfirmDialogProps> = observer(
+  ({ isOpen, keyName, isLoading, onConfirm, onClose }) => {
+    return (
+      <DialogRoot open={isOpen} onOpenChange={({ open }) => !open && onClose()} size="md">
+        <Portal>
+          <DialogBackdrop />
+          <DialogPositioner>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Revoke API Key</DialogTitle>
+              </DialogHeader>
+
+              <DialogBody>
+                <VStack align="stretch" gap="1rem">
+                  <Text>
+                    Are you sure you want to revoke the key <strong>{keyName}</strong>?
+                  </Text>
+                  <Text fontSize="sm" color="gray.600">
+                    This action cannot be undone. Any applications using this key will immediately lose access.
+                  </Text>
+                </VStack>
+              </DialogBody>
+
+              <DialogFooter>
+                <DialogActionTrigger asChild>
+                  <Button variant="outline">Cancel</Button>
+                </DialogActionTrigger>
+                <Button colorPalette="red" onClick={onConfirm} loading={isLoading}>
+                  Revoke key
+                </Button>
+              </DialogFooter>
+
+              <DialogCloseTrigger />
+            </DialogContent>
+          </DialogPositioner>
+        </Portal>
+      </DialogRoot>
+    )
+  },
+)

--- a/src/features/ApiKeyManager/ui/RotateConfirmDialog/RotateConfirmDialog.tsx
+++ b/src/features/ApiKeyManager/ui/RotateConfirmDialog/RotateConfirmDialog.tsx
@@ -1,0 +1,65 @@
+import { Button, Portal, Text, VStack } from '@chakra-ui/react'
+import {
+  DialogActionTrigger,
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+} from '@chakra-ui/react/dialog'
+import { observer } from 'mobx-react-lite'
+import { FC } from 'react'
+
+interface RotateConfirmDialogProps {
+  isOpen: boolean
+  keyName: string | undefined
+  isLoading: boolean
+  onConfirm: () => void
+  onClose: () => void
+}
+
+export const RotateConfirmDialog: FC<RotateConfirmDialogProps> = observer(
+  ({ isOpen, keyName, isLoading, onConfirm, onClose }) => {
+    return (
+      <DialogRoot open={isOpen} onOpenChange={({ open }) => !open && onClose()} size="md">
+        <Portal>
+          <DialogBackdrop />
+          <DialogPositioner>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Rotate API Key</DialogTitle>
+              </DialogHeader>
+
+              <DialogBody>
+                <VStack align="stretch" gap="1rem">
+                  <Text>
+                    Are you sure you want to rotate the key <strong>{keyName}</strong>?
+                  </Text>
+                  <Text fontSize="sm" color="gray.600">
+                    This will generate a new secret and invalidate the current one. Any applications using the current
+                    key will need to be updated.
+                  </Text>
+                </VStack>
+              </DialogBody>
+
+              <DialogFooter>
+                <DialogActionTrigger asChild>
+                  <Button variant="outline">Cancel</Button>
+                </DialogActionTrigger>
+                <Button colorPalette="orange" onClick={onConfirm} loading={isLoading}>
+                  Rotate key
+                </Button>
+              </DialogFooter>
+
+              <DialogCloseTrigger />
+            </DialogContent>
+          </DialogPositioner>
+        </Portal>
+      </DialogRoot>
+    )
+  },
+)

--- a/src/features/ApiKeyManager/ui/SecretRevealDialog/SecretRevealDialog.tsx
+++ b/src/features/ApiKeyManager/ui/SecretRevealDialog/SecretRevealDialog.tsx
@@ -1,0 +1,85 @@
+import { Box, Button, Flex, Input, Portal, Text, VStack } from '@chakra-ui/react'
+import {
+  DialogBackdrop,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+} from '@chakra-ui/react/dialog'
+import { observer } from 'mobx-react-lite'
+import { FC, useCallback } from 'react'
+import { PiCopy, PiWarningLight } from 'react-icons/pi'
+import { toaster } from 'src/shared/ui'
+
+interface SecretRevealDialogProps {
+  isOpen: boolean
+  secret: string | null
+  keyName: string | null
+  onClose: () => void
+}
+
+export const SecretRevealDialog: FC<SecretRevealDialogProps> = observer(({ isOpen, secret, keyName, onClose }) => {
+  const handleCopy = useCallback(async () => {
+    if (secret) {
+      await navigator.clipboard.writeText(secret)
+      toaster.info({ description: 'Copied to clipboard' })
+    }
+  }, [secret])
+
+  return (
+    <DialogRoot open={isOpen} onOpenChange={({ open }) => !open && onClose()} size="md" closeOnInteractOutside={false}>
+      <Portal>
+        <DialogBackdrop />
+        <DialogPositioner>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Your API Key</DialogTitle>
+            </DialogHeader>
+
+            <DialogBody>
+              <VStack align="stretch" gap="1rem">
+                {keyName && (
+                  <Text fontSize="sm" color="gray.600">
+                    Key <strong>{keyName}</strong> has been created successfully.
+                  </Text>
+                )}
+
+                <Box>
+                  <Flex gap={2}>
+                    <Input value={secret ?? ''} readOnly fontFamily="mono" fontSize="sm" bg="gray.50" />
+                    <Button variant="outline" onClick={handleCopy} flexShrink={0}>
+                      <PiCopy />
+                      Copy
+                    </Button>
+                  </Flex>
+                </Box>
+
+                <Flex
+                  align="center"
+                  gap={2}
+                  p={3}
+                  bg="yellow.50"
+                  borderRadius="md"
+                  borderWidth="1px"
+                  borderColor="yellow.200"
+                >
+                  <PiWarningLight color="var(--chakra-colors-yellow-600)" />
+                  <Text fontSize="sm" color="yellow.800">
+                    Make sure to copy your API key now. You won&apos;t be able to see it again.
+                  </Text>
+                </Flex>
+              </VStack>
+            </DialogBody>
+
+            <DialogFooter>
+              <Button onClick={onClose}>I&apos;ve copied the key</Button>
+            </DialogFooter>
+          </DialogContent>
+        </DialogPositioner>
+      </Portal>
+    </DialogRoot>
+  )
+})

--- a/src/pages/OrganizationSettingsPage/model/OrganizationSettingsPageModel.ts
+++ b/src/pages/OrganizationSettingsPage/model/OrganizationSettingsPageModel.ts
@@ -1,0 +1,49 @@
+import { makeAutoObservable } from 'mobx'
+import { OrganizationContext } from 'src/entities/Organization/model/OrganizationContext.ts'
+import { ApiKeyManagerViewModel } from 'src/features/ApiKeyManager'
+import { IViewModel } from 'src/shared/config/types.ts'
+import { container } from 'src/shared/lib'
+import { PermissionService } from 'src/shared/model/AbilityService'
+
+export class OrganizationSettingsPageModel implements IViewModel {
+  public readonly apiKeyManager: ApiKeyManagerViewModel
+
+  constructor(
+    private readonly context: OrganizationContext,
+    private readonly permissionService: PermissionService,
+    apiKeyManager: ApiKeyManagerViewModel,
+  ) {
+    makeAutoObservable(this, {}, { autoBind: true })
+    this.apiKeyManager = apiKeyManager
+  }
+
+  public get organizationId(): string {
+    return this.context.organizationId
+  }
+
+  public get canManageServiceKeys(): boolean {
+    return this.permissionService.can('update', 'Organization', { organizationId: this.organizationId })
+  }
+
+  public init(): void {
+    this.apiKeyManager.configure({
+      mode: 'service',
+      organizationId: this.organizationId,
+    })
+  }
+
+  public dispose(): void {
+    this.apiKeyManager.dispose()
+  }
+}
+
+container.register(
+  OrganizationSettingsPageModel,
+  () => {
+    const context = container.get(OrganizationContext)
+    const permissionService = container.get(PermissionService)
+    const apiKeyManager = container.get(ApiKeyManagerViewModel)
+    return new OrganizationSettingsPageModel(context, permissionService, apiKeyManager)
+  },
+  { scope: 'request' },
+)

--- a/src/pages/OrganizationSettingsPage/ui/OrganizationSettingsPage/OrganizationSettingsPage.tsx
+++ b/src/pages/OrganizationSettingsPage/ui/OrganizationSettingsPage/OrganizationSettingsPage.tsx
@@ -1,16 +1,31 @@
-import { Box, Text } from '@chakra-ui/react'
+import { Box, Text, VStack } from '@chakra-ui/react'
+import { observer } from 'mobx-react-lite'
 import { FC } from 'react'
+import { ApiKeyList } from 'src/features/ApiKeyManager'
+import { OrganizationSettingsPageModel } from 'src/pages/OrganizationSettingsPage/model/OrganizationSettingsPageModel.ts'
+import { useViewModel } from 'src/shared/lib'
 import { Page } from 'src/shared/ui'
 import { OrganizationSidebar } from 'src/widgets/OrganizationSidebar'
 
-export const OrganizationSettingsPage: FC = () => {
+export const OrganizationSettingsPage: FC = observer(() => {
+  const store = useViewModel(OrganizationSettingsPageModel)
+
   return (
     <Page sidebar={<OrganizationSidebar />}>
-      <Box>
-        <Text fontSize="20px" fontWeight="600" color="newGray.500">
-          Organization Settings
-        </Text>
+      <Box maxWidth="600px" width="100%" mb="4rem">
+        <VStack align="stretch" gap="2rem">
+          <Box>
+            <Text fontSize="20px" fontWeight="600" color="newGray.500" mb={1}>
+              API Keys
+            </Text>
+            <Text fontSize="xs" color="newGray.400">
+              Service keys for automated integrations with this organization.
+            </Text>
+          </Box>
+
+          {store.canManageServiceKeys && <ApiKeyList model={store.apiKeyManager} />}
+        </VStack>
       </Box>
     </Page>
   )
-}
+})

--- a/src/pages/ProjectApiKeysPage/index.ts
+++ b/src/pages/ProjectApiKeysPage/index.ts
@@ -1,0 +1,1 @@
+export { ProjectApiKeysPage } from './ui/ProjectApiKeysPage/ProjectApiKeysPage.tsx'

--- a/src/pages/ProjectApiKeysPage/model/ProjectApiKeysPageModel.ts
+++ b/src/pages/ProjectApiKeysPage/model/ProjectApiKeysPageModel.ts
@@ -1,0 +1,63 @@
+import { makeAutoObservable } from 'mobx'
+import { ProjectContext } from 'src/entities/Project/model/ProjectContext.ts'
+import { ApiKeyManagerViewModel } from 'src/features/ApiKeyManager'
+import { IViewModel } from 'src/shared/config/types.ts'
+import { container } from 'src/shared/lib'
+import { PermissionService, ProjectPermissions } from 'src/shared/model/AbilityService'
+
+export class ProjectApiKeysPageModel implements IViewModel {
+  public readonly apiKeyManager: ApiKeyManagerViewModel
+
+  constructor(
+    private readonly context: ProjectContext,
+    private readonly projectPermissions: ProjectPermissions,
+    private readonly permissionService: PermissionService,
+    apiKeyManager: ApiKeyManagerViewModel,
+  ) {
+    makeAutoObservable(this, {}, { autoBind: true })
+    this.apiKeyManager = apiKeyManager
+  }
+
+  public get organizationId(): string {
+    return this.context.organizationId
+  }
+
+  public get projectName(): string {
+    return this.context.projectName
+  }
+
+  public get canManageServiceKeys(): boolean {
+    return this.permissionService.can('update', 'Organization', { organizationId: this.context.organizationId })
+  }
+
+  public get organizationSettingsLink(): string {
+    return `/app/${this.context.organizationId}/-/settings`
+  }
+
+  public init(): void {
+    const projectId = this.projectPermissions.projectId ?? undefined
+    this.apiKeyManager.configure({
+      mode: 'service',
+      organizationId: this.context.organizationId,
+      defaultProjectId: projectId,
+      defaultProjectName: this.context.projectName,
+      filterByProjectId: projectId,
+    })
+  }
+
+  public dispose(): void {
+    this.apiKeyManager.dispose()
+  }
+}
+
+container.register(
+  ProjectApiKeysPageModel,
+  () => {
+    const context = container.get(ProjectContext)
+    const projectPermissions = container.get(ProjectPermissions)
+    const permissionService = container.get(PermissionService)
+    const apiKeyManager = container.get(ApiKeyManagerViewModel)
+    return new ProjectApiKeysPageModel(context, projectPermissions, permissionService, apiKeyManager)
+  },
+  { scope: 'request' },
+)

--- a/src/pages/ProjectApiKeysPage/ui/ProjectApiKeysPage/ProjectApiKeysPage.tsx
+++ b/src/pages/ProjectApiKeysPage/ui/ProjectApiKeysPage/ProjectApiKeysPage.tsx
@@ -1,0 +1,55 @@
+import { Box, Link as ChakraLink, Text, VStack } from '@chakra-ui/react'
+import { observer } from 'mobx-react-lite'
+import { FC } from 'react'
+import { PiArrowRightLight } from 'react-icons/pi'
+import { Link as RouterLink } from 'react-router-dom'
+import { ApiKeyList } from 'src/features/ApiKeyManager'
+import { ProjectApiKeysPageModel } from 'src/pages/ProjectApiKeysPage/model/ProjectApiKeysPageModel.ts'
+import { useViewModel } from 'src/shared/lib'
+import { Page } from 'src/shared/ui'
+import { ProjectSidebar } from 'src/widgets/ProjectSidebar/ui/ProjectSidebar/ProjectSidebar.tsx'
+
+export const ProjectApiKeysPage: FC = observer(() => {
+  const store = useViewModel(ProjectApiKeysPageModel)
+
+  return (
+    <Page sidebar={<ProjectSidebar />}>
+      <Box maxWidth="600px" width="100%" mb="4rem">
+        <VStack align="stretch" gap="2rem">
+          <Box>
+            <Text fontSize="20px" fontWeight="600" color="newGray.500" mb={1}>
+              API Keys
+            </Text>
+            <Text fontSize="xs" color="newGray.400">
+              Service keys scoped to this project for automated integrations.
+            </Text>
+          </Box>
+
+          {store.canManageServiceKeys ? (
+            <Box>
+              <ApiKeyList model={store.apiKeyManager} />
+              <ChakraLink asChild fontSize="xs" color="gray.500" mt={3} display="inline-flex" alignItems="center">
+                <RouterLink to={store.organizationSettingsLink}>
+                  Manage all organization keys
+                  <PiArrowRightLight style={{ marginLeft: '4px' }} />
+                </RouterLink>
+              </ChakraLink>
+            </Box>
+          ) : (
+            <Box p={6} textAlign="center" borderWidth="1px" borderColor="gray.200" borderRadius="lg" bg="gray.50">
+              <Text fontSize="sm" color="gray.500" mb={2}>
+                No API keys scoped to this project.
+              </Text>
+              <ChakraLink asChild fontSize="xs" color="blue.500">
+                <RouterLink to={store.organizationSettingsLink}>
+                  Contact an organization admin to manage API keys
+                  <PiArrowRightLight style={{ marginLeft: '4px' }} />
+                </RouterLink>
+              </ChakraLink>
+            </Box>
+          )}
+        </VStack>
+      </Box>
+    </Page>
+  )
+})

--- a/src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts
@@ -1,8 +1,9 @@
 import { makeAutoObservable } from 'mobx'
 import { LinkMaker } from 'src/entities/Navigation/model/LinkMaker.ts'
 import { ProjectContext } from 'src/entities/Project/model/ProjectContext.ts'
+import { ApiKeyManagerViewModel } from 'src/features/ApiKeyManager'
 import { container, ObservableRequest } from 'src/shared/lib'
-import { ProjectPermissions } from 'src/shared/model/AbilityService'
+import { PermissionService, ProjectPermissions } from 'src/shared/model/AbilityService'
 import { client } from 'src/shared/model/ApiService.ts'
 import { RouterService } from 'src/shared/model/RouterService.ts'
 import { toaster } from 'src/shared/ui'
@@ -14,17 +15,38 @@ export class ProjectSettingsPageModel {
   private readonly updateRequest = ObservableRequest.of(client.updateProject)
   private readonly deleteRequest = ObservableRequest.of(client.deleteProjectForSettings)
 
+  public readonly apiKeyManager: ApiKeyManagerViewModel
+
   constructor(
     private readonly context: ProjectContext,
     private readonly routerService: RouterService,
     private readonly projectPermissions: ProjectPermissions,
+    private readonly permissionService: PermissionService,
     private readonly linkMaker: LinkMaker,
+    apiKeyManager: ApiKeyManagerViewModel,
   ) {
     makeAutoObservable(this, {}, { autoBind: true })
+    this.apiKeyManager = apiKeyManager
+    const projectId = this.projectPermissions.projectId ?? undefined
+    this.apiKeyManager.configure({
+      mode: 'service',
+      organizationId: this.context.organizationId,
+      defaultProjectId: projectId,
+      defaultProjectName: this.context.projectName,
+      filterByProjectId: projectId,
+    })
   }
 
   public get endpointsLink(): string {
     return this.linkMaker.makeEndpointsLink()
+  }
+
+  public get canManageServiceKeys(): boolean {
+    return this.permissionService.can('update', 'Organization', { organizationId: this.context.organizationId })
+  }
+
+  public get organizationSettingsLink(): string {
+    return `/app/${this.context.organizationId}/-/settings`
   }
 
   public get canUpdateProject(): boolean {
@@ -106,6 +128,7 @@ export class ProjectSettingsPageModel {
   public dispose() {
     this.updateRequest.abort()
     this.deleteRequest.abort()
+    this.apiKeyManager.dispose()
   }
 }
 
@@ -115,9 +138,18 @@ container.register(
     const context = container.get(ProjectContext)
     const router = container.get(RouterService)
     const projectPermissions = container.get(ProjectPermissions)
+    const permissionService = container.get(PermissionService)
     const linkMaker = container.get(LinkMaker)
+    const apiKeyManager = container.get(ApiKeyManagerViewModel)
 
-    return new ProjectSettingsPageModel(context, router, projectPermissions, linkMaker)
+    return new ProjectSettingsPageModel(
+      context,
+      router,
+      projectPermissions,
+      permissionService,
+      linkMaker,
+      apiKeyManager,
+    )
   },
   { scope: 'request' },
 )

--- a/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -186,7 +186,7 @@ export const ProjectSettingsPage: React.FC = observer(() => {
               ) : (
                 <Box p={4} textAlign="center" borderWidth="1px" borderColor="gray.200" borderRadius="lg" bg="gray.50">
                   <Text fontSize="sm" color="gray.500">
-                    No API keys scoped to this project.
+                    You don&apos;t have permission to manage API keys for this project.
                   </Text>
                   <ChakraLink asChild fontSize="xs" color="blue.500" mt={2} display="inline-block">
                     <RouterLink to={store.organizationSettingsLink}>

--- a/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -28,6 +28,7 @@ import { observer } from 'mobx-react-lite'
 import React from 'react'
 import { PiArrowRightLight, PiCloudLight, PiLockSimpleLight } from 'react-icons/pi'
 import { Link as RouterLink } from 'react-router-dom'
+import { ApiKeyList } from 'src/features/ApiKeyManager'
 import { ProjectSettingsPageModel } from 'src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts'
 import { useViewModel } from 'src/shared/lib'
 import { Page } from 'src/shared/ui'
@@ -163,6 +164,37 @@ export const ProjectSettingsPage: React.FC = observer(() => {
                   }
                 />
               </VStack>
+            </Box>
+
+            <Box>
+              <HStack justify="space-between" align="center" mb={3}>
+                <Text fontSize="sm" fontWeight="600" color="gray.600">
+                  API Keys
+                </Text>
+                <ChakraLink asChild fontSize="xs" color="gray.500">
+                  <RouterLink to={store.organizationSettingsLink}>
+                    Manage all organization keys
+                    <Icon as={PiArrowRightLight} ml={1} />
+                  </RouterLink>
+                </ChakraLink>
+              </HStack>
+              <Text fontSize="xs" color="gray.500" mb="1rem">
+                Service keys scoped to this project.
+              </Text>
+              {store.canManageServiceKeys ? (
+                <ApiKeyList model={store.apiKeyManager} />
+              ) : (
+                <Box p={4} textAlign="center" borderWidth="1px" borderColor="gray.200" borderRadius="lg" bg="gray.50">
+                  <Text fontSize="sm" color="gray.500">
+                    No API keys scoped to this project.
+                  </Text>
+                  <ChakraLink asChild fontSize="xs" color="blue.500" mt={2} display="inline-block">
+                    <RouterLink to={store.organizationSettingsLink}>
+                      Contact an organization admin to manage API keys
+                    </RouterLink>
+                  </ChakraLink>
+                </Box>
+              )}
             </Box>
 
             {store.hasDeletePermission && (

--- a/src/widgets/OrganizationSidebar/ui/OrganizationSidebar/OrganizationSidebar.tsx
+++ b/src/widgets/OrganizationSidebar/ui/OrganizationSidebar/OrganizationSidebar.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Separator, Spacer, VStack } from '@chakra-ui/react'
 import { observer } from 'mobx-react-lite'
 import { FC } from 'react'
-import { PiCreditCardLight, PiGridFourLight, PiSignInLight, PiUsersLight } from 'react-icons/pi'
+import { PiCreditCardLight, PiGridFourLight, PiKeyLight, PiSignInLight, PiUsersLight } from 'react-icons/pi'
 import { LOGIN_ROUTE } from 'src/shared/config/routes.ts'
 import { useViewModel } from 'src/shared/lib'
 import { AccountButton } from 'src/widgets/AccountButton'
@@ -13,7 +13,7 @@ import { OrganizationHeader } from 'src/widgets/OrganizationSidebar/ui/Organizat
 export const OrganizationSidebar: FC = observer(() => {
   const model = useViewModel(OrganizationSidebarViewModel)
 
-  const { isProjectsActive, isMembersActive, isLimitsActive } = useOrganizationNavigationState()
+  const { isProjectsActive, isMembersActive, isSettingsActive, isLimitsActive } = useOrganizationNavigationState()
 
   return (
     <VStack alignItems="flex-start" gap={0} width="100%" flex={1}>
@@ -32,6 +32,14 @@ export const OrganizationSidebar: FC = observer(() => {
         />
         {model.canManageMembers && (
           <NavigationButton to={model.membersLink} label="Members" icon={<PiUsersLight />} isActive={isMembersActive} />
+        )}
+        {model.canAccessSettings && (
+          <NavigationButton
+            to={model.settingsLink}
+            label="API Keys"
+            icon={<PiKeyLight />}
+            isActive={isSettingsActive}
+          />
         )}
         {model.billingEnabled && (
           <NavigationButton

--- a/src/widgets/ProjectSidebar/hooks/useNavigationState.ts
+++ b/src/widgets/ProjectSidebar/hooks/useNavigationState.ts
@@ -14,6 +14,7 @@ export const useNavigationState = () => {
   const isBranchesActive = matches.some((match) => match.id === RouteIds.Branches)
   const isProjectUsersActive = matches.some((match) => match.id === RouteIds.ProjectUsers)
   const isMcpActive = matches.some((match) => match.id === RouteIds.ProjectMcp)
+  const isApiKeysActive = matches.some((match) => match.id === RouteIds.ProjectApiKeys)
 
   const isTablesActive =
     matches.some((match) => match.id === RouteIds.Revision) &&
@@ -23,7 +24,8 @@ export const useNavigationState = () => {
     !isRelationsActive &&
     !isBranchMapActive
   const isBranchesLevelActive = isBranchesActive || isBranchMapActive
-  const isProjectLevelActive = isProjectSettingsActive || isEndpointsActive || isProjectUsersActive || isMcpActive
+  const isProjectLevelActive =
+    isProjectSettingsActive || isEndpointsActive || isProjectUsersActive || isMcpActive || isApiKeysActive
 
   return {
     isTablesActive,
@@ -34,6 +36,7 @@ export const useNavigationState = () => {
     isEndpointsActive,
     isProjectUsersActive,
     isMcpActive,
+    isApiKeysActive,
     isProjectLevelActive,
     isBranchesLevelActive,
     isBranchesActive,

--- a/src/widgets/ProjectSidebar/ui/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/widgets/ProjectSidebar/ui/ProjectSidebar/ProjectSidebar.tsx
@@ -4,7 +4,7 @@ import { FC, useEffect } from 'react'
 import {
   PiGearLight,
   PiGitBranchLight,
-  // PiKeyLight,
+  PiKeyLight,
   PiUsersLight,
   PiDatabaseLight,
   PiFileTextLight,
@@ -54,6 +54,7 @@ export const ProjectSidebar: FC = observer(() => {
     isBranchesActive,
     isProjectUsersActive,
     isMcpActive,
+    isApiKeysActive,
     isProjectLevelActive,
     isBranchesLevelActive,
   } = useNavigationState()
@@ -173,6 +174,14 @@ export const ProjectSidebar: FC = observer(() => {
               label="Users"
               icon={<PiUsersLight />}
               isActive={isProjectUsersActive}
+            />
+          )}
+          {model.isAuthenticated && (
+            <NavigationButton
+              to={linkMaker.makeProjectApiKeysLink()}
+              label="API Keys"
+              icon={<PiKeyLight />}
+              isActive={isApiKeysActive}
             />
           )}
           {model.canAccessSettings && (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a complete API key management UI for personal tokens and service keys across Account, Organization, and Project views, with create, rotate, revoke, and permission presets. Requires backend GraphQL support for ApiKey types and ops: `myApiKeys`, `serviceApiKeys`, `apiKeyById`, `createPersonalApiKey`, `createServiceApiKey`, `rotateApiKey`, `revokeApiKey`.

- **New Features**
  - Account Settings: Personal API keys tab with list, create (read‑only toggle, expiration presets), and one‑time secret reveal.
  - Organization Settings: Service keys with permission presets (read‑only, read & write, full access), rotate/revoke, and status/permission badges.
  - Project: New Project API Keys page scoped to the current project; “Manage all keys” link to org settings.
  - Navigation: Added “API Keys” entries to Organization and Project sidebars; new route renders the Project API Keys page.

- **Bug Fixes**
  - Clarified permission message in Project Settings API Keys section when the user lacks org-level access.

<sup>Written for commit 45369a2101648d75d1680b3f5b98baa3320fafea. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/320">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

