### PR TITLE
Wire manage-api-key permission into UI

### DIFF
--- a/src/pages/OrganizationSettingsPage/model/OrganizationSettingsPageModel.ts
+++ b/src/pages/OrganizationSettingsPage/model/OrganizationSettingsPageModel.ts
@@ -26,7 +26,7 @@ export class OrganizationSettingsPageModel implements IViewModel {
   }
 
   public get canManageServiceKeys(): boolean {
-    return this.permissionService.can('update', 'Organization', { organizationId: this.organizationId })
+    return this.permissionService.can('manage', 'ApiKey', { organizationId: this.organizationId })
   }
 
   public init(): void {}

--- a/src/pages/ProjectApiKeysPage/model/ProjectApiKeysPageModel.ts
+++ b/src/pages/ProjectApiKeysPage/model/ProjectApiKeysPageModel.ts
@@ -35,7 +35,14 @@ export class ProjectApiKeysPageModel implements IViewModel {
   }
 
   public get canManageServiceKeys(): boolean {
-    return this.permissionService.can('update', 'Organization', { organizationId: this.context.organizationId })
+    const projectId = this.projectPermissions.projectId
+    if (projectId) {
+      return this.permissionService.can('manage', 'ApiKey', {
+        projectId,
+        organizationId: this.context.organizationId,
+      })
+    }
+    return this.permissionService.can('manage', 'ApiKey', { organizationId: this.context.organizationId })
   }
 
   public get organizationSettingsLink(): string {

--- a/src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts
@@ -42,7 +42,14 @@ export class ProjectSettingsPageModel {
   }
 
   public get canManageServiceKeys(): boolean {
-    return this.permissionService.can('update', 'Organization', { organizationId: this.context.organizationId })
+    const projectId = this.projectPermissions.projectId
+    if (projectId) {
+      return this.permissionService.can('manage', 'ApiKey', {
+        projectId,
+        organizationId: this.context.organizationId,
+      })
+    }
+    return this.permissionService.can('manage', 'ApiKey', { organizationId: this.context.organizationId })
   }
 
   public get organizationSettingsLink(): string {

--- a/src/shared/model/AbilityService/ProjectPermissions.ts
+++ b/src/shared/model/AbilityService/ProjectPermissions.ts
@@ -167,6 +167,10 @@ export class ProjectPermissions {
     return this.can('read', 'User')
   }
 
+  public get canManageApiKeys(): boolean {
+    return this.can('manage', 'ApiKey')
+  }
+
   public get canManageUsers(): boolean {
     return this.canAddUser || this.canReadUser
   }

--- a/src/shared/model/AbilityService/types.ts
+++ b/src/shared/model/AbilityService/types.ts
@@ -5,6 +5,7 @@ export enum PermissionAction {
   revert = 'revert',
   update = 'update',
   add = 'add',
+  manage = 'manage',
 }
 
 export enum PermissionSubject {
@@ -16,6 +17,7 @@ export enum PermissionSubject {
   Row = 'Row',
   Endpoint = 'Endpoint',
   User = 'User',
+  ApiKey = 'ApiKey',
 }
 
 export type Actions = `${PermissionAction}`

--- a/src/widgets/OrganizationSidebar/model/OrganizationSidebarViewModel.ts
+++ b/src/widgets/OrganizationSidebar/model/OrganizationSidebarViewModel.ts
@@ -41,6 +41,10 @@ export class OrganizationSidebarViewModel {
     return this.permissionService.can('add', 'User', this.organizationCondition)
   }
 
+  public get canManageApiKeys(): boolean {
+    return this.permissionService.can('manage', 'ApiKey', this.organizationCondition)
+  }
+
   public get canAccessSettings(): boolean {
     return this.permissionService.can('update', 'Organization', this.organizationCondition)
   }

--- a/src/widgets/OrganizationSidebar/ui/OrganizationSidebar/OrganizationSidebar.tsx
+++ b/src/widgets/OrganizationSidebar/ui/OrganizationSidebar/OrganizationSidebar.tsx
@@ -33,7 +33,7 @@ export const OrganizationSidebar: FC = observer(() => {
         {model.canManageMembers && (
           <NavigationButton to={model.membersLink} label="Members" icon={<PiUsersLight />} isActive={isMembersActive} />
         )}
-        {model.canAccessSettings && (
+        {model.canManageApiKeys && (
           <NavigationButton
             to={model.settingsLink}
             label="API Keys"

--- a/src/widgets/ProjectSidebar/model/ProjectSidebarViewModel.ts
+++ b/src/widgets/ProjectSidebar/model/ProjectSidebarViewModel.ts
@@ -25,6 +25,10 @@ export class ProjectSidebarViewModel {
     return this.projectPermissions.canAccessSettings
   }
 
+  public get canManageApiKeys(): boolean {
+    return this.projectPermissions.canManageApiKeys
+  }
+
   public get canManageUsers(): boolean {
     return this.projectPermissions.canManageUsers
   }

--- a/src/widgets/ProjectSidebar/ui/ProjectSidebar/ProjectSidebar.tsx
+++ b/src/widgets/ProjectSidebar/ui/ProjectSidebar/ProjectSidebar.tsx
@@ -176,7 +176,7 @@ export const ProjectSidebar: FC = observer(() => {
               isActive={isProjectUsersActive}
             />
           )}
-          {model.isAuthenticated && (
+          {model.canManageApiKeys && (
             <NavigationButton
               to={linkMaker.makeProjectApiKeysLink()}
               label="API Keys"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align API Keys UI visibility with the `manage` `ApiKey` permission. This fixes incorrect exposure of API Key pages and links that previously relied on `update` `Organization`.

- **Bug Fixes**
  - Gate API Keys pages and links with `permissionService.can('manage', 'ApiKey', ...)`, scoped by project or organization when available.
  - Add `manage` action and `ApiKey` subject to permission types; expose `canManageApiKeys` in `ProjectPermissions`.
  - Organization and project sidebars now show "API Keys" only when `canManageApiKeys` is true.

<sup>Written for commit f5290b3d9c0f59c755c8a4966ea3e882048fc2a5. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/324">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

