### PR TITLE
fix: use projects resolver, remove fetchProjectNames, fix configure race

### DIFF
--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -60,6 +60,7 @@ export type ApiKeyModel = {
   permissions?: Maybe<Scalars['JSON']['output']>;
   prefix: Scalars['String']['output'];
   projectIds: Array<Scalars['String']['output']>;
+  projects: Array<ProjectModel>;
   readOnly: Scalars['Boolean']['output'];
   revokedAt?: Maybe<Scalars['DateTime']['output']>;
   tableIds: Array<Scalars['String']['output']>;

--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -62,6 +62,7 @@ export type ApiKeyModel = {
   permissions?: Maybe<Scalars['JSON']['output']>;
   prefix: Scalars['String']['output'];
   projectIds: Array<Scalars['String']['output']>;
+  projects: Array<ProjectModel>;
   readOnly: Scalars['Boolean']['output'];
   revokedAt?: Maybe<Scalars['DateTime']['output']>;
   tableIds: Array<Scalars['String']['output']>;
@@ -2107,54 +2108,54 @@ export type UpdatePasswordMutationVariables = Exact<{
 
 export type UpdatePasswordMutation = { updatePassword: boolean };
 
-export type ApiKeyFieldsFragment = { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null };
+export type ApiKeyFieldsFragment = { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> };
 
 export type MyApiKeysQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MyApiKeysQuery = { myApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null }> };
+export type MyApiKeysQuery = { myApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> }> };
 
 export type ServiceApiKeysQueryVariables = Exact<{
   organizationId: Scalars['String']['input'];
 }>;
 
 
-export type ServiceApiKeysQuery = { serviceApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null }> };
+export type ServiceApiKeysQuery = { serviceApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> }> };
 
 export type ApiKeyByIdQueryVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type ApiKeyByIdQuery = { apiKeyById: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } };
+export type ApiKeyByIdQuery = { apiKeyById: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } };
 
 export type CreatePersonalApiKeyMutationVariables = Exact<{
   data: CreatePersonalApiKeyInput;
 }>;
 
 
-export type CreatePersonalApiKeyMutation = { createPersonalApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } } };
+export type CreatePersonalApiKeyMutation = { createPersonalApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } } };
 
 export type CreateServiceApiKeyMutationVariables = Exact<{
   data: CreateServiceApiKeyInput;
 }>;
 
 
-export type CreateServiceApiKeyMutation = { createServiceApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } } };
+export type CreateServiceApiKeyMutation = { createServiceApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } } };
 
 export type RevokeApiKeyMutationVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type RevokeApiKeyMutation = { revokeApiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } };
+export type RevokeApiKeyMutation = { revokeApiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } };
 
 export type RotateApiKeyMutationVariables = Exact<{
   id: Scalars['ID']['input'];
 }>;
 
 
-export type RotateApiKeyMutation = { rotateApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null } } };
+export type RotateApiKeyMutation = { rotateApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } } };
 
 export type CreateProjectMutationVariables = Exact<{
   data: CreateProjectInput;
@@ -2925,6 +2926,10 @@ export const ApiKeyFieldsFragmentDoc = gql`
   name
   organizationId
   projectIds
+  projects {
+    id
+    name
+  }
   branchNames
   tableIds
   readOnly

--- a/src/__generated__/schema.graphql
+++ b/src/__generated__/schema.graphql
@@ -49,6 +49,7 @@ type ApiKeyModel {
   permissions: JSON
   prefix: String!
   projectIds: [String!]!
+  projects: [ProjectModel!]!
   readOnly: Boolean!
   revokedAt: DateTime
   tableIds: [String!]!

--- a/src/entities/ApiKey/model/ApiKeyModel.ts
+++ b/src/entities/ApiKey/model/ApiKeyModel.ts
@@ -7,14 +7,8 @@ export interface ResolvedProject {
 }
 
 export class ApiKeyModel {
-  private _projectNameResolver: ((id: string) => string) | null = null
-
   constructor(public readonly data: ApiKeyFieldsFragment) {
     makeAutoObservable(this)
-  }
-
-  public setProjectNameResolver(resolver: (id: string) => string): void {
-    this._projectNameResolver = resolver
   }
 
   public get id(): string {
@@ -83,10 +77,7 @@ export class ApiKeyModel {
   }
 
   public get resolvedProjects(): ResolvedProject[] {
-    return this.data.projectIds.map((id) => ({
-      id,
-      name: this._projectNameResolver?.(id) ?? id,
-    }))
+    return this.data.projects
   }
 
   public get permissionLabel(): string {

--- a/src/features/ApiKeyManager/api/api-key.graphql
+++ b/src/features/ApiKeyManager/api/api-key.graphql
@@ -5,6 +5,10 @@ fragment ApiKeyFields on ApiKeyModel {
   name
   organizationId
   projectIds
+  projects {
+    id
+    name
+  }
   branchNames
   tableIds
   readOnly

--- a/src/features/ApiKeyManager/model/ApiKeyManagerDataSource.ts
+++ b/src/features/ApiKeyManager/model/ApiKeyManagerDataSource.ts
@@ -40,17 +40,6 @@ export class ApiKeyManagerDataSource {
     return this.serviceKeysRequest.fetch({ organizationId })
   }
 
-  public async fetchProjectNames(organizationId: string): Promise<Map<string, string>> {
-    const map = new Map<string, string>()
-    const result = await client.organizationProjects({
-      data: { organizationId, first: 100 },
-    })
-    for (const edge of result.projects.edges) {
-      map.set(edge.node.id, edge.node.name)
-    }
-    return map
-  }
-
   public async createPersonalKey(data: Parameters<typeof client.createPersonalApiKey>[0]['data']) {
     const result = await this.createPersonalRequest.fetch({ data })
     if (result.isRight) {

--- a/src/features/ApiKeyManager/model/ApiKeyManagerViewModel.ts
+++ b/src/features/ApiKeyManager/model/ApiKeyManagerViewModel.ts
@@ -29,7 +29,6 @@ export class ApiKeyManagerViewModel implements IViewModel {
   private _config: ApiKeyManagerConfig = { mode: 'personal' }
   private _items: ApiKeyModel[] = []
   private _isLoaded = false
-  private _projectNames: Map<string, string> = new Map()
 
   private _isCreateDialogOpen = false
   private _isSecretDialogOpen = false
@@ -64,14 +63,6 @@ export class ApiKeyManagerViewModel implements IViewModel {
 
   public get filterByProjectId(): string | undefined {
     return this._config.filterByProjectId
-  }
-
-  public get projectNames(): Map<string, string> {
-    return this._projectNames
-  }
-
-  public resolveProjectName(projectId: string): string {
-    return this._projectNames.get(projectId) ?? projectId
   }
 
   public get items(): ApiKeyModel[] {
@@ -194,10 +185,7 @@ export class ApiKeyManagerViewModel implements IViewModel {
         this._isLoaded = true
       })
     } else if (this._config.organizationId) {
-      const [result, projectNames] = await Promise.all([
-        this.dataSource.fetchServiceKeys(this._config.organizationId),
-        this.dataSource.fetchProjectNames(this._config.organizationId),
-      ])
+      const result = await this.dataSource.fetchServiceKeys(this._config.organizationId)
 
       if (!result.isRight) {
         if (isAborted(result)) {
@@ -210,14 +198,7 @@ export class ApiKeyManagerViewModel implements IViewModel {
       }
 
       runInAction(() => {
-        this._projectNames = projectNames
-        this._items = result.data.serviceApiKeys
-          .filter((k) => k.type !== 'INTERNAL')
-          .map((k) => {
-            const model = new ApiKeyModel(k)
-            model.setProjectNameResolver(this.resolveProjectName)
-            return model
-          })
+        this._items = result.data.serviceApiKeys.filter((k) => k.type !== 'INTERNAL').map((k) => new ApiKeyModel(k))
         this._isLoaded = true
       })
     }

--- a/src/pages/OrganizationSettingsPage/model/OrganizationSettingsPageModel.ts
+++ b/src/pages/OrganizationSettingsPage/model/OrganizationSettingsPageModel.ts
@@ -15,6 +15,10 @@ export class OrganizationSettingsPageModel implements IViewModel {
   ) {
     makeAutoObservable(this, {}, { autoBind: true })
     this.apiKeyManager = apiKeyManager
+    this.apiKeyManager.configure({
+      mode: 'service',
+      organizationId: this.context.organizationId,
+    })
   }
 
   public get organizationId(): string {
@@ -25,12 +29,7 @@ export class OrganizationSettingsPageModel implements IViewModel {
     return this.permissionService.can('update', 'Organization', { organizationId: this.organizationId })
   }
 
-  public init(): void {
-    this.apiKeyManager.configure({
-      mode: 'service',
-      organizationId: this.organizationId,
-    })
-  }
+  public init(): void {}
 
   public dispose(): void {
     this.apiKeyManager.dispose()

--- a/src/pages/ProjectApiKeysPage/model/ProjectApiKeysPageModel.ts
+++ b/src/pages/ProjectApiKeysPage/model/ProjectApiKeysPageModel.ts
@@ -16,6 +16,14 @@ export class ProjectApiKeysPageModel implements IViewModel {
   ) {
     makeAutoObservable(this, {}, { autoBind: true })
     this.apiKeyManager = apiKeyManager
+    const projectId = this.projectPermissions.projectId ?? undefined
+    this.apiKeyManager.configure({
+      mode: 'service',
+      organizationId: this.context.organizationId,
+      defaultProjectId: projectId,
+      defaultProjectName: this.context.projectName,
+      filterByProjectId: projectId,
+    })
   }
 
   public get organizationId(): string {
@@ -34,16 +42,7 @@ export class ProjectApiKeysPageModel implements IViewModel {
     return `/app/${this.context.organizationId}/-/settings`
   }
 
-  public init(): void {
-    const projectId = this.projectPermissions.projectId ?? undefined
-    this.apiKeyManager.configure({
-      mode: 'service',
-      organizationId: this.context.organizationId,
-      defaultProjectId: projectId,
-      defaultProjectName: this.context.projectName,
-      filterByProjectId: projectId,
-    })
-  }
+  public init(): void {}
 
   public dispose(): void {
     this.apiKeyManager.dispose()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched API key project resolution to use the GraphQL `projects` field, removing client-side project name fetching. Also fixed a race by configuring `ApiKeyManager` in page model constructors.

- **Refactors**
  - Added `projects { id, name }` to `ApiKeyModel` schema and `ApiKeyFields` fragment.
  - Simplified `ApiKeyModel.resolvedProjects` to return `data.projects`.
  - Removed `fetchProjectNames` and project name resolver logic; `ApiKeyManagerViewModel` now performs a single `serviceApiKeys` request.

- **Bug Fixes**
  - Moved `ApiKeyManager.configure` calls into the constructors of organization and project settings models to prevent init/configure races.

<sup>Written for commit 1c0ce19d7c0caa29dbeaf2f7a94570312da3c484. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/321">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

