### PR TITLE
feat: admin cache page with stats and reset

### DIFF
--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -1,978 +1,964 @@
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never }
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never }
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: string; output: string; }
-  JSON: { input: { [key: string]: any } | string | number | boolean | null; output: { [key: string]: any } | string | number | boolean | null; }
-  JSONObject: { input: any; output: any; }
-};
+  ID: { input: string; output: string }
+  String: { input: string; output: string }
+  Boolean: { input: boolean; output: boolean }
+  Int: { input: number; output: number }
+  Float: { input: number; output: number }
+  DateTime: { input: string; output: string }
+  JSON: {
+    input: { [key: string]: any } | string | number | boolean | null
+    output: { [key: string]: any } | string | number | boolean | null
+  }
+  JSONObject: { input: any; output: any }
+}
 
 export type ActivateEarlyAccessInput = {
-  organizationId: Scalars['ID']['input'];
-  planId: Scalars['ID']['input'];
-};
+  organizationId: Scalars['ID']['input']
+  planId: Scalars['ID']['input']
+}
 
 export type AddUserToOrganizationInput = {
-  organizationId: Scalars['String']['input'];
-  roleId: UserOrganizationRoles;
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  roleId: UserOrganizationRoles
+  userId: Scalars['String']['input']
+}
 
 export type AddUserToProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  roleId: UserProjectRoles;
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  roleId: UserProjectRoles
+  userId: Scalars['String']['input']
+}
 
 export type AddedRowChangeModel = {
-  __typename: 'AddedRowChangeModel';
-  changeType: ChangeType;
-  fieldChanges: Array<FieldChangeModel>;
-  row: RowChangeRowModel;
-  table: RowChangeTableModel;
-};
+  __typename: 'AddedRowChangeModel'
+  changeType: ChangeType
+  fieldChanges: Array<FieldChangeModel>
+  row: RowChangeRowModel
+  table: RowChangeTableModel
+}
 
 export type AdminUserInput = {
-  userId: Scalars['String']['input'];
-};
+  userId: Scalars['String']['input']
+}
 
 export type ApiKeyModel = {
-  __typename: 'ApiKeyModel';
-  allowedIps: Array<Scalars['String']['output']>;
-  branchNames: Array<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  expiresAt?: Maybe<Scalars['DateTime']['output']>;
-  id: Scalars['ID']['output'];
-  lastUsedAt?: Maybe<Scalars['DateTime']['output']>;
-  name: Scalars['String']['output'];
-  organizationId?: Maybe<Scalars['String']['output']>;
-  permissions?: Maybe<Scalars['JSON']['output']>;
-  prefix: Scalars['String']['output'];
-  projectIds: Array<Scalars['String']['output']>;
-  projects: Array<ProjectModel>;
-  readOnly: Scalars['Boolean']['output'];
-  revokedAt?: Maybe<Scalars['DateTime']['output']>;
-  tableIds: Array<Scalars['String']['output']>;
-  type: ApiKeyType;
-};
+  __typename: 'ApiKeyModel'
+  allowedIps: Array<Scalars['String']['output']>
+  branchNames: Array<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  expiresAt?: Maybe<Scalars['DateTime']['output']>
+  id: Scalars['ID']['output']
+  lastUsedAt?: Maybe<Scalars['DateTime']['output']>
+  name: Scalars['String']['output']
+  organizationId?: Maybe<Scalars['String']['output']>
+  permissions?: Maybe<Scalars['JSON']['output']>
+  prefix: Scalars['String']['output']
+  projectIds: Array<Scalars['String']['output']>
+  projects: Array<ProjectModel>
+  readOnly: Scalars['Boolean']['output']
+  revokedAt?: Maybe<Scalars['DateTime']['output']>
+  tableIds: Array<Scalars['String']['output']>
+  type: ApiKeyType
+}
 
 export enum ApiKeyType {
   INTERNAL = 'INTERNAL',
   PERSONAL = 'PERSONAL',
-  SERVICE = 'SERVICE'
+  SERVICE = 'SERVICE',
 }
 
 export type ApiKeyWithSecretModel = {
-  __typename: 'ApiKeyWithSecretModel';
-  apiKey: ApiKeyModel;
-  secret: Scalars['String']['output'];
-};
+  __typename: 'ApiKeyWithSecretModel'
+  apiKey: ApiKeyModel
+  secret: Scalars['String']['output']
+}
 
 export type ApplyMigrationResultModel = {
-  __typename: 'ApplyMigrationResultModel';
-  error?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  status: ApplyMigrationStatus;
-};
+  __typename: 'ApplyMigrationResultModel'
+  error?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  status: ApplyMigrationStatus
+}
 
 /** Status of migration application */
 export enum ApplyMigrationStatus {
   APPLIED = 'applied',
   FAILED = 'failed',
-  SKIPPED = 'skipped'
+  SKIPPED = 'skipped',
 }
 
 export type ApplyMigrationsInput = {
-  migrations: Array<Scalars['JSON']['input']>;
-  revisionId: Scalars['String']['input'];
-};
+  migrations: Array<Scalars['JSON']['input']>
+  revisionId: Scalars['String']['input']
+}
 
 export type BillingConfigurationModel = {
-  __typename: 'BillingConfigurationModel';
-  enabled: Scalars['Boolean']['output'];
-};
+  __typename: 'BillingConfigurationModel'
+  enabled: Scalars['Boolean']['output']
+}
 
 export enum BillingStatus {
   ACTIVE = 'active',
   CANCELLED = 'cancelled',
   EARLY_ADOPTER = 'early_adopter',
   FREE = 'free',
-  PAST_DUE = 'past_due'
+  PAST_DUE = 'past_due',
 }
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']['input']>;
-  not?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  equals?: InputMaybe<Scalars['Boolean']['input']>
+  not?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type BranchModel = {
-  __typename: 'BranchModel';
-  createdAt: Scalars['DateTime']['output'];
-  draft: RevisionModel;
-  head: RevisionModel;
-  id: Scalars['String']['output'];
-  isRoot: Scalars['Boolean']['output'];
-  name: Scalars['String']['output'];
-  parent?: Maybe<ParentBranchModel>;
-  project: ProjectModel;
-  projectId: Scalars['String']['output'];
-  revisions: RevisionConnection;
-  start: RevisionModel;
-  touched: Scalars['Boolean']['output'];
-};
-
+  __typename: 'BranchModel'
+  createdAt: Scalars['DateTime']['output']
+  draft: RevisionModel
+  head: RevisionModel
+  id: Scalars['String']['output']
+  isRoot: Scalars['Boolean']['output']
+  name: Scalars['String']['output']
+  parent?: Maybe<ParentBranchModel>
+  project: ProjectModel
+  projectId: Scalars['String']['output']
+  revisions: RevisionConnection
+  start: RevisionModel
+  touched: Scalars['Boolean']['output']
+}
 
 export type BranchModelRevisionsArgs = {
-  data: GetBranchRevisionsInput;
-};
+  data: GetBranchRevisionsInput
+}
 
 export type BranchModelEdge = {
-  __typename: 'BranchModelEdge';
-  cursor: Scalars['String']['output'];
-  node: BranchModel;
-};
+  __typename: 'BranchModelEdge'
+  cursor: Scalars['String']['output']
+  node: BranchModel
+}
 
 export type BranchesConnection = {
-  __typename: 'BranchesConnection';
-  edges: Array<BranchModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'BranchesConnection'
+  edges: Array<BranchModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
+
+export type CacheConfigModel = {
+  __typename: 'CacheConfigModel'
+  enabled: Scalars['Boolean']['output']
+}
+
+export type CacheMetricModel = {
+  __typename: 'CacheMetricModel'
+  deletes: Scalars['Int']['output']
+  hitRate: Scalars['Float']['output']
+  hits: Scalars['Int']['output']
+  key: Scalars['String']['output']
+  misses: Scalars['Int']['output']
+  writes: Scalars['Int']['output']
+}
+
+export type CacheStatsModel = {
+  __typename: 'CacheStatsModel'
+  byKey: Array<CacheMetricModel>
+  enabled: Scalars['Boolean']['output']
+  overallHitRate: Scalars['Float']['output']
+  totalClears: Scalars['Int']['output']
+  totalDeletes: Scalars['Int']['output']
+  totalHits: Scalars['Int']['output']
+  totalMisses: Scalars['Int']['output']
+  totalWrites: Scalars['Int']['output']
+}
 
 export type CancelSubscriptionInput = {
-  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>;
-  organizationId: Scalars['ID']['input'];
-};
+  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>
+  organizationId: Scalars['ID']['input']
+}
 
 export type CaslPermissionsInput = {
-  rules: Array<CaslRuleInput>;
-};
+  rules: Array<CaslRuleInput>
+}
 
 export type CaslRuleInput = {
-  action: Array<Scalars['String']['input']>;
-  conditions?: InputMaybe<Scalars['JSONObject']['input']>;
-  fields?: InputMaybe<Array<Scalars['String']['input']>>;
-  inverted?: InputMaybe<Scalars['Boolean']['input']>;
-  subject: Array<Scalars['String']['input']>;
-};
+  action: Array<Scalars['String']['input']>
+  conditions?: InputMaybe<Scalars['JSONObject']['input']>
+  fields?: InputMaybe<Array<Scalars['String']['input']>>
+  inverted?: InputMaybe<Scalars['Boolean']['input']>
+  subject: Array<Scalars['String']['input']>
+}
 
 export enum ChangeType {
   ADDED = 'ADDED',
   MODIFIED = 'MODIFIED',
   REMOVED = 'REMOVED',
   RENAMED = 'RENAMED',
-  RENAMED_AND_MODIFIED = 'RENAMED_AND_MODIFIED'
+  RENAMED_AND_MODIFIED = 'RENAMED_AND_MODIFIED',
 }
 
 export type CheckoutResultModel = {
-  __typename: 'CheckoutResultModel';
-  checkoutUrl: Scalars['String']['output'];
-};
+  __typename: 'CheckoutResultModel'
+  checkoutUrl: Scalars['String']['output']
+}
 
 export type ChildBranchModel = {
-  __typename: 'ChildBranchModel';
-  branch: BranchModel;
-  revision: RevisionModel;
-};
+  __typename: 'ChildBranchModel'
+  branch: BranchModel
+  revision: RevisionModel
+}
 
 export type ConfigurationModel = {
-  __typename: 'ConfigurationModel';
-  availableEmailSignUp: Scalars['Boolean']['output'];
-  billing: BillingConfigurationModel;
-  github: GithubOauth;
-  google: GoogleOauth;
-  noAuth: Scalars['Boolean']['output'];
-  plugins: PluginsModel;
-};
+  __typename: 'ConfigurationModel'
+  availableEmailSignUp: Scalars['Boolean']['output']
+  billing: BillingConfigurationModel
+  cache: CacheConfigModel
+  github: GithubOauth
+  google: GoogleOauth
+  noAuth: Scalars['Boolean']['output']
+  plugins: PluginsModel
+}
 
 export type ConfirmEmailCodeInput = {
-  code: Scalars['String']['input'];
-};
+  code: Scalars['String']['input']
+}
 
 export type CreateBranchInput = {
-  branchName: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type CreateCheckoutInput = {
-  cancelUrl: Scalars['String']['input'];
-  country?: InputMaybe<Scalars['String']['input']>;
-  interval?: InputMaybe<Scalars['String']['input']>;
-  method?: InputMaybe<Scalars['String']['input']>;
-  organizationId: Scalars['ID']['input'];
-  planId: Scalars['ID']['input'];
-  providerId?: InputMaybe<Scalars['String']['input']>;
-  successUrl: Scalars['String']['input'];
-};
+  cancelUrl: Scalars['String']['input']
+  country?: InputMaybe<Scalars['String']['input']>
+  interval?: InputMaybe<Scalars['String']['input']>
+  method?: InputMaybe<Scalars['String']['input']>
+  organizationId: Scalars['ID']['input']
+  planId: Scalars['ID']['input']
+  providerId?: InputMaybe<Scalars['String']['input']>
+  successUrl: Scalars['String']['input']
+}
 
 export type CreateEndpointInput = {
-  revisionId: Scalars['String']['input'];
-  type: EndpointType;
-};
+  revisionId: Scalars['String']['input']
+  type: EndpointType
+}
 
 export type CreatePersonalApiKeyInput = {
-  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
-  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
-  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
-  name: Scalars['String']['input'];
-  organizationId?: InputMaybe<Scalars['String']['input']>;
-  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>
+  name: Scalars['String']['input']
+  organizationId?: InputMaybe<Scalars['String']['input']>
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type CreateProjectInput = {
-  branchName?: InputMaybe<Scalars['String']['input']>;
-  fromRevisionId?: InputMaybe<Scalars['String']['input']>;
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName?: InputMaybe<Scalars['String']['input']>
+  fromRevisionId?: InputMaybe<Scalars['String']['input']>
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type CreateRevisionInput = {
-  branchName: Scalars['String']['input'];
-  comment?: InputMaybe<Scalars['String']['input']>;
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  comment?: InputMaybe<Scalars['String']['input']>
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type CreateRowInput = {
-  data: Scalars['JSON']['input'];
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type CreateRowResultModel = {
-  __typename: 'CreateRowResultModel';
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  __typename: 'CreateRowResultModel'
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type CreateRowsInput = {
-  isRestore?: InputMaybe<Scalars['Boolean']['input']>;
-  revisionId: Scalars['String']['input'];
-  rows: Array<CreateRowsRowInput>;
-  tableId: Scalars['String']['input'];
-};
+  isRestore?: InputMaybe<Scalars['Boolean']['input']>
+  revisionId: Scalars['String']['input']
+  rows: Array<CreateRowsRowInput>
+  tableId: Scalars['String']['input']
+}
 
 export type CreateRowsResultModel = {
-  __typename: 'CreateRowsResultModel';
-  previousVersionTableId: Scalars['String']['output'];
-  rows: Array<RowModel>;
-  table: TableModel;
-};
+  __typename: 'CreateRowsResultModel'
+  previousVersionTableId: Scalars['String']['output']
+  rows: Array<RowModel>
+  table: TableModel
+}
 
 export type CreateRowsRowInput = {
-  data: Scalars['JSON']['input'];
-  rowId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  rowId: Scalars['String']['input']
+}
 
 export type CreateServiceApiKeyInput = {
-  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
-  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
-  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
-  name: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  permissions: CaslPermissionsInput;
-  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>
+  name: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  permissions: CaslPermissionsInput
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type CreateTableInput = {
-  revisionId: Scalars['String']['input'];
-  schema: Scalars['JSON']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  schema: Scalars['JSON']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type CreateTableResultModel = {
-  __typename: 'CreateTableResultModel';
-  branch: BranchModel;
-  table: TableModel;
-};
+  __typename: 'CreateTableResultModel'
+  branch: BranchModel
+  table: TableModel
+}
 
 export type CreateUserInput = {
-  email?: InputMaybe<Scalars['String']['input']>;
-  password: Scalars['String']['input'];
-  roleId: UserSystemRole;
-  username: Scalars['String']['input'];
-};
+  email?: InputMaybe<Scalars['String']['input']>
+  password: Scalars['String']['input']
+  roleId: UserSystemRole
+  username: Scalars['String']['input']
+}
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['String']['input']>;
-  gt?: InputMaybe<Scalars['String']['input']>;
-  gte?: InputMaybe<Scalars['String']['input']>;
-  in?: InputMaybe<Array<Scalars['String']['input']>>;
-  lt?: InputMaybe<Scalars['String']['input']>;
-  lte?: InputMaybe<Scalars['String']['input']>;
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  equals?: InputMaybe<Scalars['String']['input']>
+  gt?: InputMaybe<Scalars['String']['input']>
+  gte?: InputMaybe<Scalars['String']['input']>
+  in?: InputMaybe<Array<Scalars['String']['input']>>
+  lt?: InputMaybe<Scalars['String']['input']>
+  lte?: InputMaybe<Scalars['String']['input']>
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type DeleteBranchInput = {
-  branchName: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type DeleteEndpointInput = {
-  endpointId: Scalars['String']['input'];
-};
+  endpointId: Scalars['String']['input']
+}
 
 export type DeleteProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type DeleteRowInput = {
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type DeleteRowResultModel = {
-  __typename: 'DeleteRowResultModel';
-  branch: BranchModel;
-  previousVersionTableId?: Maybe<Scalars['String']['output']>;
-  table?: Maybe<TableModel>;
-};
+  __typename: 'DeleteRowResultModel'
+  branch: BranchModel
+  previousVersionTableId?: Maybe<Scalars['String']['output']>
+  table?: Maybe<TableModel>
+}
 
 export type DeleteRowsInput = {
-  revisionId: Scalars['String']['input'];
-  rowIds: Array<Scalars['String']['input']>;
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowIds: Array<Scalars['String']['input']>
+  tableId: Scalars['String']['input']
+}
 
 export type DeleteRowsResultModel = {
-  __typename: 'DeleteRowsResultModel';
-  branch: BranchModel;
-  previousVersionTableId?: Maybe<Scalars['String']['output']>;
-  table?: Maybe<TableModel>;
-};
+  __typename: 'DeleteRowsResultModel'
+  branch: BranchModel
+  previousVersionTableId?: Maybe<Scalars['String']['output']>
+  table?: Maybe<TableModel>
+}
 
 export type DeleteTableInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type DeleteTableResultModel = {
-  __typename: 'DeleteTableResultModel';
-  branch: BranchModel;
-};
+  __typename: 'DeleteTableResultModel'
+  branch: BranchModel
+}
 
 export type EndpointModel = {
-  __typename: 'EndpointModel';
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['String']['output'];
-  revision: RevisionModel;
-  revisionId: Scalars['String']['output'];
-  type: EndpointType;
-};
+  __typename: 'EndpointModel'
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['String']['output']
+  revision: RevisionModel
+  revisionId: Scalars['String']['output']
+  type: EndpointType
+}
 
 export type EndpointModelEdge = {
-  __typename: 'EndpointModelEdge';
-  cursor: Scalars['String']['output'];
-  node: EndpointModel;
-};
+  __typename: 'EndpointModelEdge'
+  cursor: Scalars['String']['output']
+  node: EndpointModel
+}
 
 export enum EndpointType {
   GRAPHQL = 'GRAPHQL',
-  REST_API = 'REST_API'
+  REST_API = 'REST_API',
 }
 
 export type EndpointsConnection = {
-  __typename: 'EndpointsConnection';
-  edges: Array<EndpointModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'EndpointsConnection'
+  edges: Array<EndpointModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type FieldChangeModel = {
-  __typename: 'FieldChangeModel';
-  changeType: RowChangeDetailType;
-  fieldPath: Scalars['String']['output'];
-  movedFrom?: Maybe<Scalars['String']['output']>;
-  newValue?: Maybe<Scalars['JSON']['output']>;
-  oldValue?: Maybe<Scalars['JSON']['output']>;
-};
+  __typename: 'FieldChangeModel'
+  changeType: RowChangeDetailType
+  fieldPath: Scalars['String']['output']
+  movedFrom?: Maybe<Scalars['String']['output']>
+  newValue?: Maybe<Scalars['JSON']['output']>
+  oldValue?: Maybe<Scalars['JSON']['output']>
+}
 
 export type FormulaFieldErrorModel = {
-  __typename: 'FormulaFieldErrorModel';
-  defaultUsed: Scalars['Boolean']['output'];
-  error: Scalars['String']['output'];
-  expression: Scalars['String']['output'];
-  field: Scalars['String']['output'];
-};
+  __typename: 'FormulaFieldErrorModel'
+  defaultUsed: Scalars['Boolean']['output']
+  error: Scalars['String']['output']
+  expression: Scalars['String']['output']
+  field: Scalars['String']['output']
+}
 
 export type GetBranchInput = {
-  branchName: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GetBranchRevisionsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  comment?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  inclusive?: InputMaybe<Scalars['Boolean']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  comment?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  inclusive?: InputMaybe<Scalars['Boolean']['input']>
   /** Sort order: asc (default) or desc */
-  sort?: InputMaybe<SortOrder>;
-};
+  sort?: InputMaybe<SortOrder>
+}
 
 export type GetBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GetMeProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetOrganizationInput = {
-  organizationId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+}
 
 export type GetProjectBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetProjectEndpointsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  branchId?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  type?: InputMaybe<EndpointType>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  branchId?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  type?: InputMaybe<EndpointType>
+}
 
 export type GetProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GetProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+}
 
 export type GetRevisionChangesInput = {
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
-  revisionId: Scalars['String']['input'];
-};
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
+  revisionId: Scalars['String']['input']
+}
 
 export type GetRevisionInput = {
-  revisionId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+}
 
 export type GetRevisionTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetRowChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<RowChangesFiltersInput>;
-  first: Scalars['Int']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<RowChangesFiltersInput>
+  first: Scalars['Int']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type GetRowCountForeignKeysByInput = {
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetRowForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  foreignKeyTableId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  foreignKeyTableId: Scalars['String']['input']
+}
 
 export type GetRowInput = {
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  orderBy?: InputMaybe<Array<OrderBy>>;
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-  where?: InputMaybe<WhereInput>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  orderBy?: InputMaybe<Array<OrderBy>>
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+  where?: InputMaybe<WhereInput>
+}
 
 export type GetSubSchemaItemsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>;
-  revisionId: Scalars['String']['input'];
-  schemaId: Scalars['String']['input'];
-  where?: InputMaybe<SubSchemaWhereInput>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>
+  revisionId: Scalars['String']['input']
+  schemaId: Scalars['String']['input']
+  where?: InputMaybe<SubSchemaWhereInput>
+}
 
 export type GetTableChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<TableChangesFiltersInput>;
-  first: Scalars['Int']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<TableChangesFiltersInput>
+  first: Scalars['Int']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type GetTableForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetTableInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetTableRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetTableViewsInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type GetUsersOrganizationInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+}
 
 export type GetUsersProjectInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GithubOauth = {
-  __typename: 'GithubOauth';
-  available: Scalars['Boolean']['output'];
-  clientId?: Maybe<Scalars['String']['output']>;
-};
+  __typename: 'GithubOauth'
+  available: Scalars['Boolean']['output']
+  clientId?: Maybe<Scalars['String']['output']>
+}
 
 export type GoogleOauth = {
-  __typename: 'GoogleOauth';
-  available: Scalars['Boolean']['output'];
-  clientId?: Maybe<Scalars['String']['output']>;
-};
+  __typename: 'GoogleOauth'
+  available: Scalars['Boolean']['output']
+  clientId?: Maybe<Scalars['String']['output']>
+}
 
 export type HistoryPatchModel = {
-  __typename: 'HistoryPatchModel';
-  hash: Scalars['String']['output'];
-  patches: Array<JsonPatchOperationModel>;
-};
+  __typename: 'HistoryPatchModel'
+  hash: Scalars['String']['output']
+  patches: Array<JsonPatchOperationModel>
+}
 
 export type JsonFilter = {
-  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>;
-  array_ends_with?: InputMaybe<Scalars['JSON']['input']>;
-  array_starts_with?: InputMaybe<Scalars['JSON']['input']>;
-  equals?: InputMaybe<Scalars['JSON']['input']>;
-  gt?: InputMaybe<Scalars['Float']['input']>;
-  gte?: InputMaybe<Scalars['Float']['input']>;
-  lt?: InputMaybe<Scalars['Float']['input']>;
-  lte?: InputMaybe<Scalars['Float']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  path?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  searchIn?: InputMaybe<SearchIn>;
+  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>
+  array_ends_with?: InputMaybe<Scalars['JSON']['input']>
+  array_starts_with?: InputMaybe<Scalars['JSON']['input']>
+  equals?: InputMaybe<Scalars['JSON']['input']>
+  gt?: InputMaybe<Scalars['Float']['input']>
+  gte?: InputMaybe<Scalars['Float']['input']>
+  lt?: InputMaybe<Scalars['Float']['input']>
+  lte?: InputMaybe<Scalars['Float']['input']>
+  mode?: InputMaybe<QueryMode>
+  path?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  searchIn?: InputMaybe<SearchIn>
   /** Default: simple */
-  searchLanguage?: InputMaybe<SearchLanguage>;
-  searchType?: InputMaybe<SearchType>;
-  string_contains?: InputMaybe<Scalars['String']['input']>;
-  string_ends_with?: InputMaybe<Scalars['String']['input']>;
-  string_starts_with?: InputMaybe<Scalars['String']['input']>;
-};
+  searchLanguage?: InputMaybe<SearchLanguage>
+  searchType?: InputMaybe<SearchType>
+  string_contains?: InputMaybe<Scalars['String']['input']>
+  string_ends_with?: InputMaybe<Scalars['String']['input']>
+  string_starts_with?: InputMaybe<Scalars['String']['input']>
+}
 
 export enum JsonPatchOp {
   ADD = 'ADD',
   COPY = 'COPY',
   MOVE = 'MOVE',
   REMOVE = 'REMOVE',
-  REPLACE = 'REPLACE'
+  REPLACE = 'REPLACE',
 }
 
 export type JsonPatchOperationModel = {
-  __typename: 'JsonPatchOperationModel';
-  from?: Maybe<Scalars['String']['output']>;
-  op: JsonPatchOp;
-  path: Scalars['String']['output'];
-  value?: Maybe<Scalars['JSON']['output']>;
-};
+  __typename: 'JsonPatchOperationModel'
+  from?: Maybe<Scalars['String']['output']>
+  op: JsonPatchOp
+  path: Scalars['String']['output']
+  value?: Maybe<Scalars['JSON']['output']>
+}
 
 export type LoginGithubInput = {
-  code: Scalars['String']['input'];
-};
+  code: Scalars['String']['input']
+}
 
 export type LoginGoogleInput = {
-  code: Scalars['String']['input'];
-  redirectUrl: Scalars['String']['input'];
-};
+  code: Scalars['String']['input']
+  redirectUrl: Scalars['String']['input']
+}
 
 export type LoginInput = {
-  emailOrUsername: Scalars['String']['input'];
-  password: Scalars['String']['input'];
-};
+  emailOrUsername: Scalars['String']['input']
+  password: Scalars['String']['input']
+}
 
 export type LoginModel = {
-  __typename: 'LoginModel';
-  accessToken: Scalars['String']['output'];
-};
+  __typename: 'LoginModel'
+  accessToken: Scalars['String']['output']
+}
 
 export type MeModel = {
-  __typename: 'MeModel';
-  email?: Maybe<Scalars['String']['output']>;
-  hasPassword: Scalars['Boolean']['output'];
-  id: Scalars['String']['output'];
-  organization?: Maybe<OrganizationModel>;
-  organizationId?: Maybe<Scalars['String']['output']>;
-  role?: Maybe<RoleModel>;
-  username?: Maybe<Scalars['String']['output']>;
-};
+  __typename: 'MeModel'
+  email?: Maybe<Scalars['String']['output']>
+  hasPassword: Scalars['Boolean']['output']
+  id: Scalars['String']['output']
+  organization?: Maybe<OrganizationModel>
+  organizationId?: Maybe<Scalars['String']['output']>
+  role?: Maybe<RoleModel>
+  username?: Maybe<Scalars['String']['output']>
+}
 
 export enum MigrationType {
   INIT = 'INIT',
   REMOVE = 'REMOVE',
   RENAME = 'RENAME',
-  UPDATE = 'UPDATE'
+  UPDATE = 'UPDATE',
 }
 
 export type ModifiedRowChangeModel = {
-  __typename: 'ModifiedRowChangeModel';
-  changeType: ChangeType;
-  fieldChanges: Array<FieldChangeModel>;
-  fromRow: RowChangeRowModel;
-  fromTable: RowChangeTableModel;
-  row: RowChangeRowModel;
-  table: RowChangeTableModel;
-};
+  __typename: 'ModifiedRowChangeModel'
+  changeType: ChangeType
+  fieldChanges: Array<FieldChangeModel>
+  fromRow: RowChangeRowModel
+  fromTable: RowChangeTableModel
+  row: RowChangeRowModel
+  table: RowChangeTableModel
+}
 
 export type Mutation = {
-  __typename: 'Mutation';
-  activateEarlyAccess: SubscriptionModel;
-  addUserToOrganization: Scalars['Boolean']['output'];
-  addUserToProject: Scalars['Boolean']['output'];
-  applyMigrations: Array<ApplyMigrationResultModel>;
-  cancelSubscription: Scalars['Boolean']['output'];
-  confirmEmailCode: LoginModel;
-  createBranch: BranchModel;
-  createCheckout: CheckoutResultModel;
-  createEndpoint: EndpointModel;
-  createPersonalApiKey: ApiKeyWithSecretModel;
-  createProject: ProjectModel;
-  createRevision: RevisionModel;
-  createRow: CreateRowResultModel;
-  createRows: CreateRowsResultModel;
-  createServiceApiKey: ApiKeyWithSecretModel;
-  createTable: CreateTableResultModel;
-  createUser: Scalars['Boolean']['output'];
-  deleteBranch: Scalars['Boolean']['output'];
-  deleteEndpoint: Scalars['Boolean']['output'];
-  deleteProject: Scalars['Boolean']['output'];
-  deleteRow: DeleteRowResultModel;
-  deleteRows: DeleteRowsResultModel;
-  deleteTable: DeleteTableResultModel;
-  login: LoginModel;
-  loginGithub: LoginModel;
-  loginGoogle: LoginModel;
-  patchRow: PatchRowResultModel;
-  patchRows: PatchRowsResultModel;
-  removeUserFromOrganization: Scalars['Boolean']['output'];
-  removeUserFromProject: Scalars['Boolean']['output'];
-  renameRow: RenameRowResultModel;
-  renameTable: RenameTableResultModel;
-  resetPassword: Scalars['Boolean']['output'];
-  revertChanges: BranchModel;
-  revokeApiKey: ApiKeyModel;
-  rotateApiKey: ApiKeyWithSecretModel;
-  setUsername: Scalars['Boolean']['output'];
-  signUp: Scalars['Boolean']['output'];
-  updatePassword: Scalars['Boolean']['output'];
-  updateProject: Scalars['Boolean']['output'];
-  updateRow: UpdateRowResultModel;
-  updateRows: UpdateRowsResultModel;
-  updateTable: UpdateTableResultModel;
-  updateTableViews: TableViewsDataModel;
-  updateUserProjectRole: Scalars['Boolean']['output'];
-};
-
+  __typename: 'Mutation'
+  activateEarlyAccess: SubscriptionModel
+  addUserToOrganization: Scalars['Boolean']['output']
+  addUserToProject: Scalars['Boolean']['output']
+  adminResetAllCache: Scalars['Boolean']['output']
+  applyMigrations: Array<ApplyMigrationResultModel>
+  cancelSubscription: Scalars['Boolean']['output']
+  confirmEmailCode: LoginModel
+  createBranch: BranchModel
+  createCheckout: CheckoutResultModel
+  createEndpoint: EndpointModel
+  createPersonalApiKey: ApiKeyWithSecretModel
+  createProject: ProjectModel
+  createRevision: RevisionModel
+  createRow: CreateRowResultModel
+  createRows: CreateRowsResultModel
+  createServiceApiKey: ApiKeyWithSecretModel
+  createTable: CreateTableResultModel
+  createUser: Scalars['Boolean']['output']
+  deleteBranch: Scalars['Boolean']['output']
+  deleteEndpoint: Scalars['Boolean']['output']
+  deleteProject: Scalars['Boolean']['output']
+  deleteRow: DeleteRowResultModel
+  deleteRows: DeleteRowsResultModel
+  deleteTable: DeleteTableResultModel
+  login: LoginModel
+  loginGithub: LoginModel
+  loginGoogle: LoginModel
+  patchRow: PatchRowResultModel
+  patchRows: PatchRowsResultModel
+  removeUserFromOrganization: Scalars['Boolean']['output']
+  removeUserFromProject: Scalars['Boolean']['output']
+  renameRow: RenameRowResultModel
+  renameTable: RenameTableResultModel
+  resetPassword: Scalars['Boolean']['output']
+  revertChanges: BranchModel
+  revokeApiKey: ApiKeyModel
+  rotateApiKey: ApiKeyWithSecretModel
+  setUsername: Scalars['Boolean']['output']
+  signUp: Scalars['Boolean']['output']
+  updatePassword: Scalars['Boolean']['output']
+  updateProject: Scalars['Boolean']['output']
+  updateRow: UpdateRowResultModel
+  updateRows: UpdateRowsResultModel
+  updateTable: UpdateTableResultModel
+  updateTableViews: TableViewsDataModel
+  updateUserProjectRole: Scalars['Boolean']['output']
+}
 
 export type MutationActivateEarlyAccessArgs = {
-  data: ActivateEarlyAccessInput;
-};
-
+  data: ActivateEarlyAccessInput
+}
 
 export type MutationAddUserToOrganizationArgs = {
-  data: AddUserToOrganizationInput;
-};
-
+  data: AddUserToOrganizationInput
+}
 
 export type MutationAddUserToProjectArgs = {
-  data: AddUserToProjectInput;
-};
-
+  data: AddUserToProjectInput
+}
 
 export type MutationApplyMigrationsArgs = {
-  data: ApplyMigrationsInput;
-};
-
+  data: ApplyMigrationsInput
+}
 
 export type MutationCancelSubscriptionArgs = {
-  data: CancelSubscriptionInput;
-};
-
+  data: CancelSubscriptionInput
+}
 
 export type MutationConfirmEmailCodeArgs = {
-  data: ConfirmEmailCodeInput;
-};
-
+  data: ConfirmEmailCodeInput
+}
 
 export type MutationCreateBranchArgs = {
-  data: CreateBranchInput;
-};
-
+  data: CreateBranchInput
+}
 
 export type MutationCreateCheckoutArgs = {
-  data: CreateCheckoutInput;
-};
-
+  data: CreateCheckoutInput
+}
 
 export type MutationCreateEndpointArgs = {
-  data: CreateEndpointInput;
-};
-
+  data: CreateEndpointInput
+}
 
 export type MutationCreatePersonalApiKeyArgs = {
-  data: CreatePersonalApiKeyInput;
-};
-
+  data: CreatePersonalApiKeyInput
+}
 
 export type MutationCreateProjectArgs = {
-  data: CreateProjectInput;
-};
-
+  data: CreateProjectInput
+}
 
 export type MutationCreateRevisionArgs = {
-  data: CreateRevisionInput;
-};
-
+  data: CreateRevisionInput
+}
 
 export type MutationCreateRowArgs = {
-  data: CreateRowInput;
-};
-
+  data: CreateRowInput
+}
 
 export type MutationCreateRowsArgs = {
-  data: CreateRowsInput;
-};
-
+  data: CreateRowsInput
+}
 
 export type MutationCreateServiceApiKeyArgs = {
-  data: CreateServiceApiKeyInput;
-};
-
+  data: CreateServiceApiKeyInput
+}
 
 export type MutationCreateTableArgs = {
-  data: CreateTableInput;
-};
-
+  data: CreateTableInput
+}
 
 export type MutationCreateUserArgs = {
-  data: CreateUserInput;
-};
-
+  data: CreateUserInput
+}
 
 export type MutationDeleteBranchArgs = {
-  data: DeleteBranchInput;
-};
-
+  data: DeleteBranchInput
+}
 
 export type MutationDeleteEndpointArgs = {
-  data: DeleteEndpointInput;
-};
-
+  data: DeleteEndpointInput
+}
 
 export type MutationDeleteProjectArgs = {
-  data: DeleteProjectInput;
-};
-
+  data: DeleteProjectInput
+}
 
 export type MutationDeleteRowArgs = {
-  data: DeleteRowInput;
-};
-
+  data: DeleteRowInput
+}
 
 export type MutationDeleteRowsArgs = {
-  data: DeleteRowsInput;
-};
-
+  data: DeleteRowsInput
+}
 
 export type MutationDeleteTableArgs = {
-  data: DeleteTableInput;
-};
-
+  data: DeleteTableInput
+}
 
 export type MutationLoginArgs = {
-  data: LoginInput;
-};
-
+  data: LoginInput
+}
 
 export type MutationLoginGithubArgs = {
-  data: LoginGithubInput;
-};
-
+  data: LoginGithubInput
+}
 
 export type MutationLoginGoogleArgs = {
-  data: LoginGoogleInput;
-};
-
+  data: LoginGoogleInput
+}
 
 export type MutationPatchRowArgs = {
-  data: PatchRowInput;
-};
-
+  data: PatchRowInput
+}
 
 export type MutationPatchRowsArgs = {
-  data: PatchRowsInput;
-};
-
+  data: PatchRowsInput
+}
 
 export type MutationRemoveUserFromOrganizationArgs = {
-  data: RemoveUserFromOrganizationInput;
-};
-
+  data: RemoveUserFromOrganizationInput
+}
 
 export type MutationRemoveUserFromProjectArgs = {
-  data: RemoveUserFromProjectInput;
-};
-
+  data: RemoveUserFromProjectInput
+}
 
 export type MutationRenameRowArgs = {
-  data: RenameRowInput;
-};
-
+  data: RenameRowInput
+}
 
 export type MutationRenameTableArgs = {
-  data: RenameTableInput;
-};
-
+  data: RenameTableInput
+}
 
 export type MutationResetPasswordArgs = {
-  data: ResetPasswordInput;
-};
-
+  data: ResetPasswordInput
+}
 
 export type MutationRevertChangesArgs = {
-  data: RevertChangesInput;
-};
-
+  data: RevertChangesInput
+}
 
 export type MutationRevokeApiKeyArgs = {
-  id: Scalars['ID']['input'];
-};
-
+  id: Scalars['ID']['input']
+}
 
 export type MutationRotateApiKeyArgs = {
-  id: Scalars['ID']['input'];
-};
-
+  id: Scalars['ID']['input']
+}
 
 export type MutationSetUsernameArgs = {
-  data: SetUsernameInput;
-};
-
+  data: SetUsernameInput
+}
 
 export type MutationSignUpArgs = {
-  data: SignUpInput;
-};
-
+  data: SignUpInput
+}
 
 export type MutationUpdatePasswordArgs = {
-  data: UpdatePasswordInput;
-};
-
+  data: UpdatePasswordInput
+}
 
 export type MutationUpdateProjectArgs = {
-  data: UpdateProjectInput;
-};
-
+  data: UpdateProjectInput
+}
 
 export type MutationUpdateRowArgs = {
-  data: UpdateRowInput;
-};
-
+  data: UpdateRowInput
+}
 
 export type MutationUpdateRowsArgs = {
-  data: UpdateRowsInput;
-};
-
+  data: UpdateRowsInput
+}
 
 export type MutationUpdateTableArgs = {
-  data: UpdateTableInput;
-};
-
+  data: UpdateTableInput
+}
 
 export type MutationUpdateTableViewsArgs = {
-  data: UpdateTableViewsInput;
-};
-
+  data: UpdateTableViewsInput
+}
 
 export type MutationUpdateUserProjectRoleArgs = {
-  data: UpdateUserProjectRoleInput;
-};
+  data: UpdateUserProjectRoleInput
+}
 
 export enum NullsPosition {
   FIRST = 'first',
-  LAST = 'last'
+  LAST = 'last',
 }
 
 export type OrderBy = {
-  aggregation?: InputMaybe<OrderDataAggregation>;
-  direction: SortOrder;
-  field: OrderByField;
-  path?: InputMaybe<Scalars['String']['input']>;
-  type?: InputMaybe<OrderDataType>;
-};
+  aggregation?: InputMaybe<OrderDataAggregation>
+  direction: SortOrder
+  field: OrderByField
+  path?: InputMaybe<Scalars['String']['input']>
+  type?: InputMaybe<OrderDataType>
+}
 
 export enum OrderByField {
   CREATEDAT = 'createdAt',
   DATA = 'data',
   ID = 'id',
   PUBLISHEDAT = 'publishedAt',
-  UPDATEDAT = 'updatedAt'
+  UPDATEDAT = 'updatedAt',
 }
 
 export enum OrderDataAggregation {
@@ -980,7 +966,7 @@ export enum OrderDataAggregation {
   FIRST = 'first',
   LAST = 'last',
   MAX = 'max',
-  MIN = 'min'
+  MIN = 'min',
 }
 
 export enum OrderDataType {
@@ -988,561 +974,531 @@ export enum OrderDataType {
   FLOAT = 'float',
   INT = 'int',
   TEXT = 'text',
-  TIMESTAMP = 'timestamp'
+  TIMESTAMP = 'timestamp',
 }
 
 export type OrganizationModel = {
-  __typename: 'OrganizationModel';
-  createdId: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  subscription?: Maybe<SubscriptionModel>;
-  usage?: Maybe<UsageSummaryModel>;
-  userOrganization?: Maybe<UsersOrganizationModel>;
-};
+  __typename: 'OrganizationModel'
+  createdId: Scalars['String']['output']
+  id: Scalars['String']['output']
+  subscription?: Maybe<SubscriptionModel>
+  usage?: Maybe<UsageSummaryModel>
+  userOrganization?: Maybe<UsersOrganizationModel>
+}
 
 export type PageInfo = {
-  __typename: 'PageInfo';
-  endCursor?: Maybe<Scalars['String']['output']>;
-  hasNextPage: Scalars['Boolean']['output'];
-  hasPreviousPage: Scalars['Boolean']['output'];
-  startCursor?: Maybe<Scalars['String']['output']>;
-};
+  __typename: 'PageInfo'
+  endCursor?: Maybe<Scalars['String']['output']>
+  hasNextPage: Scalars['Boolean']['output']
+  hasPreviousPage: Scalars['Boolean']['output']
+  startCursor?: Maybe<Scalars['String']['output']>
+}
 
 export type ParentBranchModel = {
-  __typename: 'ParentBranchModel';
-  branch: BranchModel;
-  revision: RevisionModel;
-};
+  __typename: 'ParentBranchModel'
+  branch: BranchModel
+  revision: RevisionModel
+}
 
 export type PatchRow = {
-  op: PatchRowOp;
-  path: Scalars['String']['input'];
-  value: Scalars['JSON']['input'];
-};
+  op: PatchRowOp
+  path: Scalars['String']['input']
+  value: Scalars['JSON']['input']
+}
 
 export type PatchRowInput = {
-  patches: Array<PatchRow>;
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  patches: Array<PatchRow>
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export enum PatchRowOp {
-  REPLACE = 'replace'
+  REPLACE = 'replace',
 }
 
 export type PatchRowResultModel = {
-  __typename: 'PatchRowResultModel';
-  previousVersionRowId: Scalars['String']['output'];
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  __typename: 'PatchRowResultModel'
+  previousVersionRowId: Scalars['String']['output']
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type PatchRowsInput = {
-  revisionId: Scalars['String']['input'];
-  rows: Array<PatchRowsRowInput>;
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rows: Array<PatchRowsRowInput>
+  tableId: Scalars['String']['input']
+}
 
 export type PatchRowsResultModel = {
-  __typename: 'PatchRowsResultModel';
-  previousVersionTableId: Scalars['String']['output'];
-  rows: Array<RowModel>;
-  table: TableModel;
-};
+  __typename: 'PatchRowsResultModel'
+  previousVersionTableId: Scalars['String']['output']
+  rows: Array<RowModel>
+  table: TableModel
+}
 
 export type PatchRowsRowInput = {
-  patches: Array<PatchRow>;
-  rowId: Scalars['String']['input'];
-};
+  patches: Array<PatchRow>
+  rowId: Scalars['String']['input']
+}
 
 export type PaymentProviderModel = {
-  __typename: 'PaymentProviderModel';
-  id: Scalars['ID']['output'];
-  methods: Array<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-  supportsRecurring: Scalars['Boolean']['output'];
-};
+  __typename: 'PaymentProviderModel'
+  id: Scalars['ID']['output']
+  methods: Array<Scalars['String']['output']>
+  name: Scalars['String']['output']
+  supportsRecurring: Scalars['Boolean']['output']
+}
 
 export type PermissionModel = {
-  __typename: 'PermissionModel';
-  action: Scalars['String']['output'];
-  condition?: Maybe<Scalars['JSON']['output']>;
-  id: Scalars['String']['output'];
-  subject: Scalars['String']['output'];
-};
+  __typename: 'PermissionModel'
+  action: Scalars['String']['output']
+  condition?: Maybe<Scalars['JSON']['output']>
+  id: Scalars['String']['output']
+  subject: Scalars['String']['output']
+}
 
 export type PlanLimitsModel = {
-  __typename: 'PlanLimitsModel';
-  apiCallsPerDay?: Maybe<Scalars['Int']['output']>;
-  branchesPerProject?: Maybe<Scalars['Int']['output']>;
-  projects?: Maybe<Scalars['Int']['output']>;
-  rowVersions?: Maybe<Scalars['Int']['output']>;
-  rowsPerTable?: Maybe<Scalars['Int']['output']>;
-  seats?: Maybe<Scalars['Int']['output']>;
-  storageBytes?: Maybe<Scalars['Float']['output']>;
-  tablesPerRevision?: Maybe<Scalars['Int']['output']>;
-};
+  __typename: 'PlanLimitsModel'
+  apiCallsPerDay?: Maybe<Scalars['Int']['output']>
+  branchesPerProject?: Maybe<Scalars['Int']['output']>
+  projects?: Maybe<Scalars['Int']['output']>
+  rowVersions?: Maybe<Scalars['Int']['output']>
+  rowsPerTable?: Maybe<Scalars['Int']['output']>
+  seats?: Maybe<Scalars['Int']['output']>
+  storageBytes?: Maybe<Scalars['Float']['output']>
+  tablesPerRevision?: Maybe<Scalars['Int']['output']>
+}
 
 export type PlanModel = {
-  __typename: 'PlanModel';
-  features: Scalars['JSON']['output'];
-  id: Scalars['ID']['output'];
-  isPublic: Scalars['Boolean']['output'];
-  limits: PlanLimitsModel;
-  monthlyPriceUsd: Scalars['Float']['output'];
-  name: Scalars['String']['output'];
-  yearlyPriceUsd: Scalars['Float']['output'];
-};
+  __typename: 'PlanModel'
+  features: Scalars['JSON']['output']
+  id: Scalars['ID']['output']
+  isPublic: Scalars['Boolean']['output']
+  limits: PlanLimitsModel
+  monthlyPriceUsd: Scalars['Float']['output']
+  name: Scalars['String']['output']
+  yearlyPriceUsd: Scalars['Float']['output']
+}
 
 export type PluginsModel = {
-  __typename: 'PluginsModel';
-  file: Scalars['Boolean']['output'];
-};
+  __typename: 'PluginsModel'
+  file: Scalars['Boolean']['output']
+}
 
 export type ProjectModel = {
-  __typename: 'ProjectModel';
-  allBranches: BranchesConnection;
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['String']['output'];
-  isPublic: Scalars['Boolean']['output'];
-  name: Scalars['String']['output'];
-  organization: OrganizationModel;
-  organizationId: Scalars['String']['output'];
-  rootBranch: BranchModel;
-  userProject?: Maybe<UsersProjectModel>;
-};
-
+  __typename: 'ProjectModel'
+  allBranches: BranchesConnection
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['String']['output']
+  isPublic: Scalars['Boolean']['output']
+  name: Scalars['String']['output']
+  organization: OrganizationModel
+  organizationId: Scalars['String']['output']
+  rootBranch: BranchModel
+  userProject?: Maybe<UsersProjectModel>
+}
 
 export type ProjectModelAllBranchesArgs = {
-  data: GetProjectBranchesInput;
-};
+  data: GetProjectBranchesInput
+}
 
 export type ProjectModelEdge = {
-  __typename: 'ProjectModelEdge';
-  cursor: Scalars['String']['output'];
-  node: ProjectModel;
-};
+  __typename: 'ProjectModelEdge'
+  cursor: Scalars['String']['output']
+  node: ProjectModel
+}
 
 export type ProjectsConnection = {
-  __typename: 'ProjectsConnection';
-  edges: Array<ProjectModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'ProjectsConnection'
+  edges: Array<ProjectModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type Query = {
-  __typename: 'Query';
-  adminUser?: Maybe<UserModel>;
-  adminUsers: UsersConnection;
-  apiKeyById: ApiKeyModel;
-  availableProviders: Array<PaymentProviderModel>;
-  branch: BranchModel;
-  branches: BranchesConnection;
-  configuration: ConfigurationModel;
+  __typename: 'Query'
+  adminCacheStats: CacheStatsModel
+  adminUser?: Maybe<UserModel>
+  adminUsers: UsersConnection
+  apiKeyById: ApiKeyModel
+  availableProviders: Array<PaymentProviderModel>
+  branch: BranchModel
+  branches: BranchesConnection
+  configuration: ConfigurationModel
   /** @deprecated use RowModel.rowForeignKeysBy.totalCount */
-  getRowCountForeignKeysTo: Scalars['Int']['output'];
-  me: MeModel;
-  meProjects: ProjectsConnection;
-  myApiKeys: Array<ApiKeyModel>;
-  organization: OrganizationModel;
-  plans: Array<PlanModel>;
-  project: ProjectModel;
-  projectEndpoints: EndpointsConnection;
-  projects: ProjectsConnection;
-  revision: RevisionModel;
-  revisionChanges: RevisionChangesModel;
-  row?: Maybe<RowModel>;
-  rowChanges: RowChangesConnection;
-  rows: RowsConnection;
-  searchRows: SearchResultsConnection;
-  searchUsers: SearchUsersConnection;
-  serviceApiKeys: Array<ApiKeyModel>;
-  subSchemaItems: SubSchemaItemsConnection;
-  table?: Maybe<TableModel>;
-  tableChanges: TableChangesConnection;
-  tableViews: TableViewsDataModel;
-  tables: TablesConnection;
-  usersOrganization: UsersOrganizationConnection;
-  usersProject: UsersProjectConnection;
-};
-
+  getRowCountForeignKeysTo: Scalars['Int']['output']
+  me: MeModel
+  meProjects: ProjectsConnection
+  myApiKeys: Array<ApiKeyModel>
+  organization: OrganizationModel
+  plans: Array<PlanModel>
+  project: ProjectModel
+  projectEndpoints: EndpointsConnection
+  projects: ProjectsConnection
+  revision: RevisionModel
+  revisionChanges: RevisionChangesModel
+  row?: Maybe<RowModel>
+  rowChanges: RowChangesConnection
+  rows: RowsConnection
+  searchRows: SearchResultsConnection
+  searchUsers: SearchUsersConnection
+  serviceApiKeys: Array<ApiKeyModel>
+  subSchemaItems: SubSchemaItemsConnection
+  table?: Maybe<TableModel>
+  tableChanges: TableChangesConnection
+  tableViews: TableViewsDataModel
+  tables: TablesConnection
+  usersOrganization: UsersOrganizationConnection
+  usersProject: UsersProjectConnection
+}
 
 export type QueryAdminUserArgs = {
-  data: AdminUserInput;
-};
-
+  data: AdminUserInput
+}
 
 export type QueryAdminUsersArgs = {
-  data: SearchUsersInput;
-};
-
+  data: SearchUsersInput
+}
 
 export type QueryApiKeyByIdArgs = {
-  id: Scalars['ID']['input'];
-};
-
+  id: Scalars['ID']['input']
+}
 
 export type QueryAvailableProvidersArgs = {
-  country?: InputMaybe<Scalars['String']['input']>;
-  method?: InputMaybe<Scalars['String']['input']>;
-};
-
+  country?: InputMaybe<Scalars['String']['input']>
+  method?: InputMaybe<Scalars['String']['input']>
+}
 
 export type QueryBranchArgs = {
-  data: GetBranchInput;
-};
-
+  data: GetBranchInput
+}
 
 export type QueryBranchesArgs = {
-  data: GetBranchesInput;
-};
-
+  data: GetBranchesInput
+}
 
 export type QueryGetRowCountForeignKeysToArgs = {
-  data: GetRowCountForeignKeysByInput;
-};
-
+  data: GetRowCountForeignKeysByInput
+}
 
 export type QueryMeProjectsArgs = {
-  data: GetMeProjectsInput;
-};
-
+  data: GetMeProjectsInput
+}
 
 export type QueryOrganizationArgs = {
-  data: GetOrganizationInput;
-};
-
+  data: GetOrganizationInput
+}
 
 export type QueryProjectArgs = {
-  data: GetProjectInput;
-};
-
+  data: GetProjectInput
+}
 
 export type QueryProjectEndpointsArgs = {
-  data: GetProjectEndpointsInput;
-};
-
+  data: GetProjectEndpointsInput
+}
 
 export type QueryProjectsArgs = {
-  data: GetProjectsInput;
-};
-
+  data: GetProjectsInput
+}
 
 export type QueryRevisionArgs = {
-  data: GetRevisionInput;
-};
-
+  data: GetRevisionInput
+}
 
 export type QueryRevisionChangesArgs = {
-  data: GetRevisionChangesInput;
-};
-
+  data: GetRevisionChangesInput
+}
 
 export type QueryRowArgs = {
-  data: GetRowInput;
-};
-
+  data: GetRowInput
+}
 
 export type QueryRowChangesArgs = {
-  data: GetRowChangesInput;
-};
-
+  data: GetRowChangesInput
+}
 
 export type QueryRowsArgs = {
-  data: GetRowsInput;
-};
-
+  data: GetRowsInput
+}
 
 export type QuerySearchRowsArgs = {
-  data: SearchRowsInput;
-};
-
+  data: SearchRowsInput
+}
 
 export type QuerySearchUsersArgs = {
-  data: SearchUsersInput;
-};
-
+  data: SearchUsersInput
+}
 
 export type QueryServiceApiKeysArgs = {
-  organizationId: Scalars['String']['input'];
-};
-
+  organizationId: Scalars['String']['input']
+}
 
 export type QuerySubSchemaItemsArgs = {
-  data: GetSubSchemaItemsInput;
-};
-
+  data: GetSubSchemaItemsInput
+}
 
 export type QueryTableArgs = {
-  data: GetTableInput;
-};
-
+  data: GetTableInput
+}
 
 export type QueryTableChangesArgs = {
-  data: GetTableChangesInput;
-};
-
+  data: GetTableChangesInput
+}
 
 export type QueryTableViewsArgs = {
-  data: GetTableViewsInput;
-};
-
+  data: GetTableViewsInput
+}
 
 export type QueryTablesArgs = {
-  data: GetTablesInput;
-};
-
+  data: GetTablesInput
+}
 
 export type QueryUsersOrganizationArgs = {
-  data: GetUsersOrganizationInput;
-};
-
+  data: GetUsersOrganizationInput
+}
 
 export type QueryUsersProjectArgs = {
-  data: GetUsersProjectInput;
-};
+  data: GetUsersProjectInput
+}
 
 export enum QueryMode {
   DEFAULT = 'default',
-  INSENSITIVE = 'insensitive'
+  INSENSITIVE = 'insensitive',
 }
 
 export type RemoveUserFromOrganizationInput = {
-  organizationId: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}
 
 export type RemoveUserFromProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}
 
 export type RemovedRowChangeModel = {
-  __typename: 'RemovedRowChangeModel';
-  changeType: ChangeType;
-  fieldChanges: Array<FieldChangeModel>;
-  fromRow: RowChangeRowModel;
-  fromTable: RowChangeTableModel;
-};
+  __typename: 'RemovedRowChangeModel'
+  changeType: ChangeType
+  fieldChanges: Array<FieldChangeModel>
+  fromRow: RowChangeRowModel
+  fromTable: RowChangeTableModel
+}
 
 export type RenameRowInput = {
-  nextRowId: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  nextRowId: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type RenameRowResultModel = {
-  __typename: 'RenameRowResultModel';
-  previousVersionRowId: Scalars['String']['output'];
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  __typename: 'RenameRowResultModel'
+  previousVersionRowId: Scalars['String']['output']
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type RenameTableInput = {
-  nextTableId: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  nextTableId: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type RenameTableResultModel = {
-  __typename: 'RenameTableResultModel';
-  previousVersionTableId: Scalars['String']['output'];
-  table: TableModel;
-};
+  __typename: 'RenameTableResultModel'
+  previousVersionTableId: Scalars['String']['output']
+  table: TableModel
+}
 
 export type ResetPasswordInput = {
-  newPassword: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-};
+  newPassword: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}
 
 export type RevertChangesInput = {
-  branchName: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type RevisionChangeSummaryModel = {
-  __typename: 'RevisionChangeSummaryModel';
-  added: Scalars['Int']['output'];
-  modified: Scalars['Int']['output'];
-  removed: Scalars['Int']['output'];
-  renamed: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
+  __typename: 'RevisionChangeSummaryModel'
+  added: Scalars['Int']['output']
+  modified: Scalars['Int']['output']
+  removed: Scalars['Int']['output']
+  renamed: Scalars['Int']['output']
+  total: Scalars['Int']['output']
+}
 
 export type RevisionChangesModel = {
-  __typename: 'RevisionChangesModel';
-  parentRevisionId?: Maybe<Scalars['String']['output']>;
-  revisionId: Scalars['String']['output'];
-  rowsSummary: RevisionChangeSummaryModel;
-  tablesSummary: RevisionChangeSummaryModel;
-  totalChanges: Scalars['Int']['output'];
-};
+  __typename: 'RevisionChangesModel'
+  parentRevisionId?: Maybe<Scalars['String']['output']>
+  revisionId: Scalars['String']['output']
+  rowsSummary: RevisionChangeSummaryModel
+  tablesSummary: RevisionChangeSummaryModel
+  totalChanges: Scalars['Int']['output']
+}
 
 export type RevisionConnection = {
-  __typename: 'RevisionConnection';
-  edges: Array<RevisionModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'RevisionConnection'
+  edges: Array<RevisionModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type RevisionModel = {
-  __typename: 'RevisionModel';
-  branch: BranchModel;
-  changes: RevisionChangesModel;
-  child?: Maybe<RevisionModel>;
-  childBranches: Array<ChildBranchModel>;
-  children: Array<RevisionModel>;
-  comment: Scalars['String']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  endpoints: Array<EndpointModel>;
-  id: Scalars['String']['output'];
-  isDraft: Scalars['Boolean']['output'];
-  isHead: Scalars['Boolean']['output'];
-  isStart: Scalars['Boolean']['output'];
-  migrations: Array<Scalars['JSON']['output']>;
-  parent?: Maybe<RevisionModel>;
-  sequence: Scalars['Int']['output'];
-  tables: TablesConnection;
-};
-
+  __typename: 'RevisionModel'
+  branch: BranchModel
+  changes: RevisionChangesModel
+  child?: Maybe<RevisionModel>
+  childBranches: Array<ChildBranchModel>
+  children: Array<RevisionModel>
+  comment: Scalars['String']['output']
+  createdAt: Scalars['DateTime']['output']
+  endpoints: Array<EndpointModel>
+  id: Scalars['String']['output']
+  isDraft: Scalars['Boolean']['output']
+  isHead: Scalars['Boolean']['output']
+  isStart: Scalars['Boolean']['output']
+  migrations: Array<Scalars['JSON']['output']>
+  parent?: Maybe<RevisionModel>
+  sequence: Scalars['Int']['output']
+  tables: TablesConnection
+}
 
 export type RevisionModelTablesArgs = {
-  data: GetRevisionTablesInput;
-};
+  data: GetRevisionTablesInput
+}
 
 export type RevisionModelEdge = {
-  __typename: 'RevisionModelEdge';
-  cursor: Scalars['String']['output'];
-  node: RevisionModel;
-};
+  __typename: 'RevisionModelEdge'
+  cursor: Scalars['String']['output']
+  node: RevisionModel
+}
 
 export type RoleModel = {
-  __typename: 'RoleModel';
-  id: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  permissions: Array<PermissionModel>;
-};
+  __typename: 'RoleModel'
+  id: Scalars['String']['output']
+  name: Scalars['String']['output']
+  permissions: Array<PermissionModel>
+}
 
-export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel;
+export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel
 
 export enum RowChangeDetailType {
   FIELD_ADDED = 'FIELD_ADDED',
   FIELD_MODIFIED = 'FIELD_MODIFIED',
   FIELD_MOVED = 'FIELD_MOVED',
-  FIELD_REMOVED = 'FIELD_REMOVED'
+  FIELD_REMOVED = 'FIELD_REMOVED',
 }
 
 export type RowChangeEdge = {
-  __typename: 'RowChangeEdge';
-  cursor: Scalars['String']['output'];
-  node: RowChange;
-};
+  __typename: 'RowChangeEdge'
+  cursor: Scalars['String']['output']
+  node: RowChange
+}
 
 export type RowChangeRowModel = {
-  __typename: 'RowChangeRowModel';
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  data: Scalars['JSON']['output'];
-  hash: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  meta: Scalars['JSON']['output'];
-  publishedAt: Scalars['DateTime']['output'];
-  readonly: Scalars['Boolean']['output'];
-  schemaHash: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-};
+  __typename: 'RowChangeRowModel'
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  data: Scalars['JSON']['output']
+  hash: Scalars['String']['output']
+  id: Scalars['String']['output']
+  meta: Scalars['JSON']['output']
+  publishedAt: Scalars['DateTime']['output']
+  readonly: Scalars['Boolean']['output']
+  schemaHash: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+}
 
 export type RowChangeTableModel = {
-  __typename: 'RowChangeTableModel';
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  readonly: Scalars['Boolean']['output'];
-  system: Scalars['Boolean']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-};
+  __typename: 'RowChangeTableModel'
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  id: Scalars['String']['output']
+  readonly: Scalars['Boolean']['output']
+  system: Scalars['Boolean']['output']
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+}
 
 export type RowChangesConnection = {
-  __typename: 'RowChangesConnection';
-  edges: Array<RowChangeEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'RowChangesConnection'
+  edges: Array<RowChangeEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type RowChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>;
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  tableId?: InputMaybe<Scalars['String']['input']>;
-};
+  changeTypes?: InputMaybe<Array<ChangeType>>
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
+  search?: InputMaybe<Scalars['String']['input']>
+  tableId?: InputMaybe<Scalars['String']['input']>
+}
 
 export type RowModel = {
-  __typename: 'RowModel';
-  countForeignKeysTo: Scalars['Int']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  data: Scalars['JSON']['output'];
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
-  id: Scalars['String']['output'];
-  publishedAt: Scalars['DateTime']['output'];
-  readonly: Scalars['Boolean']['output'];
-  rowForeignKeysBy: RowsConnection;
-  rowForeignKeysTo: RowsConnection;
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-};
-
+  __typename: 'RowModel'
+  countForeignKeysTo: Scalars['Int']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  data: Scalars['JSON']['output']
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
+  id: Scalars['String']['output']
+  publishedAt: Scalars['DateTime']['output']
+  readonly: Scalars['Boolean']['output']
+  rowForeignKeysBy: RowsConnection
+  rowForeignKeysTo: RowsConnection
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+}
 
 export type RowModelRowForeignKeysByArgs = {
-  data: GetRowForeignKeysInput;
-};
-
+  data: GetRowForeignKeysInput
+}
 
 export type RowModelRowForeignKeysToArgs = {
-  data: GetRowForeignKeysInput;
-};
+  data: GetRowForeignKeysInput
+}
 
 export type RowModelEdge = {
-  __typename: 'RowModelEdge';
-  cursor: Scalars['String']['output'];
-  node: RowModel;
-};
+  __typename: 'RowModelEdge'
+  cursor: Scalars['String']['output']
+  node: RowModel
+}
 
 export type RowsConnection = {
-  __typename: 'RowsConnection';
-  edges: Array<RowModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'RowsConnection'
+  edges: Array<RowModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SchemaFieldChangeModel = {
-  __typename: 'SchemaFieldChangeModel';
-  changeType: Scalars['String']['output'];
-  fieldPath: Scalars['String']['output'];
-  movedFrom?: Maybe<Scalars['String']['output']>;
-  movedTo?: Maybe<Scalars['String']['output']>;
-  newSchema?: Maybe<Scalars['JSON']['output']>;
-  oldSchema?: Maybe<Scalars['JSON']['output']>;
-};
+  __typename: 'SchemaFieldChangeModel'
+  changeType: Scalars['String']['output']
+  fieldPath: Scalars['String']['output']
+  movedFrom?: Maybe<Scalars['String']['output']>
+  movedTo?: Maybe<Scalars['String']['output']>
+  newSchema?: Maybe<Scalars['JSON']['output']>
+  oldSchema?: Maybe<Scalars['JSON']['output']>
+}
 
 export type SchemaMigrationDetailModel = {
-  __typename: 'SchemaMigrationDetailModel';
-  historyPatches?: Maybe<Array<HistoryPatchModel>>;
-  initialSchema?: Maybe<Scalars['JSON']['output']>;
-  migrationId: Scalars['String']['output'];
-  migrationType: MigrationType;
-  newTableId?: Maybe<Scalars['String']['output']>;
-  oldTableId?: Maybe<Scalars['String']['output']>;
-  patches?: Maybe<Array<JsonPatchOperationModel>>;
-};
+  __typename: 'SchemaMigrationDetailModel'
+  historyPatches?: Maybe<Array<HistoryPatchModel>>
+  initialSchema?: Maybe<Scalars['JSON']['output']>
+  migrationId: Scalars['String']['output']
+  migrationType: MigrationType
+  newTableId?: Maybe<Scalars['String']['output']>
+  oldTableId?: Maybe<Scalars['String']['output']>
+  patches?: Maybe<Array<JsonPatchOperationModel>>
+}
 
 export enum SearchIn {
   ALL = 'all',
@@ -1550,7 +1506,7 @@ export enum SearchIn {
   KEYS = 'keys',
   NUMBERS = 'numbers',
   STRINGS = 'strings',
-  VALUES = 'values'
+  VALUES = 'values',
 }
 
 /** Language for full-text search. Default: simple */
@@ -1583,531 +1539,528 @@ export enum SearchLanguage {
   SWEDISH = 'swedish',
   TAMIL = 'tamil',
   TURKISH = 'turkish',
-  YIDDISH = 'yiddish'
+  YIDDISH = 'yiddish',
 }
 
 export type SearchMatch = {
-  __typename: 'SearchMatch';
-  highlight?: Maybe<Scalars['String']['output']>;
-  path: Scalars['String']['output'];
-  value: Scalars['JSON']['output'];
-};
+  __typename: 'SearchMatch'
+  highlight?: Maybe<Scalars['String']['output']>
+  path: Scalars['String']['output']
+  value: Scalars['JSON']['output']
+}
 
 export type SearchResult = {
-  __typename: 'SearchResult';
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
-  matches: Array<SearchMatch>;
-  row: RowModel;
-  table: TableModel;
-};
+  __typename: 'SearchResult'
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
+  matches: Array<SearchMatch>
+  row: RowModel
+  table: TableModel
+}
 
 export type SearchResultEdge = {
-  __typename: 'SearchResultEdge';
-  cursor: Scalars['String']['output'];
-  node: SearchResult;
-};
+  __typename: 'SearchResultEdge'
+  cursor: Scalars['String']['output']
+  node: SearchResult
+}
 
 export type SearchResultsConnection = {
-  __typename: 'SearchResultsConnection';
-  edges: Array<SearchResultEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'SearchResultsConnection'
+  edges: Array<SearchResultEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SearchRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  query: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  query: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export enum SearchType {
   PHRASE = 'phrase',
   PLAIN = 'plain',
   PREFIX = 'prefix',
-  TSQUERY = 'tsquery'
+  TSQUERY = 'tsquery',
 }
 
 export type SearchUserModel = {
-  __typename: 'SearchUserModel';
-  email?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  username?: Maybe<Scalars['String']['output']>;
-};
+  __typename: 'SearchUserModel'
+  email?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  username?: Maybe<Scalars['String']['output']>
+}
 
 export type SearchUserModelEdge = {
-  __typename: 'SearchUserModelEdge';
-  cursor: Scalars['String']['output'];
-  node: SearchUserModel;
-};
+  __typename: 'SearchUserModelEdge'
+  cursor: Scalars['String']['output']
+  node: SearchUserModel
+}
 
 export type SearchUsersConnection = {
-  __typename: 'SearchUsersConnection';
-  edges: Array<SearchUserModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'SearchUsersConnection'
+  edges: Array<SearchUserModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SearchUsersInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  search?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SetUsernameInput = {
-  username: Scalars['String']['input'];
-};
+  username: Scalars['String']['input']
+}
 
 export type SignUpInput = {
-  email: Scalars['String']['input'];
-  password: Scalars['String']['input'];
-  username: Scalars['String']['input'];
-};
+  email: Scalars['String']['input']
+  password: Scalars['String']['input']
+  username: Scalars['String']['input']
+}
 
 export enum SortOrder {
   ASC = 'asc',
-  DESC = 'desc'
+  DESC = 'desc',
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']['input']>;
-  endsWith?: InputMaybe<Scalars['String']['input']>;
-  equals?: InputMaybe<Scalars['String']['input']>;
-  gt?: InputMaybe<Scalars['String']['input']>;
-  gte?: InputMaybe<Scalars['String']['input']>;
-  in?: InputMaybe<Array<Scalars['String']['input']>>;
-  lt?: InputMaybe<Scalars['String']['input']>;
-  lte?: InputMaybe<Scalars['String']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']['input']>;
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
-  startsWith?: InputMaybe<Scalars['String']['input']>;
-};
+  contains?: InputMaybe<Scalars['String']['input']>
+  endsWith?: InputMaybe<Scalars['String']['input']>
+  equals?: InputMaybe<Scalars['String']['input']>
+  gt?: InputMaybe<Scalars['String']['input']>
+  gte?: InputMaybe<Scalars['String']['input']>
+  in?: InputMaybe<Array<Scalars['String']['input']>>
+  lt?: InputMaybe<Scalars['String']['input']>
+  lte?: InputMaybe<Scalars['String']['input']>
+  mode?: InputMaybe<QueryMode>
+  not?: InputMaybe<Scalars['String']['input']>
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>
+  startsWith?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SubSchemaDataOrderByInput = {
-  nulls?: InputMaybe<NullsPosition>;
-  order: SortOrder;
-  path: Scalars['JSON']['input'];
-};
+  nulls?: InputMaybe<NullsPosition>
+  order: SortOrder
+  path: Scalars['JSON']['input']
+}
 
 export type SubSchemaItemModel = {
-  __typename: 'SubSchemaItemModel';
-  data: Scalars['JSON']['output'];
-  fieldPath: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  __typename: 'SubSchemaItemModel'
+  data: Scalars['JSON']['output']
+  fieldPath: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type SubSchemaItemModelEdge = {
-  __typename: 'SubSchemaItemModelEdge';
-  cursor: Scalars['String']['output'];
-  node: SubSchemaItemModel;
-};
+  __typename: 'SubSchemaItemModelEdge'
+  cursor: Scalars['String']['output']
+  node: SubSchemaItemModel
+}
 
 export type SubSchemaItemsConnection = {
-  __typename: 'SubSchemaItemsConnection';
-  edges: Array<SubSchemaItemModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'SubSchemaItemsConnection'
+  edges: Array<SubSchemaItemModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SubSchemaJsonFilterInput = {
-  equals?: InputMaybe<Scalars['JSON']['input']>;
-  gt?: InputMaybe<Scalars['JSON']['input']>;
-  gte?: InputMaybe<Scalars['JSON']['input']>;
-  in?: InputMaybe<Array<Scalars['JSON']['input']>>;
-  lt?: InputMaybe<Scalars['JSON']['input']>;
-  lte?: InputMaybe<Scalars['JSON']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['JSON']['input']>;
-  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>;
-  path: Scalars['JSON']['input'];
-  string_contains?: InputMaybe<Scalars['String']['input']>;
-  string_ends_with?: InputMaybe<Scalars['String']['input']>;
-  string_starts_with?: InputMaybe<Scalars['String']['input']>;
-};
+  equals?: InputMaybe<Scalars['JSON']['input']>
+  gt?: InputMaybe<Scalars['JSON']['input']>
+  gte?: InputMaybe<Scalars['JSON']['input']>
+  in?: InputMaybe<Array<Scalars['JSON']['input']>>
+  lt?: InputMaybe<Scalars['JSON']['input']>
+  lte?: InputMaybe<Scalars['JSON']['input']>
+  mode?: InputMaybe<QueryMode>
+  not?: InputMaybe<Scalars['JSON']['input']>
+  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>
+  path: Scalars['JSON']['input']
+  string_contains?: InputMaybe<Scalars['String']['input']>
+  string_ends_with?: InputMaybe<Scalars['String']['input']>
+  string_starts_with?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SubSchemaOrderByItemInput = {
-  data?: InputMaybe<SubSchemaDataOrderByInput>;
-  fieldPath?: InputMaybe<SortOrder>;
-  rowCreatedAt?: InputMaybe<SortOrder>;
-  rowId?: InputMaybe<SortOrder>;
-  tableId?: InputMaybe<SortOrder>;
-};
+  data?: InputMaybe<SubSchemaDataOrderByInput>
+  fieldPath?: InputMaybe<SortOrder>
+  rowCreatedAt?: InputMaybe<SortOrder>
+  rowId?: InputMaybe<SortOrder>
+  tableId?: InputMaybe<SortOrder>
+}
 
 export type SubSchemaStringFilterInput = {
-  contains?: InputMaybe<Scalars['String']['input']>;
-  endsWith?: InputMaybe<Scalars['String']['input']>;
-  equals?: InputMaybe<Scalars['String']['input']>;
-  gt?: InputMaybe<Scalars['String']['input']>;
-  gte?: InputMaybe<Scalars['String']['input']>;
-  in?: InputMaybe<Array<Scalars['String']['input']>>;
-  lt?: InputMaybe<Scalars['String']['input']>;
-  lte?: InputMaybe<Scalars['String']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']['input']>;
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
-  startsWith?: InputMaybe<Scalars['String']['input']>;
-};
+  contains?: InputMaybe<Scalars['String']['input']>
+  endsWith?: InputMaybe<Scalars['String']['input']>
+  equals?: InputMaybe<Scalars['String']['input']>
+  gt?: InputMaybe<Scalars['String']['input']>
+  gte?: InputMaybe<Scalars['String']['input']>
+  in?: InputMaybe<Array<Scalars['String']['input']>>
+  lt?: InputMaybe<Scalars['String']['input']>
+  lte?: InputMaybe<Scalars['String']['input']>
+  mode?: InputMaybe<QueryMode>
+  not?: InputMaybe<Scalars['String']['input']>
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>
+  startsWith?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SubSchemaWhereInput = {
-  AND?: InputMaybe<Array<SubSchemaWhereInput>>;
-  NOT?: InputMaybe<SubSchemaWhereInput>;
-  OR?: InputMaybe<Array<SubSchemaWhereInput>>;
-  data?: InputMaybe<SubSchemaJsonFilterInput>;
-  fieldPath?: InputMaybe<SubSchemaStringFilterInput>;
-  rowId?: InputMaybe<SubSchemaStringFilterInput>;
-  tableId?: InputMaybe<SubSchemaStringFilterInput>;
-};
+  AND?: InputMaybe<Array<SubSchemaWhereInput>>
+  NOT?: InputMaybe<SubSchemaWhereInput>
+  OR?: InputMaybe<Array<SubSchemaWhereInput>>
+  data?: InputMaybe<SubSchemaJsonFilterInput>
+  fieldPath?: InputMaybe<SubSchemaStringFilterInput>
+  rowId?: InputMaybe<SubSchemaStringFilterInput>
+  tableId?: InputMaybe<SubSchemaStringFilterInput>
+}
 
 export type SubscriptionModel = {
-  __typename: 'SubscriptionModel';
-  cancelAt?: Maybe<Scalars['DateTime']['output']>;
-  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>;
-  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>;
-  interval?: Maybe<Scalars['String']['output']>;
-  planId: Scalars['String']['output'];
-  provider?: Maybe<Scalars['String']['output']>;
-  status: BillingStatus;
-};
+  __typename: 'SubscriptionModel'
+  cancelAt?: Maybe<Scalars['DateTime']['output']>
+  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>
+  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>
+  interval?: Maybe<Scalars['String']['output']>
+  planId: Scalars['String']['output']
+  provider?: Maybe<Scalars['String']['output']>
+  status: BillingStatus
+}
 
 export type TableChangeModel = {
-  __typename: 'TableChangeModel';
-  addedRowsCount: Scalars['Int']['output'];
-  changeType: ChangeType;
-  fromVersionId?: Maybe<Scalars['String']['output']>;
-  modifiedRowsCount: Scalars['Int']['output'];
-  newTableId?: Maybe<Scalars['String']['output']>;
-  oldTableId?: Maybe<Scalars['String']['output']>;
-  removedRowsCount: Scalars['Int']['output'];
-  renamedRowsCount: Scalars['Int']['output'];
-  rowChangesCount: Scalars['Int']['output'];
-  schemaMigrations: Array<SchemaMigrationDetailModel>;
-  tableCreatedId: Scalars['String']['output'];
-  tableId: Scalars['String']['output'];
-  toVersionId?: Maybe<Scalars['String']['output']>;
-  viewsChanges: ViewsChangeDetailModel;
-};
+  __typename: 'TableChangeModel'
+  addedRowsCount: Scalars['Int']['output']
+  changeType: ChangeType
+  fromVersionId?: Maybe<Scalars['String']['output']>
+  modifiedRowsCount: Scalars['Int']['output']
+  newTableId?: Maybe<Scalars['String']['output']>
+  oldTableId?: Maybe<Scalars['String']['output']>
+  removedRowsCount: Scalars['Int']['output']
+  renamedRowsCount: Scalars['Int']['output']
+  rowChangesCount: Scalars['Int']['output']
+  schemaMigrations: Array<SchemaMigrationDetailModel>
+  tableCreatedId: Scalars['String']['output']
+  tableId: Scalars['String']['output']
+  toVersionId?: Maybe<Scalars['String']['output']>
+  viewsChanges: ViewsChangeDetailModel
+}
 
 export type TableChangeModelEdge = {
-  __typename: 'TableChangeModelEdge';
-  cursor: Scalars['String']['output'];
-  node: TableChangeModel;
-};
+  __typename: 'TableChangeModelEdge'
+  cursor: Scalars['String']['output']
+  node: TableChangeModel
+}
 
 export type TableChangesConnection = {
-  __typename: 'TableChangesConnection';
-  edges: Array<TableChangeModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'TableChangesConnection'
+  edges: Array<TableChangeModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type TableChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>;
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  changeTypes?: InputMaybe<Array<ChangeType>>
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
+  search?: InputMaybe<Scalars['String']['input']>
+  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type TableModel = {
-  __typename: 'TableModel';
-  count: Scalars['Int']['output'];
-  countForeignKeysBy: Scalars['Int']['output'];
-  countForeignKeysTo: Scalars['Int']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  foreignKeysBy: TablesConnection;
-  foreignKeysTo: TablesConnection;
-  id: Scalars['String']['output'];
-  readonly: Scalars['Boolean']['output'];
-  rows: RowsConnection;
-  schema: Scalars['JSON']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-  views: TableViewsDataModel;
-};
-
+  __typename: 'TableModel'
+  count: Scalars['Int']['output']
+  countForeignKeysBy: Scalars['Int']['output']
+  countForeignKeysTo: Scalars['Int']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  foreignKeysBy: TablesConnection
+  foreignKeysTo: TablesConnection
+  id: Scalars['String']['output']
+  readonly: Scalars['Boolean']['output']
+  rows: RowsConnection
+  schema: Scalars['JSON']['output']
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+  views: TableViewsDataModel
+}
 
 export type TableModelForeignKeysByArgs = {
-  data: GetTableForeignKeysInput;
-};
-
+  data: GetTableForeignKeysInput
+}
 
 export type TableModelForeignKeysToArgs = {
-  data: GetTableForeignKeysInput;
-};
-
+  data: GetTableForeignKeysInput
+}
 
 export type TableModelRowsArgs = {
-  data: GetTableRowsInput;
-};
+  data: GetTableRowsInput
+}
 
 export type TableModelEdge = {
-  __typename: 'TableModelEdge';
-  cursor: Scalars['String']['output'];
-  node: TableModel;
-};
+  __typename: 'TableModelEdge'
+  cursor: Scalars['String']['output']
+  node: TableModel
+}
 
 export type TableViewsDataInput = {
-  defaultViewId: Scalars['String']['input'];
-  version: Scalars['Int']['input'];
-  views: Array<ViewInput>;
-};
+  defaultViewId: Scalars['String']['input']
+  version: Scalars['Int']['input']
+  views: Array<ViewInput>
+}
 
 export type TableViewsDataModel = {
-  __typename: 'TableViewsDataModel';
-  defaultViewId: Scalars['String']['output'];
-  version: Scalars['Int']['output'];
-  views: Array<ViewModel>;
-};
+  __typename: 'TableViewsDataModel'
+  defaultViewId: Scalars['String']['output']
+  version: Scalars['Int']['output']
+  views: Array<ViewModel>
+}
 
 export type TablesConnection = {
-  __typename: 'TablesConnection';
-  edges: Array<TableModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'TablesConnection'
+  edges: Array<TableModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UpdatePasswordInput = {
-  newPassword: Scalars['String']['input'];
-  oldPassword: Scalars['String']['input'];
-};
+  newPassword: Scalars['String']['input']
+  oldPassword: Scalars['String']['input']
+}
 
 export type UpdateProjectInput = {
-  isPublic: Scalars['Boolean']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  isPublic: Scalars['Boolean']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type UpdateRowInput = {
-  data: Scalars['JSON']['input'];
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type UpdateRowResultModel = {
-  __typename: 'UpdateRowResultModel';
-  previousVersionRowId: Scalars['String']['output'];
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  __typename: 'UpdateRowResultModel'
+  previousVersionRowId: Scalars['String']['output']
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type UpdateRowsInput = {
-  revisionId: Scalars['String']['input'];
-  rows: Array<UpdateRowsRowInput>;
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rows: Array<UpdateRowsRowInput>
+  tableId: Scalars['String']['input']
+}
 
 export type UpdateRowsResultModel = {
-  __typename: 'UpdateRowsResultModel';
-  previousVersionTableId: Scalars['String']['output'];
-  rows: Array<RowModel>;
-  table: TableModel;
-};
+  __typename: 'UpdateRowsResultModel'
+  previousVersionTableId: Scalars['String']['output']
+  rows: Array<RowModel>
+  table: TableModel
+}
 
 export type UpdateRowsRowInput = {
-  data: Scalars['JSON']['input'];
-  rowId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  rowId: Scalars['String']['input']
+}
 
 export type UpdateTableInput = {
-  patches: Scalars['JSON']['input'];
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  patches: Scalars['JSON']['input']
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type UpdateTableResultModel = {
-  __typename: 'UpdateTableResultModel';
-  previousVersionTableId: Scalars['String']['output'];
-  table: TableModel;
-};
+  __typename: 'UpdateTableResultModel'
+  previousVersionTableId: Scalars['String']['output']
+  table: TableModel
+}
 
 export type UpdateTableViewsInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-  viewsData: TableViewsDataInput;
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+  viewsData: TableViewsDataInput
+}
 
 export type UpdateUserProjectRoleInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  roleId: UserProjectRoles;
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  roleId: UserProjectRoles
+  userId: Scalars['String']['input']
+}
 
 export type UsageMetricModel = {
-  __typename: 'UsageMetricModel';
-  current: Scalars['Float']['output'];
-  limit?: Maybe<Scalars['Float']['output']>;
-  percentage?: Maybe<Scalars['Float']['output']>;
-};
+  __typename: 'UsageMetricModel'
+  current: Scalars['Float']['output']
+  limit?: Maybe<Scalars['Float']['output']>
+  percentage?: Maybe<Scalars['Float']['output']>
+}
 
 export type UsageSummaryModel = {
-  __typename: 'UsageSummaryModel';
-  projects: UsageMetricModel;
-  rowVersions: UsageMetricModel;
-  seats: UsageMetricModel;
-  storageBytes: UsageMetricModel;
-};
+  __typename: 'UsageSummaryModel'
+  projects: UsageMetricModel
+  rowVersions: UsageMetricModel
+  seats: UsageMetricModel
+  storageBytes: UsageMetricModel
+}
 
 export type UserModel = {
-  __typename: 'UserModel';
-  email?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  organizationId?: Maybe<Scalars['String']['output']>;
-  role: RoleModel;
-  roleId: Scalars['String']['output'];
-  username?: Maybe<Scalars['String']['output']>;
-};
+  __typename: 'UserModel'
+  email?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  organizationId?: Maybe<Scalars['String']['output']>
+  role: RoleModel
+  roleId: Scalars['String']['output']
+  username?: Maybe<Scalars['String']['output']>
+}
 
 export type UserModelEdge = {
-  __typename: 'UserModelEdge';
-  cursor: Scalars['String']['output'];
-  node: UserModel;
-};
+  __typename: 'UserModelEdge'
+  cursor: Scalars['String']['output']
+  node: UserModel
+}
 
 export enum UserOrganizationRoles {
   DEVELOPER = 'developer',
   EDITOR = 'editor',
   ORGANIZATIONADMIN = 'organizationAdmin',
   ORGANIZATIONOWNER = 'organizationOwner',
-  READER = 'reader'
+  READER = 'reader',
 }
 
 export enum UserProjectRoles {
   DEVELOPER = 'developer',
   EDITOR = 'editor',
-  READER = 'reader'
+  READER = 'reader',
 }
 
 export enum UserSystemRole {
   SYSTEMADMIN = 'systemAdmin',
   SYSTEMFULLAPIREAD = 'systemFullApiRead',
-  SYSTEMUSER = 'systemUser'
+  SYSTEMUSER = 'systemUser',
 }
 
 export type UsersConnection = {
-  __typename: 'UsersConnection';
-  edges: Array<UserModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'UsersConnection'
+  edges: Array<UserModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UsersOrganizationConnection = {
-  __typename: 'UsersOrganizationConnection';
-  edges: Array<UsersOrganizationModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'UsersOrganizationConnection'
+  edges: Array<UsersOrganizationModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UsersOrganizationModel = {
-  __typename: 'UsersOrganizationModel';
-  id: Scalars['String']['output'];
-  role: RoleModel;
-  user: UserModel;
-};
+  __typename: 'UsersOrganizationModel'
+  id: Scalars['String']['output']
+  role: RoleModel
+  user: UserModel
+}
 
 export type UsersOrganizationModelEdge = {
-  __typename: 'UsersOrganizationModelEdge';
-  cursor: Scalars['String']['output'];
-  node: UsersOrganizationModel;
-};
+  __typename: 'UsersOrganizationModelEdge'
+  cursor: Scalars['String']['output']
+  node: UsersOrganizationModel
+}
 
 export type UsersProjectConnection = {
-  __typename: 'UsersProjectConnection';
-  edges: Array<UsersProjectModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  __typename: 'UsersProjectConnection'
+  edges: Array<UsersProjectModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UsersProjectModel = {
-  __typename: 'UsersProjectModel';
-  id: Scalars['String']['output'];
-  role: RoleModel;
-  user: UserModel;
-};
+  __typename: 'UsersProjectModel'
+  id: Scalars['String']['output']
+  role: RoleModel
+  user: UserModel
+}
 
 export type UsersProjectModelEdge = {
-  __typename: 'UsersProjectModelEdge';
-  cursor: Scalars['String']['output'];
-  node: UsersProjectModel;
-};
+  __typename: 'UsersProjectModelEdge'
+  cursor: Scalars['String']['output']
+  node: UsersProjectModel
+}
 
 export type ViewChangeModel = {
-  __typename: 'ViewChangeModel';
-  changeType: ChangeType;
-  oldViewName?: Maybe<Scalars['String']['output']>;
-  viewId: Scalars['String']['output'];
-  viewName: Scalars['String']['output'];
-};
+  __typename: 'ViewChangeModel'
+  changeType: ChangeType
+  oldViewName?: Maybe<Scalars['String']['output']>
+  viewId: Scalars['String']['output']
+  viewName: Scalars['String']['output']
+}
 
 export type ViewColumnInput = {
-  field: Scalars['String']['input'];
-  pinned?: InputMaybe<Scalars['String']['input']>;
-  width?: InputMaybe<Scalars['Float']['input']>;
-};
+  field: Scalars['String']['input']
+  pinned?: InputMaybe<Scalars['String']['input']>
+  width?: InputMaybe<Scalars['Float']['input']>
+}
 
 export type ViewColumnModel = {
-  __typename: 'ViewColumnModel';
-  field: Scalars['String']['output'];
-  pinned?: Maybe<Scalars['String']['output']>;
-  width?: Maybe<Scalars['Float']['output']>;
-};
+  __typename: 'ViewColumnModel'
+  field: Scalars['String']['output']
+  pinned?: Maybe<Scalars['String']['output']>
+  width?: Maybe<Scalars['Float']['output']>
+}
 
 export type ViewInput = {
-  columns?: InputMaybe<Array<ViewColumnInput>>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<Scalars['JSON']['input']>;
-  id: Scalars['String']['input'];
-  name: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  sorts?: InputMaybe<Array<ViewSortInput>>;
-};
+  columns?: InputMaybe<Array<ViewColumnInput>>
+  description?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<Scalars['JSON']['input']>
+  id: Scalars['String']['input']
+  name: Scalars['String']['input']
+  search?: InputMaybe<Scalars['String']['input']>
+  sorts?: InputMaybe<Array<ViewSortInput>>
+}
 
 export type ViewModel = {
-  __typename: 'ViewModel';
-  columns?: Maybe<Array<ViewColumnModel>>;
-  description?: Maybe<Scalars['String']['output']>;
-  filters?: Maybe<Scalars['JSON']['output']>;
-  id: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  search?: Maybe<Scalars['String']['output']>;
-  sorts?: Maybe<Array<ViewSortModel>>;
-};
+  __typename: 'ViewModel'
+  columns?: Maybe<Array<ViewColumnModel>>
+  description?: Maybe<Scalars['String']['output']>
+  filters?: Maybe<Scalars['JSON']['output']>
+  id: Scalars['String']['output']
+  name: Scalars['String']['output']
+  search?: Maybe<Scalars['String']['output']>
+  sorts?: Maybe<Array<ViewSortModel>>
+}
 
 export type ViewSortInput = {
-  direction: SortOrder;
-  field: Scalars['String']['input'];
-};
+  direction: SortOrder
+  field: Scalars['String']['input']
+}
 
 export type ViewSortModel = {
-  __typename: 'ViewSortModel';
-  direction: Scalars['String']['output'];
-  field: Scalars['String']['output'];
-};
+  __typename: 'ViewSortModel'
+  direction: Scalars['String']['output']
+  field: Scalars['String']['output']
+}
 
 export type ViewsChangeDetailModel = {
-  __typename: 'ViewsChangeDetailModel';
-  addedCount: Scalars['Int']['output'];
-  changes: Array<ViewChangeModel>;
-  hasChanges: Scalars['Boolean']['output'];
-  modifiedCount: Scalars['Int']['output'];
-  removedCount: Scalars['Int']['output'];
-  renamedCount: Scalars['Int']['output'];
-};
+  __typename: 'ViewsChangeDetailModel'
+  addedCount: Scalars['Int']['output']
+  changes: Array<ViewChangeModel>
+  hasChanges: Scalars['Boolean']['output']
+  modifiedCount: Scalars['Int']['output']
+  removedCount: Scalars['Int']['output']
+  renamedCount: Scalars['Int']['output']
+}
 
 export type WhereInput = {
-  AND?: InputMaybe<Array<WhereInput>>;
-  NOT?: InputMaybe<Array<WhereInput>>;
-  OR?: InputMaybe<Array<WhereInput>>;
-  createdAt?: InputMaybe<DateTimeFilter>;
-  createdId?: InputMaybe<StringFilter>;
-  data?: InputMaybe<JsonFilter>;
-  id?: InputMaybe<StringFilter>;
-  publishedAt?: InputMaybe<DateTimeFilter>;
-  readonly?: InputMaybe<BooleanFilter>;
-  updatedAt?: InputMaybe<DateTimeFilter>;
-  versionId?: InputMaybe<StringFilter>;
-};
+  AND?: InputMaybe<Array<WhereInput>>
+  NOT?: InputMaybe<Array<WhereInput>>
+  OR?: InputMaybe<Array<WhereInput>>
+  createdAt?: InputMaybe<DateTimeFilter>
+  createdId?: InputMaybe<StringFilter>
+  data?: InputMaybe<JsonFilter>
+  id?: InputMaybe<StringFilter>
+  publishedAt?: InputMaybe<DateTimeFilter>
+  readonly?: InputMaybe<BooleanFilter>
+  updatedAt?: InputMaybe<DateTimeFilter>
+  versionId?: InputMaybe<StringFilter>
+}

--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -1,952 +1,935 @@
 // @ts-ignore
-import { GraphQLClient, RequestOptions } from 'graphql-request';
-import gql from 'graphql-tag';
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
-type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
+import { GraphQLClient, RequestOptions } from 'graphql-request'
+import gql from 'graphql-tag'
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> }
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> }
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never }
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never }
+type GraphQLClientRequestHeaders = RequestOptions['requestHeaders']
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: string; output: string; }
-  JSON: { input: { [key: string]: any } | string | number | boolean | null; output: { [key: string]: any } | string | number | boolean | null; }
-  JSONObject: { input: any; output: any; }
-};
+  ID: { input: string; output: string }
+  String: { input: string; output: string }
+  Boolean: { input: boolean; output: boolean }
+  Int: { input: number; output: number }
+  Float: { input: number; output: number }
+  DateTime: { input: string; output: string }
+  JSON: {
+    input: { [key: string]: any } | string | number | boolean | null
+    output: { [key: string]: any } | string | number | boolean | null
+  }
+  JSONObject: { input: any; output: any }
+}
 
 export type ActivateEarlyAccessInput = {
-  organizationId: Scalars['ID']['input'];
-  planId: Scalars['ID']['input'];
-};
+  organizationId: Scalars['ID']['input']
+  planId: Scalars['ID']['input']
+}
 
 export type AddUserToOrganizationInput = {
-  organizationId: Scalars['String']['input'];
-  roleId: UserOrganizationRoles;
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  roleId: UserOrganizationRoles
+  userId: Scalars['String']['input']
+}
 
 export type AddUserToProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  roleId: UserProjectRoles;
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  roleId: UserProjectRoles
+  userId: Scalars['String']['input']
+}
 
 export type AddedRowChangeModel = {
-  changeType: ChangeType;
-  fieldChanges: Array<FieldChangeModel>;
-  row: RowChangeRowModel;
-  table: RowChangeTableModel;
-};
+  changeType: ChangeType
+  fieldChanges: Array<FieldChangeModel>
+  row: RowChangeRowModel
+  table: RowChangeTableModel
+}
 
 export type AdminUserInput = {
-  userId: Scalars['String']['input'];
-};
+  userId: Scalars['String']['input']
+}
 
 export type ApiKeyModel = {
-  allowedIps: Array<Scalars['String']['output']>;
-  branchNames: Array<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  expiresAt?: Maybe<Scalars['DateTime']['output']>;
-  id: Scalars['ID']['output'];
-  lastUsedAt?: Maybe<Scalars['DateTime']['output']>;
-  name: Scalars['String']['output'];
-  organizationId?: Maybe<Scalars['String']['output']>;
-  permissions?: Maybe<Scalars['JSON']['output']>;
-  prefix: Scalars['String']['output'];
-  projectIds: Array<Scalars['String']['output']>;
-  projects: Array<ProjectModel>;
-  readOnly: Scalars['Boolean']['output'];
-  revokedAt?: Maybe<Scalars['DateTime']['output']>;
-  tableIds: Array<Scalars['String']['output']>;
-  type: ApiKeyType;
-};
+  allowedIps: Array<Scalars['String']['output']>
+  branchNames: Array<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  expiresAt?: Maybe<Scalars['DateTime']['output']>
+  id: Scalars['ID']['output']
+  lastUsedAt?: Maybe<Scalars['DateTime']['output']>
+  name: Scalars['String']['output']
+  organizationId?: Maybe<Scalars['String']['output']>
+  permissions?: Maybe<Scalars['JSON']['output']>
+  prefix: Scalars['String']['output']
+  projectIds: Array<Scalars['String']['output']>
+  projects: Array<ProjectModel>
+  readOnly: Scalars['Boolean']['output']
+  revokedAt?: Maybe<Scalars['DateTime']['output']>
+  tableIds: Array<Scalars['String']['output']>
+  type: ApiKeyType
+}
 
 export enum ApiKeyType {
   Internal = 'INTERNAL',
   Personal = 'PERSONAL',
-  Service = 'SERVICE'
+  Service = 'SERVICE',
 }
 
 export type ApiKeyWithSecretModel = {
-  apiKey: ApiKeyModel;
-  secret: Scalars['String']['output'];
-};
+  apiKey: ApiKeyModel
+  secret: Scalars['String']['output']
+}
 
 export type ApplyMigrationResultModel = {
-  error?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  status: ApplyMigrationStatus;
-};
+  error?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  status: ApplyMigrationStatus
+}
 
 /** Status of migration application */
 export enum ApplyMigrationStatus {
   Applied = 'applied',
   Failed = 'failed',
-  Skipped = 'skipped'
+  Skipped = 'skipped',
 }
 
 export type ApplyMigrationsInput = {
-  migrations: Array<Scalars['JSON']['input']>;
-  revisionId: Scalars['String']['input'];
-};
+  migrations: Array<Scalars['JSON']['input']>
+  revisionId: Scalars['String']['input']
+}
 
 export type BillingConfigurationModel = {
-  enabled: Scalars['Boolean']['output'];
-};
+  enabled: Scalars['Boolean']['output']
+}
 
 export enum BillingStatus {
   Active = 'active',
   Cancelled = 'cancelled',
   EarlyAdopter = 'early_adopter',
   Free = 'free',
-  PastDue = 'past_due'
+  PastDue = 'past_due',
 }
 
 export type BooleanFilter = {
-  equals?: InputMaybe<Scalars['Boolean']['input']>;
-  not?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  equals?: InputMaybe<Scalars['Boolean']['input']>
+  not?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type BranchModel = {
-  createdAt: Scalars['DateTime']['output'];
-  draft: RevisionModel;
-  head: RevisionModel;
-  id: Scalars['String']['output'];
-  isRoot: Scalars['Boolean']['output'];
-  name: Scalars['String']['output'];
-  parent?: Maybe<ParentBranchModel>;
-  project: ProjectModel;
-  projectId: Scalars['String']['output'];
-  revisions: RevisionConnection;
-  start: RevisionModel;
-  touched: Scalars['Boolean']['output'];
-};
-
+  createdAt: Scalars['DateTime']['output']
+  draft: RevisionModel
+  head: RevisionModel
+  id: Scalars['String']['output']
+  isRoot: Scalars['Boolean']['output']
+  name: Scalars['String']['output']
+  parent?: Maybe<ParentBranchModel>
+  project: ProjectModel
+  projectId: Scalars['String']['output']
+  revisions: RevisionConnection
+  start: RevisionModel
+  touched: Scalars['Boolean']['output']
+}
 
 export type BranchModelRevisionsArgs = {
-  data: GetBranchRevisionsInput;
-};
+  data: GetBranchRevisionsInput
+}
 
 export type BranchModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: BranchModel;
-};
+  cursor: Scalars['String']['output']
+  node: BranchModel
+}
 
 export type BranchesConnection = {
-  edges: Array<BranchModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<BranchModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
+
+export type CacheConfigModel = {
+  enabled: Scalars['Boolean']['output']
+}
+
+export type CacheMetricModel = {
+  deletes: Scalars['Int']['output']
+  hitRate: Scalars['Float']['output']
+  hits: Scalars['Int']['output']
+  key: Scalars['String']['output']
+  misses: Scalars['Int']['output']
+  writes: Scalars['Int']['output']
+}
+
+export type CacheStatsModel = {
+  byCategory: Array<CacheMetricModel>
+  enabled: Scalars['Boolean']['output']
+  overallHitRate: Scalars['Float']['output']
+  totalClears: Scalars['Int']['output']
+  totalDeletes: Scalars['Int']['output']
+  totalHits: Scalars['Int']['output']
+  totalMisses: Scalars['Int']['output']
+  totalWrites: Scalars['Int']['output']
+}
 
 export type CancelSubscriptionInput = {
-  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>;
-  organizationId: Scalars['ID']['input'];
-};
+  cancelAtPeriodEnd?: InputMaybe<Scalars['Boolean']['input']>
+  organizationId: Scalars['ID']['input']
+}
 
 export type CaslPermissionsInput = {
-  rules: Array<CaslRuleInput>;
-};
+  rules: Array<CaslRuleInput>
+}
 
 export type CaslRuleInput = {
-  action: Array<Scalars['String']['input']>;
-  conditions?: InputMaybe<Scalars['JSONObject']['input']>;
-  fields?: InputMaybe<Array<Scalars['String']['input']>>;
-  inverted?: InputMaybe<Scalars['Boolean']['input']>;
-  subject: Array<Scalars['String']['input']>;
-};
+  action: Array<Scalars['String']['input']>
+  conditions?: InputMaybe<Scalars['JSONObject']['input']>
+  fields?: InputMaybe<Array<Scalars['String']['input']>>
+  inverted?: InputMaybe<Scalars['Boolean']['input']>
+  subject: Array<Scalars['String']['input']>
+}
 
 export enum ChangeType {
   Added = 'ADDED',
   Modified = 'MODIFIED',
   Removed = 'REMOVED',
   Renamed = 'RENAMED',
-  RenamedAndModified = 'RENAMED_AND_MODIFIED'
+  RenamedAndModified = 'RENAMED_AND_MODIFIED',
 }
 
 export type CheckoutResultModel = {
-  checkoutUrl: Scalars['String']['output'];
-};
+  checkoutUrl: Scalars['String']['output']
+}
 
 export type ChildBranchModel = {
-  branch: BranchModel;
-  revision: RevisionModel;
-};
+  branch: BranchModel
+  revision: RevisionModel
+}
 
 export type ConfigurationModel = {
-  availableEmailSignUp: Scalars['Boolean']['output'];
-  billing: BillingConfigurationModel;
-  github: GithubOauth;
-  google: GoogleOauth;
-  noAuth: Scalars['Boolean']['output'];
-  plugins: PluginsModel;
-};
+  availableEmailSignUp: Scalars['Boolean']['output']
+  billing: BillingConfigurationModel
+  cache: CacheConfigModel
+  github: GithubOauth
+  google: GoogleOauth
+  noAuth: Scalars['Boolean']['output']
+  plugins: PluginsModel
+}
 
 export type ConfirmEmailCodeInput = {
-  code: Scalars['String']['input'];
-};
+  code: Scalars['String']['input']
+}
 
 export type CreateBranchInput = {
-  branchName: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type CreateCheckoutInput = {
-  cancelUrl: Scalars['String']['input'];
-  country?: InputMaybe<Scalars['String']['input']>;
-  interval?: InputMaybe<Scalars['String']['input']>;
-  method?: InputMaybe<Scalars['String']['input']>;
-  organizationId: Scalars['ID']['input'];
-  planId: Scalars['ID']['input'];
-  providerId?: InputMaybe<Scalars['String']['input']>;
-  successUrl: Scalars['String']['input'];
-};
+  cancelUrl: Scalars['String']['input']
+  country?: InputMaybe<Scalars['String']['input']>
+  interval?: InputMaybe<Scalars['String']['input']>
+  method?: InputMaybe<Scalars['String']['input']>
+  organizationId: Scalars['ID']['input']
+  planId: Scalars['ID']['input']
+  providerId?: InputMaybe<Scalars['String']['input']>
+  successUrl: Scalars['String']['input']
+}
 
 export type CreateEndpointInput = {
-  revisionId: Scalars['String']['input'];
-  type: EndpointType;
-};
+  revisionId: Scalars['String']['input']
+  type: EndpointType
+}
 
 export type CreatePersonalApiKeyInput = {
-  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
-  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
-  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
-  name: Scalars['String']['input'];
-  organizationId?: InputMaybe<Scalars['String']['input']>;
-  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>
+  name: Scalars['String']['input']
+  organizationId?: InputMaybe<Scalars['String']['input']>
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type CreateProjectInput = {
-  branchName?: InputMaybe<Scalars['String']['input']>;
-  fromRevisionId?: InputMaybe<Scalars['String']['input']>;
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName?: InputMaybe<Scalars['String']['input']>
+  fromRevisionId?: InputMaybe<Scalars['String']['input']>
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type CreateRevisionInput = {
-  branchName: Scalars['String']['input'];
-  comment?: InputMaybe<Scalars['String']['input']>;
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  comment?: InputMaybe<Scalars['String']['input']>
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type CreateRowInput = {
-  data: Scalars['JSON']['input'];
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type CreateRowResultModel = {
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type CreateRowsInput = {
-  isRestore?: InputMaybe<Scalars['Boolean']['input']>;
-  revisionId: Scalars['String']['input'];
-  rows: Array<CreateRowsRowInput>;
-  tableId: Scalars['String']['input'];
-};
+  isRestore?: InputMaybe<Scalars['Boolean']['input']>
+  revisionId: Scalars['String']['input']
+  rows: Array<CreateRowsRowInput>
+  tableId: Scalars['String']['input']
+}
 
 export type CreateRowsResultModel = {
-  previousVersionTableId: Scalars['String']['output'];
-  rows: Array<RowModel>;
-  table: TableModel;
-};
+  previousVersionTableId: Scalars['String']['output']
+  rows: Array<RowModel>
+  table: TableModel
+}
 
 export type CreateRowsRowInput = {
-  data: Scalars['JSON']['input'];
-  rowId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  rowId: Scalars['String']['input']
+}
 
 export type CreateServiceApiKeyInput = {
-  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>;
-  branchNames?: InputMaybe<Array<Scalars['String']['input']>>;
-  expiresAt?: InputMaybe<Scalars['DateTime']['input']>;
-  name: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  permissions: CaslPermissionsInput;
-  projectIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  readOnly?: InputMaybe<Scalars['Boolean']['input']>;
-  tableIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  allowedIps?: InputMaybe<Array<Scalars['String']['input']>>
+  branchNames?: InputMaybe<Array<Scalars['String']['input']>>
+  expiresAt?: InputMaybe<Scalars['DateTime']['input']>
+  name: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  permissions: CaslPermissionsInput
+  projectIds?: InputMaybe<Array<Scalars['String']['input']>>
+  readOnly?: InputMaybe<Scalars['Boolean']['input']>
+  tableIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type CreateTableInput = {
-  revisionId: Scalars['String']['input'];
-  schema: Scalars['JSON']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  schema: Scalars['JSON']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type CreateTableResultModel = {
-  branch: BranchModel;
-  table: TableModel;
-};
+  branch: BranchModel
+  table: TableModel
+}
 
 export type CreateUserInput = {
-  email?: InputMaybe<Scalars['String']['input']>;
-  password: Scalars['String']['input'];
-  roleId: UserSystemRole;
-  username: Scalars['String']['input'];
-};
+  email?: InputMaybe<Scalars['String']['input']>
+  password: Scalars['String']['input']
+  roleId: UserSystemRole
+  username: Scalars['String']['input']
+}
 
 export type DateTimeFilter = {
-  equals?: InputMaybe<Scalars['String']['input']>;
-  gt?: InputMaybe<Scalars['String']['input']>;
-  gte?: InputMaybe<Scalars['String']['input']>;
-  in?: InputMaybe<Array<Scalars['String']['input']>>;
-  lt?: InputMaybe<Scalars['String']['input']>;
-  lte?: InputMaybe<Scalars['String']['input']>;
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  equals?: InputMaybe<Scalars['String']['input']>
+  gt?: InputMaybe<Scalars['String']['input']>
+  gte?: InputMaybe<Scalars['String']['input']>
+  in?: InputMaybe<Array<Scalars['String']['input']>>
+  lt?: InputMaybe<Scalars['String']['input']>
+  lte?: InputMaybe<Scalars['String']['input']>
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type DeleteBranchInput = {
-  branchName: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type DeleteEndpointInput = {
-  endpointId: Scalars['String']['input'];
-};
+  endpointId: Scalars['String']['input']
+}
 
 export type DeleteProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type DeleteRowInput = {
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type DeleteRowResultModel = {
-  branch: BranchModel;
-  previousVersionTableId?: Maybe<Scalars['String']['output']>;
-  table?: Maybe<TableModel>;
-};
+  branch: BranchModel
+  previousVersionTableId?: Maybe<Scalars['String']['output']>
+  table?: Maybe<TableModel>
+}
 
 export type DeleteRowsInput = {
-  revisionId: Scalars['String']['input'];
-  rowIds: Array<Scalars['String']['input']>;
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowIds: Array<Scalars['String']['input']>
+  tableId: Scalars['String']['input']
+}
 
 export type DeleteRowsResultModel = {
-  branch: BranchModel;
-  previousVersionTableId?: Maybe<Scalars['String']['output']>;
-  table?: Maybe<TableModel>;
-};
+  branch: BranchModel
+  previousVersionTableId?: Maybe<Scalars['String']['output']>
+  table?: Maybe<TableModel>
+}
 
 export type DeleteTableInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type DeleteTableResultModel = {
-  branch: BranchModel;
-};
+  branch: BranchModel
+}
 
 export type EndpointModel = {
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['String']['output'];
-  revision: RevisionModel;
-  revisionId: Scalars['String']['output'];
-  type: EndpointType;
-};
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['String']['output']
+  revision: RevisionModel
+  revisionId: Scalars['String']['output']
+  type: EndpointType
+}
 
 export type EndpointModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: EndpointModel;
-};
+  cursor: Scalars['String']['output']
+  node: EndpointModel
+}
 
 export enum EndpointType {
   Graphql = 'GRAPHQL',
-  RestApi = 'REST_API'
+  RestApi = 'REST_API',
 }
 
 export type EndpointsConnection = {
-  edges: Array<EndpointModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<EndpointModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type FieldChangeModel = {
-  changeType: RowChangeDetailType;
-  fieldPath: Scalars['String']['output'];
-  movedFrom?: Maybe<Scalars['String']['output']>;
-  newValue?: Maybe<Scalars['JSON']['output']>;
-  oldValue?: Maybe<Scalars['JSON']['output']>;
-};
+  changeType: RowChangeDetailType
+  fieldPath: Scalars['String']['output']
+  movedFrom?: Maybe<Scalars['String']['output']>
+  newValue?: Maybe<Scalars['JSON']['output']>
+  oldValue?: Maybe<Scalars['JSON']['output']>
+}
 
 export type FormulaFieldErrorModel = {
-  defaultUsed: Scalars['Boolean']['output'];
-  error: Scalars['String']['output'];
-  expression: Scalars['String']['output'];
-  field: Scalars['String']['output'];
-};
+  defaultUsed: Scalars['Boolean']['output']
+  error: Scalars['String']['output']
+  expression: Scalars['String']['output']
+  field: Scalars['String']['output']
+}
 
 export type GetBranchInput = {
-  branchName: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GetBranchRevisionsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  comment?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  inclusive?: InputMaybe<Scalars['Boolean']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  comment?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  inclusive?: InputMaybe<Scalars['Boolean']['input']>
   /** Sort order: asc (default) or desc */
-  sort?: InputMaybe<SortOrder>;
-};
+  sort?: InputMaybe<SortOrder>
+}
 
 export type GetBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GetMeProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetOrganizationInput = {
-  organizationId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+}
 
 export type GetProjectBranchesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetProjectEndpointsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  branchId?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  type?: InputMaybe<EndpointType>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  branchId?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  type?: InputMaybe<EndpointType>
+}
 
 export type GetProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GetProjectsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+}
 
 export type GetRevisionChangesInput = {
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
-  revisionId: Scalars['String']['input'];
-};
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
+  revisionId: Scalars['String']['input']
+}
 
 export type GetRevisionInput = {
-  revisionId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+}
 
 export type GetRevisionTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetRowChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<RowChangesFiltersInput>;
-  first: Scalars['Int']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<RowChangesFiltersInput>
+  first: Scalars['Int']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type GetRowCountForeignKeysByInput = {
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetRowForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  foreignKeyTableId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  foreignKeyTableId: Scalars['String']['input']
+}
 
 export type GetRowInput = {
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  orderBy?: InputMaybe<Array<OrderBy>>;
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-  where?: InputMaybe<WhereInput>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  orderBy?: InputMaybe<Array<OrderBy>>
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+  where?: InputMaybe<WhereInput>
+}
 
 export type GetSubSchemaItemsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>;
-  revisionId: Scalars['String']['input'];
-  schemaId: Scalars['String']['input'];
-  where?: InputMaybe<SubSchemaWhereInput>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  orderBy?: InputMaybe<Array<SubSchemaOrderByItemInput>>
+  revisionId: Scalars['String']['input']
+  schemaId: Scalars['String']['input']
+  where?: InputMaybe<SubSchemaWhereInput>
+}
 
 export type GetTableChangesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<TableChangesFiltersInput>;
-  first: Scalars['Int']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<TableChangesFiltersInput>
+  first: Scalars['Int']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type GetTableForeignKeysInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetTableInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetTableRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+}
 
 export type GetTableViewsInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type GetTablesInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export type GetUsersOrganizationInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+}
 
 export type GetUsersProjectInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type GithubOauth = {
-  available: Scalars['Boolean']['output'];
-  clientId?: Maybe<Scalars['String']['output']>;
-};
+  available: Scalars['Boolean']['output']
+  clientId?: Maybe<Scalars['String']['output']>
+}
 
 export type GoogleOauth = {
-  available: Scalars['Boolean']['output'];
-  clientId?: Maybe<Scalars['String']['output']>;
-};
+  available: Scalars['Boolean']['output']
+  clientId?: Maybe<Scalars['String']['output']>
+}
 
 export type HistoryPatchModel = {
-  hash: Scalars['String']['output'];
-  patches: Array<JsonPatchOperationModel>;
-};
+  hash: Scalars['String']['output']
+  patches: Array<JsonPatchOperationModel>
+}
 
 export type JsonFilter = {
-  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>;
-  array_ends_with?: InputMaybe<Scalars['JSON']['input']>;
-  array_starts_with?: InputMaybe<Scalars['JSON']['input']>;
-  equals?: InputMaybe<Scalars['JSON']['input']>;
-  gt?: InputMaybe<Scalars['Float']['input']>;
-  gte?: InputMaybe<Scalars['Float']['input']>;
-  lt?: InputMaybe<Scalars['Float']['input']>;
-  lte?: InputMaybe<Scalars['Float']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  path?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  searchIn?: InputMaybe<SearchIn>;
+  array_contains?: InputMaybe<Array<Scalars['JSON']['input']>>
+  array_ends_with?: InputMaybe<Scalars['JSON']['input']>
+  array_starts_with?: InputMaybe<Scalars['JSON']['input']>
+  equals?: InputMaybe<Scalars['JSON']['input']>
+  gt?: InputMaybe<Scalars['Float']['input']>
+  gte?: InputMaybe<Scalars['Float']['input']>
+  lt?: InputMaybe<Scalars['Float']['input']>
+  lte?: InputMaybe<Scalars['Float']['input']>
+  mode?: InputMaybe<QueryMode>
+  path?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  searchIn?: InputMaybe<SearchIn>
   /** Default: simple */
-  searchLanguage?: InputMaybe<SearchLanguage>;
-  searchType?: InputMaybe<SearchType>;
-  string_contains?: InputMaybe<Scalars['String']['input']>;
-  string_ends_with?: InputMaybe<Scalars['String']['input']>;
-  string_starts_with?: InputMaybe<Scalars['String']['input']>;
-};
+  searchLanguage?: InputMaybe<SearchLanguage>
+  searchType?: InputMaybe<SearchType>
+  string_contains?: InputMaybe<Scalars['String']['input']>
+  string_ends_with?: InputMaybe<Scalars['String']['input']>
+  string_starts_with?: InputMaybe<Scalars['String']['input']>
+}
 
 export enum JsonPatchOp {
   Add = 'ADD',
   Copy = 'COPY',
   Move = 'MOVE',
   Remove = 'REMOVE',
-  Replace = 'REPLACE'
+  Replace = 'REPLACE',
 }
 
 export type JsonPatchOperationModel = {
-  from?: Maybe<Scalars['String']['output']>;
-  op: JsonPatchOp;
-  path: Scalars['String']['output'];
-  value?: Maybe<Scalars['JSON']['output']>;
-};
+  from?: Maybe<Scalars['String']['output']>
+  op: JsonPatchOp
+  path: Scalars['String']['output']
+  value?: Maybe<Scalars['JSON']['output']>
+}
 
 export type LoginGithubInput = {
-  code: Scalars['String']['input'];
-};
+  code: Scalars['String']['input']
+}
 
 export type LoginGoogleInput = {
-  code: Scalars['String']['input'];
-  redirectUrl: Scalars['String']['input'];
-};
+  code: Scalars['String']['input']
+  redirectUrl: Scalars['String']['input']
+}
 
 export type LoginInput = {
-  emailOrUsername: Scalars['String']['input'];
-  password: Scalars['String']['input'];
-};
+  emailOrUsername: Scalars['String']['input']
+  password: Scalars['String']['input']
+}
 
 export type LoginModel = {
-  accessToken: Scalars['String']['output'];
-};
+  accessToken: Scalars['String']['output']
+}
 
 export type MeModel = {
-  email?: Maybe<Scalars['String']['output']>;
-  hasPassword: Scalars['Boolean']['output'];
-  id: Scalars['String']['output'];
-  organization?: Maybe<OrganizationModel>;
-  organizationId?: Maybe<Scalars['String']['output']>;
-  role?: Maybe<RoleModel>;
-  username?: Maybe<Scalars['String']['output']>;
-};
+  email?: Maybe<Scalars['String']['output']>
+  hasPassword: Scalars['Boolean']['output']
+  id: Scalars['String']['output']
+  organization?: Maybe<OrganizationModel>
+  organizationId?: Maybe<Scalars['String']['output']>
+  role?: Maybe<RoleModel>
+  username?: Maybe<Scalars['String']['output']>
+}
 
 export enum MigrationType {
   Init = 'INIT',
   Remove = 'REMOVE',
   Rename = 'RENAME',
-  Update = 'UPDATE'
+  Update = 'UPDATE',
 }
 
 export type ModifiedRowChangeModel = {
-  changeType: ChangeType;
-  fieldChanges: Array<FieldChangeModel>;
-  fromRow: RowChangeRowModel;
-  fromTable: RowChangeTableModel;
-  row: RowChangeRowModel;
-  table: RowChangeTableModel;
-};
+  changeType: ChangeType
+  fieldChanges: Array<FieldChangeModel>
+  fromRow: RowChangeRowModel
+  fromTable: RowChangeTableModel
+  row: RowChangeRowModel
+  table: RowChangeTableModel
+}
 
 export type Mutation = {
-  activateEarlyAccess: SubscriptionModel;
-  addUserToOrganization: Scalars['Boolean']['output'];
-  addUserToProject: Scalars['Boolean']['output'];
-  applyMigrations: Array<ApplyMigrationResultModel>;
-  cancelSubscription: Scalars['Boolean']['output'];
-  confirmEmailCode: LoginModel;
-  createBranch: BranchModel;
-  createCheckout: CheckoutResultModel;
-  createEndpoint: EndpointModel;
-  createPersonalApiKey: ApiKeyWithSecretModel;
-  createProject: ProjectModel;
-  createRevision: RevisionModel;
-  createRow: CreateRowResultModel;
-  createRows: CreateRowsResultModel;
-  createServiceApiKey: ApiKeyWithSecretModel;
-  createTable: CreateTableResultModel;
-  createUser: Scalars['Boolean']['output'];
-  deleteBranch: Scalars['Boolean']['output'];
-  deleteEndpoint: Scalars['Boolean']['output'];
-  deleteProject: Scalars['Boolean']['output'];
-  deleteRow: DeleteRowResultModel;
-  deleteRows: DeleteRowsResultModel;
-  deleteTable: DeleteTableResultModel;
-  login: LoginModel;
-  loginGithub: LoginModel;
-  loginGoogle: LoginModel;
-  patchRow: PatchRowResultModel;
-  patchRows: PatchRowsResultModel;
-  removeUserFromOrganization: Scalars['Boolean']['output'];
-  removeUserFromProject: Scalars['Boolean']['output'];
-  renameRow: RenameRowResultModel;
-  renameTable: RenameTableResultModel;
-  resetPassword: Scalars['Boolean']['output'];
-  revertChanges: BranchModel;
-  revokeApiKey: ApiKeyModel;
-  rotateApiKey: ApiKeyWithSecretModel;
-  setUsername: Scalars['Boolean']['output'];
-  signUp: Scalars['Boolean']['output'];
-  updatePassword: Scalars['Boolean']['output'];
-  updateProject: Scalars['Boolean']['output'];
-  updateRow: UpdateRowResultModel;
-  updateRows: UpdateRowsResultModel;
-  updateTable: UpdateTableResultModel;
-  updateTableViews: TableViewsDataModel;
-  updateUserProjectRole: Scalars['Boolean']['output'];
-};
-
+  activateEarlyAccess: SubscriptionModel
+  addUserToOrganization: Scalars['Boolean']['output']
+  addUserToProject: Scalars['Boolean']['output']
+  adminResetAllCache: Scalars['Boolean']['output']
+  applyMigrations: Array<ApplyMigrationResultModel>
+  cancelSubscription: Scalars['Boolean']['output']
+  confirmEmailCode: LoginModel
+  createBranch: BranchModel
+  createCheckout: CheckoutResultModel
+  createEndpoint: EndpointModel
+  createPersonalApiKey: ApiKeyWithSecretModel
+  createProject: ProjectModel
+  createRevision: RevisionModel
+  createRow: CreateRowResultModel
+  createRows: CreateRowsResultModel
+  createServiceApiKey: ApiKeyWithSecretModel
+  createTable: CreateTableResultModel
+  createUser: Scalars['Boolean']['output']
+  deleteBranch: Scalars['Boolean']['output']
+  deleteEndpoint: Scalars['Boolean']['output']
+  deleteProject: Scalars['Boolean']['output']
+  deleteRow: DeleteRowResultModel
+  deleteRows: DeleteRowsResultModel
+  deleteTable: DeleteTableResultModel
+  login: LoginModel
+  loginGithub: LoginModel
+  loginGoogle: LoginModel
+  patchRow: PatchRowResultModel
+  patchRows: PatchRowsResultModel
+  removeUserFromOrganization: Scalars['Boolean']['output']
+  removeUserFromProject: Scalars['Boolean']['output']
+  renameRow: RenameRowResultModel
+  renameTable: RenameTableResultModel
+  resetPassword: Scalars['Boolean']['output']
+  revertChanges: BranchModel
+  revokeApiKey: ApiKeyModel
+  rotateApiKey: ApiKeyWithSecretModel
+  setUsername: Scalars['Boolean']['output']
+  signUp: Scalars['Boolean']['output']
+  updatePassword: Scalars['Boolean']['output']
+  updateProject: Scalars['Boolean']['output']
+  updateRow: UpdateRowResultModel
+  updateRows: UpdateRowsResultModel
+  updateTable: UpdateTableResultModel
+  updateTableViews: TableViewsDataModel
+  updateUserProjectRole: Scalars['Boolean']['output']
+}
 
 export type MutationActivateEarlyAccessArgs = {
-  data: ActivateEarlyAccessInput;
-};
-
+  data: ActivateEarlyAccessInput
+}
 
 export type MutationAddUserToOrganizationArgs = {
-  data: AddUserToOrganizationInput;
-};
-
+  data: AddUserToOrganizationInput
+}
 
 export type MutationAddUserToProjectArgs = {
-  data: AddUserToProjectInput;
-};
-
+  data: AddUserToProjectInput
+}
 
 export type MutationApplyMigrationsArgs = {
-  data: ApplyMigrationsInput;
-};
-
+  data: ApplyMigrationsInput
+}
 
 export type MutationCancelSubscriptionArgs = {
-  data: CancelSubscriptionInput;
-};
-
+  data: CancelSubscriptionInput
+}
 
 export type MutationConfirmEmailCodeArgs = {
-  data: ConfirmEmailCodeInput;
-};
-
+  data: ConfirmEmailCodeInput
+}
 
 export type MutationCreateBranchArgs = {
-  data: CreateBranchInput;
-};
-
+  data: CreateBranchInput
+}
 
 export type MutationCreateCheckoutArgs = {
-  data: CreateCheckoutInput;
-};
-
+  data: CreateCheckoutInput
+}
 
 export type MutationCreateEndpointArgs = {
-  data: CreateEndpointInput;
-};
-
+  data: CreateEndpointInput
+}
 
 export type MutationCreatePersonalApiKeyArgs = {
-  data: CreatePersonalApiKeyInput;
-};
-
+  data: CreatePersonalApiKeyInput
+}
 
 export type MutationCreateProjectArgs = {
-  data: CreateProjectInput;
-};
-
+  data: CreateProjectInput
+}
 
 export type MutationCreateRevisionArgs = {
-  data: CreateRevisionInput;
-};
-
+  data: CreateRevisionInput
+}
 
 export type MutationCreateRowArgs = {
-  data: CreateRowInput;
-};
-
+  data: CreateRowInput
+}
 
 export type MutationCreateRowsArgs = {
-  data: CreateRowsInput;
-};
-
+  data: CreateRowsInput
+}
 
 export type MutationCreateServiceApiKeyArgs = {
-  data: CreateServiceApiKeyInput;
-};
-
+  data: CreateServiceApiKeyInput
+}
 
 export type MutationCreateTableArgs = {
-  data: CreateTableInput;
-};
-
+  data: CreateTableInput
+}
 
 export type MutationCreateUserArgs = {
-  data: CreateUserInput;
-};
-
+  data: CreateUserInput
+}
 
 export type MutationDeleteBranchArgs = {
-  data: DeleteBranchInput;
-};
-
+  data: DeleteBranchInput
+}
 
 export type MutationDeleteEndpointArgs = {
-  data: DeleteEndpointInput;
-};
-
+  data: DeleteEndpointInput
+}
 
 export type MutationDeleteProjectArgs = {
-  data: DeleteProjectInput;
-};
-
+  data: DeleteProjectInput
+}
 
 export type MutationDeleteRowArgs = {
-  data: DeleteRowInput;
-};
-
+  data: DeleteRowInput
+}
 
 export type MutationDeleteRowsArgs = {
-  data: DeleteRowsInput;
-};
-
+  data: DeleteRowsInput
+}
 
 export type MutationDeleteTableArgs = {
-  data: DeleteTableInput;
-};
-
+  data: DeleteTableInput
+}
 
 export type MutationLoginArgs = {
-  data: LoginInput;
-};
-
+  data: LoginInput
+}
 
 export type MutationLoginGithubArgs = {
-  data: LoginGithubInput;
-};
-
+  data: LoginGithubInput
+}
 
 export type MutationLoginGoogleArgs = {
-  data: LoginGoogleInput;
-};
-
+  data: LoginGoogleInput
+}
 
 export type MutationPatchRowArgs = {
-  data: PatchRowInput;
-};
-
+  data: PatchRowInput
+}
 
 export type MutationPatchRowsArgs = {
-  data: PatchRowsInput;
-};
-
+  data: PatchRowsInput
+}
 
 export type MutationRemoveUserFromOrganizationArgs = {
-  data: RemoveUserFromOrganizationInput;
-};
-
+  data: RemoveUserFromOrganizationInput
+}
 
 export type MutationRemoveUserFromProjectArgs = {
-  data: RemoveUserFromProjectInput;
-};
-
+  data: RemoveUserFromProjectInput
+}
 
 export type MutationRenameRowArgs = {
-  data: RenameRowInput;
-};
-
+  data: RenameRowInput
+}
 
 export type MutationRenameTableArgs = {
-  data: RenameTableInput;
-};
-
+  data: RenameTableInput
+}
 
 export type MutationResetPasswordArgs = {
-  data: ResetPasswordInput;
-};
-
+  data: ResetPasswordInput
+}
 
 export type MutationRevertChangesArgs = {
-  data: RevertChangesInput;
-};
-
+  data: RevertChangesInput
+}
 
 export type MutationRevokeApiKeyArgs = {
-  id: Scalars['ID']['input'];
-};
-
+  id: Scalars['ID']['input']
+}
 
 export type MutationRotateApiKeyArgs = {
-  id: Scalars['ID']['input'];
-};
-
+  id: Scalars['ID']['input']
+}
 
 export type MutationSetUsernameArgs = {
-  data: SetUsernameInput;
-};
-
+  data: SetUsernameInput
+}
 
 export type MutationSignUpArgs = {
-  data: SignUpInput;
-};
-
+  data: SignUpInput
+}
 
 export type MutationUpdatePasswordArgs = {
-  data: UpdatePasswordInput;
-};
-
+  data: UpdatePasswordInput
+}
 
 export type MutationUpdateProjectArgs = {
-  data: UpdateProjectInput;
-};
-
+  data: UpdateProjectInput
+}
 
 export type MutationUpdateRowArgs = {
-  data: UpdateRowInput;
-};
-
+  data: UpdateRowInput
+}
 
 export type MutationUpdateRowsArgs = {
-  data: UpdateRowsInput;
-};
-
+  data: UpdateRowsInput
+}
 
 export type MutationUpdateTableArgs = {
-  data: UpdateTableInput;
-};
-
+  data: UpdateTableInput
+}
 
 export type MutationUpdateTableViewsArgs = {
-  data: UpdateTableViewsInput;
-};
-
+  data: UpdateTableViewsInput
+}
 
 export type MutationUpdateUserProjectRoleArgs = {
-  data: UpdateUserProjectRoleInput;
-};
+  data: UpdateUserProjectRoleInput
+}
 
 export enum NullsPosition {
   First = 'first',
-  Last = 'last'
+  Last = 'last',
 }
 
 export type OrderBy = {
-  aggregation?: InputMaybe<OrderDataAggregation>;
-  direction: SortOrder;
-  field: OrderByField;
-  path?: InputMaybe<Scalars['String']['input']>;
-  type?: InputMaybe<OrderDataType>;
-};
+  aggregation?: InputMaybe<OrderDataAggregation>
+  direction: SortOrder
+  field: OrderByField
+  path?: InputMaybe<Scalars['String']['input']>
+  type?: InputMaybe<OrderDataType>
+}
 
 export enum OrderByField {
   CreatedAt = 'createdAt',
   Data = 'data',
   Id = 'id',
   PublishedAt = 'publishedAt',
-  UpdatedAt = 'updatedAt'
+  UpdatedAt = 'updatedAt',
 }
 
 export enum OrderDataAggregation {
@@ -954,7 +937,7 @@ export enum OrderDataAggregation {
   First = 'first',
   Last = 'last',
   Max = 'max',
-  Min = 'min'
+  Min = 'min',
 }
 
 export enum OrderDataType {
@@ -962,529 +945,499 @@ export enum OrderDataType {
   Float = 'float',
   Int = 'int',
   Text = 'text',
-  Timestamp = 'timestamp'
+  Timestamp = 'timestamp',
 }
 
 export type OrganizationModel = {
-  createdId: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  subscription?: Maybe<SubscriptionModel>;
-  usage?: Maybe<UsageSummaryModel>;
-  userOrganization?: Maybe<UsersOrganizationModel>;
-};
+  createdId: Scalars['String']['output']
+  id: Scalars['String']['output']
+  subscription?: Maybe<SubscriptionModel>
+  usage?: Maybe<UsageSummaryModel>
+  userOrganization?: Maybe<UsersOrganizationModel>
+}
 
 export type PageInfo = {
-  endCursor?: Maybe<Scalars['String']['output']>;
-  hasNextPage: Scalars['Boolean']['output'];
-  hasPreviousPage: Scalars['Boolean']['output'];
-  startCursor?: Maybe<Scalars['String']['output']>;
-};
+  endCursor?: Maybe<Scalars['String']['output']>
+  hasNextPage: Scalars['Boolean']['output']
+  hasPreviousPage: Scalars['Boolean']['output']
+  startCursor?: Maybe<Scalars['String']['output']>
+}
 
 export type ParentBranchModel = {
-  branch: BranchModel;
-  revision: RevisionModel;
-};
+  branch: BranchModel
+  revision: RevisionModel
+}
 
 export type PatchRow = {
-  op: PatchRowOp;
-  path: Scalars['String']['input'];
-  value: Scalars['JSON']['input'];
-};
+  op: PatchRowOp
+  path: Scalars['String']['input']
+  value: Scalars['JSON']['input']
+}
 
 export type PatchRowInput = {
-  patches: Array<PatchRow>;
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  patches: Array<PatchRow>
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export enum PatchRowOp {
-  Replace = 'replace'
+  Replace = 'replace',
 }
 
 export type PatchRowResultModel = {
-  previousVersionRowId: Scalars['String']['output'];
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  previousVersionRowId: Scalars['String']['output']
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type PatchRowsInput = {
-  revisionId: Scalars['String']['input'];
-  rows: Array<PatchRowsRowInput>;
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rows: Array<PatchRowsRowInput>
+  tableId: Scalars['String']['input']
+}
 
 export type PatchRowsResultModel = {
-  previousVersionTableId: Scalars['String']['output'];
-  rows: Array<RowModel>;
-  table: TableModel;
-};
+  previousVersionTableId: Scalars['String']['output']
+  rows: Array<RowModel>
+  table: TableModel
+}
 
 export type PatchRowsRowInput = {
-  patches: Array<PatchRow>;
-  rowId: Scalars['String']['input'];
-};
+  patches: Array<PatchRow>
+  rowId: Scalars['String']['input']
+}
 
 export type PaymentProviderModel = {
-  id: Scalars['ID']['output'];
-  methods: Array<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-  supportsRecurring: Scalars['Boolean']['output'];
-};
+  id: Scalars['ID']['output']
+  methods: Array<Scalars['String']['output']>
+  name: Scalars['String']['output']
+  supportsRecurring: Scalars['Boolean']['output']
+}
 
 export type PermissionModel = {
-  action: Scalars['String']['output'];
-  condition?: Maybe<Scalars['JSON']['output']>;
-  id: Scalars['String']['output'];
-  subject: Scalars['String']['output'];
-};
+  action: Scalars['String']['output']
+  condition?: Maybe<Scalars['JSON']['output']>
+  id: Scalars['String']['output']
+  subject: Scalars['String']['output']
+}
 
 export type PlanLimitsModel = {
-  apiCallsPerDay?: Maybe<Scalars['Int']['output']>;
-  branchesPerProject?: Maybe<Scalars['Int']['output']>;
-  projects?: Maybe<Scalars['Int']['output']>;
-  rowVersions?: Maybe<Scalars['Int']['output']>;
-  rowsPerTable?: Maybe<Scalars['Int']['output']>;
-  seats?: Maybe<Scalars['Int']['output']>;
-  storageBytes?: Maybe<Scalars['Float']['output']>;
-  tablesPerRevision?: Maybe<Scalars['Int']['output']>;
-};
+  apiCallsPerDay?: Maybe<Scalars['Int']['output']>
+  branchesPerProject?: Maybe<Scalars['Int']['output']>
+  projects?: Maybe<Scalars['Int']['output']>
+  rowVersions?: Maybe<Scalars['Int']['output']>
+  rowsPerTable?: Maybe<Scalars['Int']['output']>
+  seats?: Maybe<Scalars['Int']['output']>
+  storageBytes?: Maybe<Scalars['Float']['output']>
+  tablesPerRevision?: Maybe<Scalars['Int']['output']>
+}
 
 export type PlanModel = {
-  features: Scalars['JSON']['output'];
-  id: Scalars['ID']['output'];
-  isPublic: Scalars['Boolean']['output'];
-  limits: PlanLimitsModel;
-  monthlyPriceUsd: Scalars['Float']['output'];
-  name: Scalars['String']['output'];
-  yearlyPriceUsd: Scalars['Float']['output'];
-};
+  features: Scalars['JSON']['output']
+  id: Scalars['ID']['output']
+  isPublic: Scalars['Boolean']['output']
+  limits: PlanLimitsModel
+  monthlyPriceUsd: Scalars['Float']['output']
+  name: Scalars['String']['output']
+  yearlyPriceUsd: Scalars['Float']['output']
+}
 
 export type PluginsModel = {
-  file: Scalars['Boolean']['output'];
-};
+  file: Scalars['Boolean']['output']
+}
 
 export type ProjectModel = {
-  allBranches: BranchesConnection;
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['String']['output'];
-  isPublic: Scalars['Boolean']['output'];
-  name: Scalars['String']['output'];
-  organization: OrganizationModel;
-  organizationId: Scalars['String']['output'];
-  rootBranch: BranchModel;
-  userProject?: Maybe<UsersProjectModel>;
-};
-
+  allBranches: BranchesConnection
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['String']['output']
+  isPublic: Scalars['Boolean']['output']
+  name: Scalars['String']['output']
+  organization: OrganizationModel
+  organizationId: Scalars['String']['output']
+  rootBranch: BranchModel
+  userProject?: Maybe<UsersProjectModel>
+}
 
 export type ProjectModelAllBranchesArgs = {
-  data: GetProjectBranchesInput;
-};
+  data: GetProjectBranchesInput
+}
 
 export type ProjectModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: ProjectModel;
-};
+  cursor: Scalars['String']['output']
+  node: ProjectModel
+}
 
 export type ProjectsConnection = {
-  edges: Array<ProjectModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<ProjectModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type Query = {
-  adminUser?: Maybe<UserModel>;
-  adminUsers: UsersConnection;
-  apiKeyById: ApiKeyModel;
-  availableProviders: Array<PaymentProviderModel>;
-  branch: BranchModel;
-  branches: BranchesConnection;
-  configuration: ConfigurationModel;
+  adminCacheStats: CacheStatsModel
+  adminUser?: Maybe<UserModel>
+  adminUsers: UsersConnection
+  apiKeyById: ApiKeyModel
+  availableProviders: Array<PaymentProviderModel>
+  branch: BranchModel
+  branches: BranchesConnection
+  configuration: ConfigurationModel
   /** @deprecated use RowModel.rowForeignKeysBy.totalCount */
-  getRowCountForeignKeysTo: Scalars['Int']['output'];
-  me: MeModel;
-  meProjects: ProjectsConnection;
-  myApiKeys: Array<ApiKeyModel>;
-  organization: OrganizationModel;
-  plans: Array<PlanModel>;
-  project: ProjectModel;
-  projectEndpoints: EndpointsConnection;
-  projects: ProjectsConnection;
-  revision: RevisionModel;
-  revisionChanges: RevisionChangesModel;
-  row?: Maybe<RowModel>;
-  rowChanges: RowChangesConnection;
-  rows: RowsConnection;
-  searchRows: SearchResultsConnection;
-  searchUsers: SearchUsersConnection;
-  serviceApiKeys: Array<ApiKeyModel>;
-  subSchemaItems: SubSchemaItemsConnection;
-  table?: Maybe<TableModel>;
-  tableChanges: TableChangesConnection;
-  tableViews: TableViewsDataModel;
-  tables: TablesConnection;
-  usersOrganization: UsersOrganizationConnection;
-  usersProject: UsersProjectConnection;
-};
-
+  getRowCountForeignKeysTo: Scalars['Int']['output']
+  me: MeModel
+  meProjects: ProjectsConnection
+  myApiKeys: Array<ApiKeyModel>
+  organization: OrganizationModel
+  plans: Array<PlanModel>
+  project: ProjectModel
+  projectEndpoints: EndpointsConnection
+  projects: ProjectsConnection
+  revision: RevisionModel
+  revisionChanges: RevisionChangesModel
+  row?: Maybe<RowModel>
+  rowChanges: RowChangesConnection
+  rows: RowsConnection
+  searchRows: SearchResultsConnection
+  searchUsers: SearchUsersConnection
+  serviceApiKeys: Array<ApiKeyModel>
+  subSchemaItems: SubSchemaItemsConnection
+  table?: Maybe<TableModel>
+  tableChanges: TableChangesConnection
+  tableViews: TableViewsDataModel
+  tables: TablesConnection
+  usersOrganization: UsersOrganizationConnection
+  usersProject: UsersProjectConnection
+}
 
 export type QueryAdminUserArgs = {
-  data: AdminUserInput;
-};
-
+  data: AdminUserInput
+}
 
 export type QueryAdminUsersArgs = {
-  data: SearchUsersInput;
-};
-
+  data: SearchUsersInput
+}
 
 export type QueryApiKeyByIdArgs = {
-  id: Scalars['ID']['input'];
-};
-
+  id: Scalars['ID']['input']
+}
 
 export type QueryAvailableProvidersArgs = {
-  country?: InputMaybe<Scalars['String']['input']>;
-  method?: InputMaybe<Scalars['String']['input']>;
-};
-
+  country?: InputMaybe<Scalars['String']['input']>
+  method?: InputMaybe<Scalars['String']['input']>
+}
 
 export type QueryBranchArgs = {
-  data: GetBranchInput;
-};
-
+  data: GetBranchInput
+}
 
 export type QueryBranchesArgs = {
-  data: GetBranchesInput;
-};
-
+  data: GetBranchesInput
+}
 
 export type QueryGetRowCountForeignKeysToArgs = {
-  data: GetRowCountForeignKeysByInput;
-};
-
+  data: GetRowCountForeignKeysByInput
+}
 
 export type QueryMeProjectsArgs = {
-  data: GetMeProjectsInput;
-};
-
+  data: GetMeProjectsInput
+}
 
 export type QueryOrganizationArgs = {
-  data: GetOrganizationInput;
-};
-
+  data: GetOrganizationInput
+}
 
 export type QueryProjectArgs = {
-  data: GetProjectInput;
-};
-
+  data: GetProjectInput
+}
 
 export type QueryProjectEndpointsArgs = {
-  data: GetProjectEndpointsInput;
-};
-
+  data: GetProjectEndpointsInput
+}
 
 export type QueryProjectsArgs = {
-  data: GetProjectsInput;
-};
-
+  data: GetProjectsInput
+}
 
 export type QueryRevisionArgs = {
-  data: GetRevisionInput;
-};
-
+  data: GetRevisionInput
+}
 
 export type QueryRevisionChangesArgs = {
-  data: GetRevisionChangesInput;
-};
-
+  data: GetRevisionChangesInput
+}
 
 export type QueryRowArgs = {
-  data: GetRowInput;
-};
-
+  data: GetRowInput
+}
 
 export type QueryRowChangesArgs = {
-  data: GetRowChangesInput;
-};
-
+  data: GetRowChangesInput
+}
 
 export type QueryRowsArgs = {
-  data: GetRowsInput;
-};
-
+  data: GetRowsInput
+}
 
 export type QuerySearchRowsArgs = {
-  data: SearchRowsInput;
-};
-
+  data: SearchRowsInput
+}
 
 export type QuerySearchUsersArgs = {
-  data: SearchUsersInput;
-};
-
+  data: SearchUsersInput
+}
 
 export type QueryServiceApiKeysArgs = {
-  organizationId: Scalars['String']['input'];
-};
-
+  organizationId: Scalars['String']['input']
+}
 
 export type QuerySubSchemaItemsArgs = {
-  data: GetSubSchemaItemsInput;
-};
-
+  data: GetSubSchemaItemsInput
+}
 
 export type QueryTableArgs = {
-  data: GetTableInput;
-};
-
+  data: GetTableInput
+}
 
 export type QueryTableChangesArgs = {
-  data: GetTableChangesInput;
-};
-
+  data: GetTableChangesInput
+}
 
 export type QueryTableViewsArgs = {
-  data: GetTableViewsInput;
-};
-
+  data: GetTableViewsInput
+}
 
 export type QueryTablesArgs = {
-  data: GetTablesInput;
-};
-
+  data: GetTablesInput
+}
 
 export type QueryUsersOrganizationArgs = {
-  data: GetUsersOrganizationInput;
-};
-
+  data: GetUsersOrganizationInput
+}
 
 export type QueryUsersProjectArgs = {
-  data: GetUsersProjectInput;
-};
+  data: GetUsersProjectInput
+}
 
 export enum QueryMode {
   Default = 'default',
-  Insensitive = 'insensitive'
+  Insensitive = 'insensitive',
 }
 
 export type RemoveUserFromOrganizationInput = {
-  organizationId: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}
 
 export type RemoveUserFromProjectInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}
 
 export type RemovedRowChangeModel = {
-  changeType: ChangeType;
-  fieldChanges: Array<FieldChangeModel>;
-  fromRow: RowChangeRowModel;
-  fromTable: RowChangeTableModel;
-};
+  changeType: ChangeType
+  fieldChanges: Array<FieldChangeModel>
+  fromRow: RowChangeRowModel
+  fromTable: RowChangeTableModel
+}
 
 export type RenameRowInput = {
-  nextRowId: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  nextRowId: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type RenameRowResultModel = {
-  previousVersionRowId: Scalars['String']['output'];
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  previousVersionRowId: Scalars['String']['output']
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type RenameTableInput = {
-  nextTableId: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  nextTableId: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type RenameTableResultModel = {
-  previousVersionTableId: Scalars['String']['output'];
-  table: TableModel;
-};
+  previousVersionTableId: Scalars['String']['output']
+  table: TableModel
+}
 
 export type ResetPasswordInput = {
-  newPassword: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-};
+  newPassword: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}
 
 export type RevertChangesInput = {
-  branchName: Scalars['String']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  branchName: Scalars['String']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type RevisionChangeSummaryModel = {
-  added: Scalars['Int']['output'];
-  modified: Scalars['Int']['output'];
-  removed: Scalars['Int']['output'];
-  renamed: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
-};
+  added: Scalars['Int']['output']
+  modified: Scalars['Int']['output']
+  removed: Scalars['Int']['output']
+  renamed: Scalars['Int']['output']
+  total: Scalars['Int']['output']
+}
 
 export type RevisionChangesModel = {
-  parentRevisionId?: Maybe<Scalars['String']['output']>;
-  revisionId: Scalars['String']['output'];
-  rowsSummary: RevisionChangeSummaryModel;
-  tablesSummary: RevisionChangeSummaryModel;
-  totalChanges: Scalars['Int']['output'];
-};
+  parentRevisionId?: Maybe<Scalars['String']['output']>
+  revisionId: Scalars['String']['output']
+  rowsSummary: RevisionChangeSummaryModel
+  tablesSummary: RevisionChangeSummaryModel
+  totalChanges: Scalars['Int']['output']
+}
 
 export type RevisionConnection = {
-  edges: Array<RevisionModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<RevisionModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type RevisionModel = {
-  branch: BranchModel;
-  changes: RevisionChangesModel;
-  child?: Maybe<RevisionModel>;
-  childBranches: Array<ChildBranchModel>;
-  children: Array<RevisionModel>;
-  comment: Scalars['String']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  endpoints: Array<EndpointModel>;
-  id: Scalars['String']['output'];
-  isDraft: Scalars['Boolean']['output'];
-  isHead: Scalars['Boolean']['output'];
-  isStart: Scalars['Boolean']['output'];
-  migrations: Array<Scalars['JSON']['output']>;
-  parent?: Maybe<RevisionModel>;
-  sequence: Scalars['Int']['output'];
-  tables: TablesConnection;
-};
-
+  branch: BranchModel
+  changes: RevisionChangesModel
+  child?: Maybe<RevisionModel>
+  childBranches: Array<ChildBranchModel>
+  children: Array<RevisionModel>
+  comment: Scalars['String']['output']
+  createdAt: Scalars['DateTime']['output']
+  endpoints: Array<EndpointModel>
+  id: Scalars['String']['output']
+  isDraft: Scalars['Boolean']['output']
+  isHead: Scalars['Boolean']['output']
+  isStart: Scalars['Boolean']['output']
+  migrations: Array<Scalars['JSON']['output']>
+  parent?: Maybe<RevisionModel>
+  sequence: Scalars['Int']['output']
+  tables: TablesConnection
+}
 
 export type RevisionModelTablesArgs = {
-  data: GetRevisionTablesInput;
-};
+  data: GetRevisionTablesInput
+}
 
 export type RevisionModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: RevisionModel;
-};
+  cursor: Scalars['String']['output']
+  node: RevisionModel
+}
 
 export type RoleModel = {
-  id: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  permissions: Array<PermissionModel>;
-};
+  id: Scalars['String']['output']
+  name: Scalars['String']['output']
+  permissions: Array<PermissionModel>
+}
 
-export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel;
+export type RowChange = AddedRowChangeModel | ModifiedRowChangeModel | RemovedRowChangeModel
 
 export enum RowChangeDetailType {
   FieldAdded = 'FIELD_ADDED',
   FieldModified = 'FIELD_MODIFIED',
   FieldMoved = 'FIELD_MOVED',
-  FieldRemoved = 'FIELD_REMOVED'
+  FieldRemoved = 'FIELD_REMOVED',
 }
 
 export type RowChangeEdge = {
-  cursor: Scalars['String']['output'];
-  node: RowChange;
-};
+  cursor: Scalars['String']['output']
+  node: RowChange
+}
 
 export type RowChangeRowModel = {
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  data: Scalars['JSON']['output'];
-  hash: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  meta: Scalars['JSON']['output'];
-  publishedAt: Scalars['DateTime']['output'];
-  readonly: Scalars['Boolean']['output'];
-  schemaHash: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-};
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  data: Scalars['JSON']['output']
+  hash: Scalars['String']['output']
+  id: Scalars['String']['output']
+  meta: Scalars['JSON']['output']
+  publishedAt: Scalars['DateTime']['output']
+  readonly: Scalars['Boolean']['output']
+  schemaHash: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+}
 
 export type RowChangeTableModel = {
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  readonly: Scalars['Boolean']['output'];
-  system: Scalars['Boolean']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-};
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  id: Scalars['String']['output']
+  readonly: Scalars['Boolean']['output']
+  system: Scalars['Boolean']['output']
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+}
 
 export type RowChangesConnection = {
-  edges: Array<RowChangeEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<RowChangeEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type RowChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>;
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  tableId?: InputMaybe<Scalars['String']['input']>;
-};
+  changeTypes?: InputMaybe<Array<ChangeType>>
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
+  search?: InputMaybe<Scalars['String']['input']>
+  tableId?: InputMaybe<Scalars['String']['input']>
+}
 
 export type RowModel = {
-  countForeignKeysTo: Scalars['Int']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  data: Scalars['JSON']['output'];
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
-  id: Scalars['String']['output'];
-  publishedAt: Scalars['DateTime']['output'];
-  readonly: Scalars['Boolean']['output'];
-  rowForeignKeysBy: RowsConnection;
-  rowForeignKeysTo: RowsConnection;
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-};
-
+  countForeignKeysTo: Scalars['Int']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  data: Scalars['JSON']['output']
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
+  id: Scalars['String']['output']
+  publishedAt: Scalars['DateTime']['output']
+  readonly: Scalars['Boolean']['output']
+  rowForeignKeysBy: RowsConnection
+  rowForeignKeysTo: RowsConnection
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+}
 
 export type RowModelRowForeignKeysByArgs = {
-  data: GetRowForeignKeysInput;
-};
-
+  data: GetRowForeignKeysInput
+}
 
 export type RowModelRowForeignKeysToArgs = {
-  data: GetRowForeignKeysInput;
-};
+  data: GetRowForeignKeysInput
+}
 
 export type RowModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: RowModel;
-};
+  cursor: Scalars['String']['output']
+  node: RowModel
+}
 
 export type RowsConnection = {
-  edges: Array<RowModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<RowModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SchemaFieldChangeModel = {
-  changeType: Scalars['String']['output'];
-  fieldPath: Scalars['String']['output'];
-  movedFrom?: Maybe<Scalars['String']['output']>;
-  movedTo?: Maybe<Scalars['String']['output']>;
-  newSchema?: Maybe<Scalars['JSON']['output']>;
-  oldSchema?: Maybe<Scalars['JSON']['output']>;
-};
+  changeType: Scalars['String']['output']
+  fieldPath: Scalars['String']['output']
+  movedFrom?: Maybe<Scalars['String']['output']>
+  movedTo?: Maybe<Scalars['String']['output']>
+  newSchema?: Maybe<Scalars['JSON']['output']>
+  oldSchema?: Maybe<Scalars['JSON']['output']>
+}
 
 export type SchemaMigrationDetailModel = {
-  historyPatches?: Maybe<Array<HistoryPatchModel>>;
-  initialSchema?: Maybe<Scalars['JSON']['output']>;
-  migrationId: Scalars['String']['output'];
-  migrationType: MigrationType;
-  newTableId?: Maybe<Scalars['String']['output']>;
-  oldTableId?: Maybe<Scalars['String']['output']>;
-  patches?: Maybe<Array<JsonPatchOperationModel>>;
-};
+  historyPatches?: Maybe<Array<HistoryPatchModel>>
+  initialSchema?: Maybe<Scalars['JSON']['output']>
+  migrationId: Scalars['String']['output']
+  migrationType: MigrationType
+  newTableId?: Maybe<Scalars['String']['output']>
+  oldTableId?: Maybe<Scalars['String']['output']>
+  patches?: Maybe<Array<JsonPatchOperationModel>>
+}
 
 export enum SearchIn {
   All = 'all',
@@ -1492,7 +1445,7 @@ export enum SearchIn {
   Keys = 'keys',
   Numbers = 'numbers',
   Strings = 'strings',
-  Values = 'values'
+  Values = 'values',
 }
 
 /** Language for full-text search. Default: simple */
@@ -1525,1930 +1478,2662 @@ export enum SearchLanguage {
   Swedish = 'swedish',
   Tamil = 'tamil',
   Turkish = 'turkish',
-  Yiddish = 'yiddish'
+  Yiddish = 'yiddish',
 }
 
 export type SearchMatch = {
-  highlight?: Maybe<Scalars['String']['output']>;
-  path: Scalars['String']['output'];
-  value: Scalars['JSON']['output'];
-};
+  highlight?: Maybe<Scalars['String']['output']>
+  path: Scalars['String']['output']
+  value: Scalars['JSON']['output']
+}
 
 export type SearchResult = {
-  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>;
-  matches: Array<SearchMatch>;
-  row: RowModel;
-  table: TableModel;
-};
+  formulaErrors?: Maybe<Array<FormulaFieldErrorModel>>
+  matches: Array<SearchMatch>
+  row: RowModel
+  table: TableModel
+}
 
 export type SearchResultEdge = {
-  cursor: Scalars['String']['output'];
-  node: SearchResult;
-};
+  cursor: Scalars['String']['output']
+  node: SearchResult
+}
 
 export type SearchResultsConnection = {
-  edges: Array<SearchResultEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<SearchResultEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SearchRowsInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  query: Scalars['String']['input'];
-  revisionId: Scalars['String']['input'];
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  query: Scalars['String']['input']
+  revisionId: Scalars['String']['input']
+}
 
 export enum SearchType {
   Phrase = 'phrase',
   Plain = 'plain',
   Prefix = 'prefix',
-  Tsquery = 'tsquery'
+  Tsquery = 'tsquery',
 }
 
 export type SearchUserModel = {
-  email?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  username?: Maybe<Scalars['String']['output']>;
-};
+  email?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  username?: Maybe<Scalars['String']['output']>
+}
 
 export type SearchUserModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: SearchUserModel;
-};
+  cursor: Scalars['String']['output']
+  node: SearchUserModel
+}
 
 export type SearchUsersConnection = {
-  edges: Array<SearchUserModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<SearchUserModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SearchUsersInput = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  search?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SetUsernameInput = {
-  username: Scalars['String']['input'];
-};
+  username: Scalars['String']['input']
+}
 
 export type SignUpInput = {
-  email: Scalars['String']['input'];
-  password: Scalars['String']['input'];
-  username: Scalars['String']['input'];
-};
+  email: Scalars['String']['input']
+  password: Scalars['String']['input']
+  username: Scalars['String']['input']
+}
 
 export enum SortOrder {
   Asc = 'asc',
-  Desc = 'desc'
+  Desc = 'desc',
 }
 
 export type StringFilter = {
-  contains?: InputMaybe<Scalars['String']['input']>;
-  endsWith?: InputMaybe<Scalars['String']['input']>;
-  equals?: InputMaybe<Scalars['String']['input']>;
-  gt?: InputMaybe<Scalars['String']['input']>;
-  gte?: InputMaybe<Scalars['String']['input']>;
-  in?: InputMaybe<Array<Scalars['String']['input']>>;
-  lt?: InputMaybe<Scalars['String']['input']>;
-  lte?: InputMaybe<Scalars['String']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']['input']>;
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
-  startsWith?: InputMaybe<Scalars['String']['input']>;
-};
+  contains?: InputMaybe<Scalars['String']['input']>
+  endsWith?: InputMaybe<Scalars['String']['input']>
+  equals?: InputMaybe<Scalars['String']['input']>
+  gt?: InputMaybe<Scalars['String']['input']>
+  gte?: InputMaybe<Scalars['String']['input']>
+  in?: InputMaybe<Array<Scalars['String']['input']>>
+  lt?: InputMaybe<Scalars['String']['input']>
+  lte?: InputMaybe<Scalars['String']['input']>
+  mode?: InputMaybe<QueryMode>
+  not?: InputMaybe<Scalars['String']['input']>
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>
+  startsWith?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SubSchemaDataOrderByInput = {
-  nulls?: InputMaybe<NullsPosition>;
-  order: SortOrder;
-  path: Scalars['JSON']['input'];
-};
+  nulls?: InputMaybe<NullsPosition>
+  order: SortOrder
+  path: Scalars['JSON']['input']
+}
 
 export type SubSchemaItemModel = {
-  data: Scalars['JSON']['output'];
-  fieldPath: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  data: Scalars['JSON']['output']
+  fieldPath: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type SubSchemaItemModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: SubSchemaItemModel;
-};
+  cursor: Scalars['String']['output']
+  node: SubSchemaItemModel
+}
 
 export type SubSchemaItemsConnection = {
-  edges: Array<SubSchemaItemModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<SubSchemaItemModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type SubSchemaJsonFilterInput = {
-  equals?: InputMaybe<Scalars['JSON']['input']>;
-  gt?: InputMaybe<Scalars['JSON']['input']>;
-  gte?: InputMaybe<Scalars['JSON']['input']>;
-  in?: InputMaybe<Array<Scalars['JSON']['input']>>;
-  lt?: InputMaybe<Scalars['JSON']['input']>;
-  lte?: InputMaybe<Scalars['JSON']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['JSON']['input']>;
-  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>;
-  path: Scalars['JSON']['input'];
-  string_contains?: InputMaybe<Scalars['String']['input']>;
-  string_ends_with?: InputMaybe<Scalars['String']['input']>;
-  string_starts_with?: InputMaybe<Scalars['String']['input']>;
-};
+  equals?: InputMaybe<Scalars['JSON']['input']>
+  gt?: InputMaybe<Scalars['JSON']['input']>
+  gte?: InputMaybe<Scalars['JSON']['input']>
+  in?: InputMaybe<Array<Scalars['JSON']['input']>>
+  lt?: InputMaybe<Scalars['JSON']['input']>
+  lte?: InputMaybe<Scalars['JSON']['input']>
+  mode?: InputMaybe<QueryMode>
+  not?: InputMaybe<Scalars['JSON']['input']>
+  notIn?: InputMaybe<Array<Scalars['JSON']['input']>>
+  path: Scalars['JSON']['input']
+  string_contains?: InputMaybe<Scalars['String']['input']>
+  string_ends_with?: InputMaybe<Scalars['String']['input']>
+  string_starts_with?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SubSchemaOrderByItemInput = {
-  data?: InputMaybe<SubSchemaDataOrderByInput>;
-  fieldPath?: InputMaybe<SortOrder>;
-  rowCreatedAt?: InputMaybe<SortOrder>;
-  rowId?: InputMaybe<SortOrder>;
-  tableId?: InputMaybe<SortOrder>;
-};
+  data?: InputMaybe<SubSchemaDataOrderByInput>
+  fieldPath?: InputMaybe<SortOrder>
+  rowCreatedAt?: InputMaybe<SortOrder>
+  rowId?: InputMaybe<SortOrder>
+  tableId?: InputMaybe<SortOrder>
+}
 
 export type SubSchemaStringFilterInput = {
-  contains?: InputMaybe<Scalars['String']['input']>;
-  endsWith?: InputMaybe<Scalars['String']['input']>;
-  equals?: InputMaybe<Scalars['String']['input']>;
-  gt?: InputMaybe<Scalars['String']['input']>;
-  gte?: InputMaybe<Scalars['String']['input']>;
-  in?: InputMaybe<Array<Scalars['String']['input']>>;
-  lt?: InputMaybe<Scalars['String']['input']>;
-  lte?: InputMaybe<Scalars['String']['input']>;
-  mode?: InputMaybe<QueryMode>;
-  not?: InputMaybe<Scalars['String']['input']>;
-  notIn?: InputMaybe<Array<Scalars['String']['input']>>;
-  startsWith?: InputMaybe<Scalars['String']['input']>;
-};
+  contains?: InputMaybe<Scalars['String']['input']>
+  endsWith?: InputMaybe<Scalars['String']['input']>
+  equals?: InputMaybe<Scalars['String']['input']>
+  gt?: InputMaybe<Scalars['String']['input']>
+  gte?: InputMaybe<Scalars['String']['input']>
+  in?: InputMaybe<Array<Scalars['String']['input']>>
+  lt?: InputMaybe<Scalars['String']['input']>
+  lte?: InputMaybe<Scalars['String']['input']>
+  mode?: InputMaybe<QueryMode>
+  not?: InputMaybe<Scalars['String']['input']>
+  notIn?: InputMaybe<Array<Scalars['String']['input']>>
+  startsWith?: InputMaybe<Scalars['String']['input']>
+}
 
 export type SubSchemaWhereInput = {
-  AND?: InputMaybe<Array<SubSchemaWhereInput>>;
-  NOT?: InputMaybe<SubSchemaWhereInput>;
-  OR?: InputMaybe<Array<SubSchemaWhereInput>>;
-  data?: InputMaybe<SubSchemaJsonFilterInput>;
-  fieldPath?: InputMaybe<SubSchemaStringFilterInput>;
-  rowId?: InputMaybe<SubSchemaStringFilterInput>;
-  tableId?: InputMaybe<SubSchemaStringFilterInput>;
-};
+  AND?: InputMaybe<Array<SubSchemaWhereInput>>
+  NOT?: InputMaybe<SubSchemaWhereInput>
+  OR?: InputMaybe<Array<SubSchemaWhereInput>>
+  data?: InputMaybe<SubSchemaJsonFilterInput>
+  fieldPath?: InputMaybe<SubSchemaStringFilterInput>
+  rowId?: InputMaybe<SubSchemaStringFilterInput>
+  tableId?: InputMaybe<SubSchemaStringFilterInput>
+}
 
 export type SubscriptionModel = {
-  cancelAt?: Maybe<Scalars['DateTime']['output']>;
-  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>;
-  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>;
-  interval?: Maybe<Scalars['String']['output']>;
-  planId: Scalars['String']['output'];
-  provider?: Maybe<Scalars['String']['output']>;
-  status: BillingStatus;
-};
+  cancelAt?: Maybe<Scalars['DateTime']['output']>
+  currentPeriodEnd?: Maybe<Scalars['DateTime']['output']>
+  currentPeriodStart?: Maybe<Scalars['DateTime']['output']>
+  interval?: Maybe<Scalars['String']['output']>
+  planId: Scalars['String']['output']
+  provider?: Maybe<Scalars['String']['output']>
+  status: BillingStatus
+}
 
 export type TableChangeModel = {
-  addedRowsCount: Scalars['Int']['output'];
-  changeType: ChangeType;
-  fromVersionId?: Maybe<Scalars['String']['output']>;
-  modifiedRowsCount: Scalars['Int']['output'];
-  newTableId?: Maybe<Scalars['String']['output']>;
-  oldTableId?: Maybe<Scalars['String']['output']>;
-  removedRowsCount: Scalars['Int']['output'];
-  renamedRowsCount: Scalars['Int']['output'];
-  rowChangesCount: Scalars['Int']['output'];
-  schemaMigrations: Array<SchemaMigrationDetailModel>;
-  tableCreatedId: Scalars['String']['output'];
-  tableId: Scalars['String']['output'];
-  toVersionId?: Maybe<Scalars['String']['output']>;
-  viewsChanges: ViewsChangeDetailModel;
-};
+  addedRowsCount: Scalars['Int']['output']
+  changeType: ChangeType
+  fromVersionId?: Maybe<Scalars['String']['output']>
+  modifiedRowsCount: Scalars['Int']['output']
+  newTableId?: Maybe<Scalars['String']['output']>
+  oldTableId?: Maybe<Scalars['String']['output']>
+  removedRowsCount: Scalars['Int']['output']
+  renamedRowsCount: Scalars['Int']['output']
+  rowChangesCount: Scalars['Int']['output']
+  schemaMigrations: Array<SchemaMigrationDetailModel>
+  tableCreatedId: Scalars['String']['output']
+  tableId: Scalars['String']['output']
+  toVersionId?: Maybe<Scalars['String']['output']>
+  viewsChanges: ViewsChangeDetailModel
+}
 
 export type TableChangeModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: TableChangeModel;
-};
+  cursor: Scalars['String']['output']
+  node: TableChangeModel
+}
 
 export type TableChangesConnection = {
-  edges: Array<TableChangeModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<TableChangeModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type TableChangesFiltersInput = {
-  changeTypes?: InputMaybe<Array<ChangeType>>;
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>;
-};
+  changeTypes?: InputMaybe<Array<ChangeType>>
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
+  search?: InputMaybe<Scalars['String']['input']>
+  withSchemaMigrations?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type TableModel = {
-  count: Scalars['Int']['output'];
-  countForeignKeysBy: Scalars['Int']['output'];
-  countForeignKeysTo: Scalars['Int']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdId: Scalars['String']['output'];
-  foreignKeysBy: TablesConnection;
-  foreignKeysTo: TablesConnection;
-  id: Scalars['String']['output'];
-  readonly: Scalars['Boolean']['output'];
-  rows: RowsConnection;
-  schema: Scalars['JSON']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  versionId: Scalars['String']['output'];
-  views: TableViewsDataModel;
-};
-
+  count: Scalars['Int']['output']
+  countForeignKeysBy: Scalars['Int']['output']
+  countForeignKeysTo: Scalars['Int']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdId: Scalars['String']['output']
+  foreignKeysBy: TablesConnection
+  foreignKeysTo: TablesConnection
+  id: Scalars['String']['output']
+  readonly: Scalars['Boolean']['output']
+  rows: RowsConnection
+  schema: Scalars['JSON']['output']
+  updatedAt: Scalars['DateTime']['output']
+  versionId: Scalars['String']['output']
+  views: TableViewsDataModel
+}
 
 export type TableModelForeignKeysByArgs = {
-  data: GetTableForeignKeysInput;
-};
-
+  data: GetTableForeignKeysInput
+}
 
 export type TableModelForeignKeysToArgs = {
-  data: GetTableForeignKeysInput;
-};
-
+  data: GetTableForeignKeysInput
+}
 
 export type TableModelRowsArgs = {
-  data: GetTableRowsInput;
-};
+  data: GetTableRowsInput
+}
 
 export type TableModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: TableModel;
-};
+  cursor: Scalars['String']['output']
+  node: TableModel
+}
 
 export type TableViewsDataInput = {
-  defaultViewId: Scalars['String']['input'];
-  version: Scalars['Int']['input'];
-  views: Array<ViewInput>;
-};
+  defaultViewId: Scalars['String']['input']
+  version: Scalars['Int']['input']
+  views: Array<ViewInput>
+}
 
 export type TableViewsDataModel = {
-  defaultViewId: Scalars['String']['output'];
-  version: Scalars['Int']['output'];
-  views: Array<ViewModel>;
-};
+  defaultViewId: Scalars['String']['output']
+  version: Scalars['Int']['output']
+  views: Array<ViewModel>
+}
 
 export type TablesConnection = {
-  edges: Array<TableModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<TableModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UpdatePasswordInput = {
-  newPassword: Scalars['String']['input'];
-  oldPassword: Scalars['String']['input'];
-};
+  newPassword: Scalars['String']['input']
+  oldPassword: Scalars['String']['input']
+}
 
 export type UpdateProjectInput = {
-  isPublic: Scalars['Boolean']['input'];
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-};
+  isPublic: Scalars['Boolean']['input']
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+}
 
 export type UpdateRowInput = {
-  data: Scalars['JSON']['input'];
-  revisionId: Scalars['String']['input'];
-  rowId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  revisionId: Scalars['String']['input']
+  rowId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type UpdateRowResultModel = {
-  previousVersionRowId: Scalars['String']['output'];
-  previousVersionTableId: Scalars['String']['output'];
-  row: RowModel;
-  table: TableModel;
-};
+  previousVersionRowId: Scalars['String']['output']
+  previousVersionTableId: Scalars['String']['output']
+  row: RowModel
+  table: TableModel
+}
 
 export type UpdateRowsInput = {
-  revisionId: Scalars['String']['input'];
-  rows: Array<UpdateRowsRowInput>;
-  tableId: Scalars['String']['input'];
-};
+  revisionId: Scalars['String']['input']
+  rows: Array<UpdateRowsRowInput>
+  tableId: Scalars['String']['input']
+}
 
 export type UpdateRowsResultModel = {
-  previousVersionTableId: Scalars['String']['output'];
-  rows: Array<RowModel>;
-  table: TableModel;
-};
+  previousVersionTableId: Scalars['String']['output']
+  rows: Array<RowModel>
+  table: TableModel
+}
 
 export type UpdateRowsRowInput = {
-  data: Scalars['JSON']['input'];
-  rowId: Scalars['String']['input'];
-};
+  data: Scalars['JSON']['input']
+  rowId: Scalars['String']['input']
+}
 
 export type UpdateTableInput = {
-  patches: Scalars['JSON']['input'];
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-};
+  patches: Scalars['JSON']['input']
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+}
 
 export type UpdateTableResultModel = {
-  previousVersionTableId: Scalars['String']['output'];
-  table: TableModel;
-};
+  previousVersionTableId: Scalars['String']['output']
+  table: TableModel
+}
 
 export type UpdateTableViewsInput = {
-  revisionId: Scalars['String']['input'];
-  tableId: Scalars['String']['input'];
-  viewsData: TableViewsDataInput;
-};
+  revisionId: Scalars['String']['input']
+  tableId: Scalars['String']['input']
+  viewsData: TableViewsDataInput
+}
 
 export type UpdateUserProjectRoleInput = {
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  roleId: UserProjectRoles;
-  userId: Scalars['String']['input'];
-};
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  roleId: UserProjectRoles
+  userId: Scalars['String']['input']
+}
 
 export type UsageMetricModel = {
-  current: Scalars['Float']['output'];
-  limit?: Maybe<Scalars['Float']['output']>;
-  percentage?: Maybe<Scalars['Float']['output']>;
-};
+  current: Scalars['Float']['output']
+  limit?: Maybe<Scalars['Float']['output']>
+  percentage?: Maybe<Scalars['Float']['output']>
+}
 
 export type UsageSummaryModel = {
-  projects: UsageMetricModel;
-  rowVersions: UsageMetricModel;
-  seats: UsageMetricModel;
-  storageBytes: UsageMetricModel;
-};
+  projects: UsageMetricModel
+  rowVersions: UsageMetricModel
+  seats: UsageMetricModel
+  storageBytes: UsageMetricModel
+}
 
 export type UserModel = {
-  email?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  organizationId?: Maybe<Scalars['String']['output']>;
-  role: RoleModel;
-  roleId: Scalars['String']['output'];
-  username?: Maybe<Scalars['String']['output']>;
-};
+  email?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  organizationId?: Maybe<Scalars['String']['output']>
+  role: RoleModel
+  roleId: Scalars['String']['output']
+  username?: Maybe<Scalars['String']['output']>
+}
 
 export type UserModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: UserModel;
-};
+  cursor: Scalars['String']['output']
+  node: UserModel
+}
 
 export enum UserOrganizationRoles {
   Developer = 'developer',
   Editor = 'editor',
   OrganizationAdmin = 'organizationAdmin',
   OrganizationOwner = 'organizationOwner',
-  Reader = 'reader'
+  Reader = 'reader',
 }
 
 export enum UserProjectRoles {
   Developer = 'developer',
   Editor = 'editor',
-  Reader = 'reader'
+  Reader = 'reader',
 }
 
 export enum UserSystemRole {
   SystemAdmin = 'systemAdmin',
   SystemFullApiRead = 'systemFullApiRead',
-  SystemUser = 'systemUser'
+  SystemUser = 'systemUser',
 }
 
 export type UsersConnection = {
-  edges: Array<UserModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<UserModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UsersOrganizationConnection = {
-  edges: Array<UsersOrganizationModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<UsersOrganizationModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UsersOrganizationModel = {
-  id: Scalars['String']['output'];
-  role: RoleModel;
-  user: UserModel;
-};
+  id: Scalars['String']['output']
+  role: RoleModel
+  user: UserModel
+}
 
 export type UsersOrganizationModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: UsersOrganizationModel;
-};
+  cursor: Scalars['String']['output']
+  node: UsersOrganizationModel
+}
 
 export type UsersProjectConnection = {
-  edges: Array<UsersProjectModelEdge>;
-  pageInfo: PageInfo;
-  totalCount: Scalars['Int']['output'];
-};
+  edges: Array<UsersProjectModelEdge>
+  pageInfo: PageInfo
+  totalCount: Scalars['Int']['output']
+}
 
 export type UsersProjectModel = {
-  id: Scalars['String']['output'];
-  role: RoleModel;
-  user: UserModel;
-};
+  id: Scalars['String']['output']
+  role: RoleModel
+  user: UserModel
+}
 
 export type UsersProjectModelEdge = {
-  cursor: Scalars['String']['output'];
-  node: UsersProjectModel;
-};
+  cursor: Scalars['String']['output']
+  node: UsersProjectModel
+}
 
 export type ViewChangeModel = {
-  changeType: ChangeType;
-  oldViewName?: Maybe<Scalars['String']['output']>;
-  viewId: Scalars['String']['output'];
-  viewName: Scalars['String']['output'];
-};
+  changeType: ChangeType
+  oldViewName?: Maybe<Scalars['String']['output']>
+  viewId: Scalars['String']['output']
+  viewName: Scalars['String']['output']
+}
 
 export type ViewColumnInput = {
-  field: Scalars['String']['input'];
-  pinned?: InputMaybe<Scalars['String']['input']>;
-  width?: InputMaybe<Scalars['Float']['input']>;
-};
+  field: Scalars['String']['input']
+  pinned?: InputMaybe<Scalars['String']['input']>
+  width?: InputMaybe<Scalars['Float']['input']>
+}
 
 export type ViewColumnModel = {
-  field: Scalars['String']['output'];
-  pinned?: Maybe<Scalars['String']['output']>;
-  width?: Maybe<Scalars['Float']['output']>;
-};
+  field: Scalars['String']['output']
+  pinned?: Maybe<Scalars['String']['output']>
+  width?: Maybe<Scalars['Float']['output']>
+}
 
 export type ViewInput = {
-  columns?: InputMaybe<Array<ViewColumnInput>>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<Scalars['JSON']['input']>;
-  id: Scalars['String']['input'];
-  name: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  sorts?: InputMaybe<Array<ViewSortInput>>;
-};
+  columns?: InputMaybe<Array<ViewColumnInput>>
+  description?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<Scalars['JSON']['input']>
+  id: Scalars['String']['input']
+  name: Scalars['String']['input']
+  search?: InputMaybe<Scalars['String']['input']>
+  sorts?: InputMaybe<Array<ViewSortInput>>
+}
 
 export type ViewModel = {
-  columns?: Maybe<Array<ViewColumnModel>>;
-  description?: Maybe<Scalars['String']['output']>;
-  filters?: Maybe<Scalars['JSON']['output']>;
-  id: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  search?: Maybe<Scalars['String']['output']>;
-  sorts?: Maybe<Array<ViewSortModel>>;
-};
+  columns?: Maybe<Array<ViewColumnModel>>
+  description?: Maybe<Scalars['String']['output']>
+  filters?: Maybe<Scalars['JSON']['output']>
+  id: Scalars['String']['output']
+  name: Scalars['String']['output']
+  search?: Maybe<Scalars['String']['output']>
+  sorts?: Maybe<Array<ViewSortModel>>
+}
 
 export type ViewSortInput = {
-  direction: SortOrder;
-  field: Scalars['String']['input'];
-};
+  direction: SortOrder
+  field: Scalars['String']['input']
+}
 
 export type ViewSortModel = {
-  direction: Scalars['String']['output'];
-  field: Scalars['String']['output'];
-};
+  direction: Scalars['String']['output']
+  field: Scalars['String']['output']
+}
 
 export type ViewsChangeDetailModel = {
-  addedCount: Scalars['Int']['output'];
-  changes: Array<ViewChangeModel>;
-  hasChanges: Scalars['Boolean']['output'];
-  modifiedCount: Scalars['Int']['output'];
-  removedCount: Scalars['Int']['output'];
-  renamedCount: Scalars['Int']['output'];
-};
+  addedCount: Scalars['Int']['output']
+  changes: Array<ViewChangeModel>
+  hasChanges: Scalars['Boolean']['output']
+  modifiedCount: Scalars['Int']['output']
+  removedCount: Scalars['Int']['output']
+  renamedCount: Scalars['Int']['output']
+}
 
 export type WhereInput = {
-  AND?: InputMaybe<Array<WhereInput>>;
-  NOT?: InputMaybe<Array<WhereInput>>;
-  OR?: InputMaybe<Array<WhereInput>>;
-  createdAt?: InputMaybe<DateTimeFilter>;
-  createdId?: InputMaybe<StringFilter>;
-  data?: InputMaybe<JsonFilter>;
-  id?: InputMaybe<StringFilter>;
-  publishedAt?: InputMaybe<DateTimeFilter>;
-  readonly?: InputMaybe<BooleanFilter>;
-  updatedAt?: InputMaybe<DateTimeFilter>;
-  versionId?: InputMaybe<StringFilter>;
-};
+  AND?: InputMaybe<Array<WhereInput>>
+  NOT?: InputMaybe<Array<WhereInput>>
+  OR?: InputMaybe<Array<WhereInput>>
+  createdAt?: InputMaybe<DateTimeFilter>
+  createdId?: InputMaybe<StringFilter>
+  data?: InputMaybe<JsonFilter>
+  id?: InputMaybe<StringFilter>
+  publishedAt?: InputMaybe<DateTimeFilter>
+  readonly?: InputMaybe<BooleanFilter>
+  updatedAt?: InputMaybe<DateTimeFilter>
+  versionId?: InputMaybe<StringFilter>
+}
 
-export type BranchLoaderFragmentFragment = { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } };
+export type BranchLoaderFragmentFragment = {
+  id: string
+  createdAt: string
+  name: string
+  touched: boolean
+  projectId: string
+  head: { id: string }
+  draft: { id: string }
+}
 
 export type GetBranchForLoaderQueryVariables = Exact<{
-  data: GetBranchInput;
-}>;
+  data: GetBranchInput
+}>
 
+export type GetBranchForLoaderQuery = {
+  branch: {
+    id: string
+    createdAt: string
+    name: string
+    touched: boolean
+    projectId: string
+    head: { id: string }
+    draft: { id: string }
+  }
+}
 
-export type GetBranchForLoaderQuery = { branch: { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } } };
-
-export type OrganizationProjectItemFragment = { id: string, name: string, organizationId: string, isPublic: boolean, rootBranch: { name: string, touched: boolean } };
+export type OrganizationProjectItemFragment = {
+  id: string
+  name: string
+  organizationId: string
+  isPublic: boolean
+  rootBranch: { name: string; touched: boolean }
+}
 
 export type OrganizationProjectsQueryVariables = Exact<{
-  data: GetProjectsInput;
-}>;
+  data: GetProjectsInput
+}>
 
-
-export type OrganizationProjectsQuery = { projects: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, organizationId: string, isPublic: boolean, rootBranch: { name: string, touched: boolean } } }> } };
+export type OrganizationProjectsQuery = {
+  projects: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+    edges: Array<{
+      cursor: string
+      node: {
+        id: string
+        name: string
+        organizationId: string
+        isPublic: boolean
+        rootBranch: { name: string; touched: boolean }
+      }
+    }>
+  }
+}
 
 export type GetProjectQueryVariables = Exact<{
-  data: GetProjectInput;
-}>;
+  data: GetProjectInput
+}>
 
+export type GetProjectQuery = {
+  project: {
+    id: string
+    organizationId: string
+    createdAt: string
+    name: string
+    isPublic: boolean
+    userProject?: {
+      id: string
+      role: {
+        id: string
+        name: string
+        permissions: Array<{
+          id: string
+          action: string
+          subject: string
+          condition?: { [key: string]: any } | string | number | boolean | null | null
+        }>
+      }
+    } | null
+    organization: {
+      id: string
+      userOrganization?: {
+        id: string
+        role: {
+          id: string
+          name: string
+          permissions: Array<{
+            id: string
+            action: string
+            subject: string
+            condition?: { [key: string]: any } | string | number | boolean | null | null
+          }>
+        }
+      } | null
+    }
+  }
+}
 
-export type GetProjectQuery = { project: { id: string, organizationId: string, createdAt: string, name: string, isPublic: boolean, userProject?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null, organization: { id: string, userOrganization?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } } };
+export type BranchFragmentFragment = {
+  id: string
+  createdAt: string
+  name: string
+  touched: boolean
+  projectId: string
+  head: { id: string }
+  draft: { id: string }
+}
 
-export type BranchFragmentFragment = { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } };
-
-export type ProjectLoaderFragmentFragment = { id: string, organizationId: string, createdAt: string, name: string, isPublic: boolean, rootBranch: { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } }, userProject?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null, organization: { id: string, userOrganization?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } };
+export type ProjectLoaderFragmentFragment = {
+  id: string
+  organizationId: string
+  createdAt: string
+  name: string
+  isPublic: boolean
+  rootBranch: {
+    id: string
+    createdAt: string
+    name: string
+    touched: boolean
+    projectId: string
+    head: { id: string }
+    draft: { id: string }
+  }
+  userProject?: {
+    id: string
+    role: {
+      id: string
+      name: string
+      permissions: Array<{
+        id: string
+        action: string
+        subject: string
+        condition?: { [key: string]: any } | string | number | boolean | null | null
+      }>
+    }
+  } | null
+  organization: {
+    id: string
+    userOrganization?: {
+      id: string
+      role: {
+        id: string
+        name: string
+        permissions: Array<{
+          id: string
+          action: string
+          subject: string
+          condition?: { [key: string]: any } | string | number | boolean | null | null
+        }>
+      }
+    } | null
+  }
+}
 
 export type GetProjectForLoaderQueryVariables = Exact<{
-  data: GetProjectInput;
-}>;
+  data: GetProjectInput
+}>
 
-
-export type GetProjectForLoaderQuery = { project: { id: string, organizationId: string, createdAt: string, name: string, isPublic: boolean, rootBranch: { id: string, createdAt: string, name: string, touched: boolean, projectId: string, head: { id: string }, draft: { id: string } }, userProject?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null, organization: { id: string, userOrganization?: { id: string, role: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } } };
+export type GetProjectForLoaderQuery = {
+  project: {
+    id: string
+    organizationId: string
+    createdAt: string
+    name: string
+    isPublic: boolean
+    rootBranch: {
+      id: string
+      createdAt: string
+      name: string
+      touched: boolean
+      projectId: string
+      head: { id: string }
+      draft: { id: string }
+    }
+    userProject?: {
+      id: string
+      role: {
+        id: string
+        name: string
+        permissions: Array<{
+          id: string
+          action: string
+          subject: string
+          condition?: { [key: string]: any } | string | number | boolean | null | null
+        }>
+      }
+    } | null
+    organization: {
+      id: string
+      userOrganization?: {
+        id: string
+        role: {
+          id: string
+          name: string
+          permissions: Array<{
+            id: string
+            action: string
+            subject: string
+            condition?: { [key: string]: any } | string | number | boolean | null | null
+          }>
+        }
+      } | null
+    }
+  }
+}
 
 export type GetRevisionForLoaderQueryVariables = Exact<{
-  data: GetRevisionInput;
-}>;
+  data: GetRevisionInput
+}>
 
+export type GetRevisionForLoaderQuery = { revision: { id: string } }
 
-export type GetRevisionForLoaderQuery = { revision: { id: string } };
-
-export type RowLoaderFragmentFragment = { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null };
+export type RowLoaderFragmentFragment = {
+  createdId: string
+  id: string
+  versionId: string
+  createdAt: string
+  updatedAt: string
+  readonly: boolean
+  data: { [key: string]: any } | string | number | boolean | null
+}
 
 export type GetRowForLoaderQueryVariables = Exact<{
-  data: GetRowInput;
-}>;
+  data: GetRowInput
+}>
 
-
-export type GetRowForLoaderQuery = { row?: { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } | null };
+export type GetRowForLoaderQuery = {
+  row?: {
+    createdId: string
+    id: string
+    versionId: string
+    createdAt: string
+    updatedAt: string
+    readonly: boolean
+    data: { [key: string]: any } | string | number | boolean | null
+  } | null
+}
 
 export type GetRowCountForeignKeysToForLoaderQueryVariables = Exact<{
-  data: GetRowInput;
-}>;
+  data: GetRowInput
+}>
 
-
-export type GetRowCountForeignKeysToForLoaderQuery = { row?: { id: string, countForeignKeysTo: number } | null };
+export type GetRowCountForeignKeysToForLoaderQuery = { row?: { id: string; countForeignKeysTo: number } | null }
 
 export type ForeignKeysByQueryVariables = Exact<{
-  tableData: GetTableInput;
-  foreignKeyTablesData: GetTableForeignKeysInput;
-}>;
+  tableData: GetTableInput
+  foreignKeyTablesData: GetTableForeignKeysInput
+}>
 
-
-export type ForeignKeysByQuery = { table?: { id: string, foreignKeysBy: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string } }> } } | null };
+export type ForeignKeysByQuery = {
+  table?: {
+    id: string
+    foreignKeysBy: {
+      totalCount: number
+      pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+      edges: Array<{ node: { id: string } }>
+    }
+  } | null
+}
 
 export type ForeignKeysByRowsQueryVariables = Exact<{
-  rowData: GetRowInput;
-  foreignKeyRowsData: GetRowForeignKeysInput;
-}>;
+  rowData: GetRowInput
+  foreignKeyRowsData: GetRowForeignKeysInput
+}>
 
+export type ForeignKeysByRowsQuery = {
+  row?: {
+    id: string
+    rowForeignKeysBy: {
+      totalCount: number
+      pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+      edges: Array<{
+        node: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
+      }>
+    }
+  } | null
+}
 
-export type ForeignKeysByRowsQuery = { row?: { id: string, rowForeignKeysBy: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } }> } } | null };
-
-export type TableLoaderFragmentFragment = { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
+export type TableLoaderFragmentFragment = {
+  createdId: string
+  id: string
+  versionId: string
+  createdAt: string
+  updatedAt: string
+  readonly: boolean
+  count: number
+  schema: { [key: string]: any } | string | number | boolean | null
+}
 
 export type GetTableForLoaderQueryVariables = Exact<{
-  data: GetTableInput;
-}>;
+  data: GetTableInput
+}>
 
-
-export type GetTableForLoaderQuery = { table?: { createdId: string, id: string, versionId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } | null };
+export type GetTableForLoaderQuery = {
+  table?: {
+    createdId: string
+    id: string
+    versionId: string
+    createdAt: string
+    updatedAt: string
+    readonly: boolean
+    count: number
+    schema: { [key: string]: any } | string | number | boolean | null
+  } | null
+}
 
 export type UpdatePasswordMutationVariables = Exact<{
-  data: UpdatePasswordInput;
-}>;
+  data: UpdatePasswordInput
+}>
 
+export type UpdatePasswordMutation = { updatePassword: boolean }
 
-export type UpdatePasswordMutation = { updatePassword: boolean };
+export type ApiKeyFieldsFragment = {
+  id: string
+  prefix: string
+  type: ApiKeyType
+  name: string
+  organizationId?: string | null
+  projectIds: Array<string>
+  branchNames: Array<string>
+  tableIds: Array<string>
+  readOnly: boolean
+  permissions?: { [key: string]: any } | string | number | boolean | null | null
+  allowedIps: Array<string>
+  expiresAt?: string | null
+  lastUsedAt?: string | null
+  createdAt: string
+  revokedAt?: string | null
+  projects: Array<{ id: string; name: string }>
+}
 
-export type ApiKeyFieldsFragment = { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> };
+export type MyApiKeysQueryVariables = Exact<{ [key: string]: never }>
 
-export type MyApiKeysQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type MyApiKeysQuery = { myApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> }> };
+export type MyApiKeysQuery = {
+  myApiKeys: Array<{
+    id: string
+    prefix: string
+    type: ApiKeyType
+    name: string
+    organizationId?: string | null
+    projectIds: Array<string>
+    branchNames: Array<string>
+    tableIds: Array<string>
+    readOnly: boolean
+    permissions?: { [key: string]: any } | string | number | boolean | null | null
+    allowedIps: Array<string>
+    expiresAt?: string | null
+    lastUsedAt?: string | null
+    createdAt: string
+    revokedAt?: string | null
+    projects: Array<{ id: string; name: string }>
+  }>
+}
 
 export type ServiceApiKeysQueryVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-}>;
+  organizationId: Scalars['String']['input']
+}>
 
-
-export type ServiceApiKeysQuery = { serviceApiKeys: Array<{ id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> }> };
+export type ServiceApiKeysQuery = {
+  serviceApiKeys: Array<{
+    id: string
+    prefix: string
+    type: ApiKeyType
+    name: string
+    organizationId?: string | null
+    projectIds: Array<string>
+    branchNames: Array<string>
+    tableIds: Array<string>
+    readOnly: boolean
+    permissions?: { [key: string]: any } | string | number | boolean | null | null
+    allowedIps: Array<string>
+    expiresAt?: string | null
+    lastUsedAt?: string | null
+    createdAt: string
+    revokedAt?: string | null
+    projects: Array<{ id: string; name: string }>
+  }>
+}
 
 export type ApiKeyByIdQueryVariables = Exact<{
-  id: Scalars['ID']['input'];
-}>;
+  id: Scalars['ID']['input']
+}>
 
-
-export type ApiKeyByIdQuery = { apiKeyById: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } };
+export type ApiKeyByIdQuery = {
+  apiKeyById: {
+    id: string
+    prefix: string
+    type: ApiKeyType
+    name: string
+    organizationId?: string | null
+    projectIds: Array<string>
+    branchNames: Array<string>
+    tableIds: Array<string>
+    readOnly: boolean
+    permissions?: { [key: string]: any } | string | number | boolean | null | null
+    allowedIps: Array<string>
+    expiresAt?: string | null
+    lastUsedAt?: string | null
+    createdAt: string
+    revokedAt?: string | null
+    projects: Array<{ id: string; name: string }>
+  }
+}
 
 export type CreatePersonalApiKeyMutationVariables = Exact<{
-  data: CreatePersonalApiKeyInput;
-}>;
+  data: CreatePersonalApiKeyInput
+}>
 
-
-export type CreatePersonalApiKeyMutation = { createPersonalApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } } };
+export type CreatePersonalApiKeyMutation = {
+  createPersonalApiKey: {
+    secret: string
+    apiKey: {
+      id: string
+      prefix: string
+      type: ApiKeyType
+      name: string
+      organizationId?: string | null
+      projectIds: Array<string>
+      branchNames: Array<string>
+      tableIds: Array<string>
+      readOnly: boolean
+      permissions?: { [key: string]: any } | string | number | boolean | null | null
+      allowedIps: Array<string>
+      expiresAt?: string | null
+      lastUsedAt?: string | null
+      createdAt: string
+      revokedAt?: string | null
+      projects: Array<{ id: string; name: string }>
+    }
+  }
+}
 
 export type CreateServiceApiKeyMutationVariables = Exact<{
-  data: CreateServiceApiKeyInput;
-}>;
+  data: CreateServiceApiKeyInput
+}>
 
-
-export type CreateServiceApiKeyMutation = { createServiceApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } } };
+export type CreateServiceApiKeyMutation = {
+  createServiceApiKey: {
+    secret: string
+    apiKey: {
+      id: string
+      prefix: string
+      type: ApiKeyType
+      name: string
+      organizationId?: string | null
+      projectIds: Array<string>
+      branchNames: Array<string>
+      tableIds: Array<string>
+      readOnly: boolean
+      permissions?: { [key: string]: any } | string | number | boolean | null | null
+      allowedIps: Array<string>
+      expiresAt?: string | null
+      lastUsedAt?: string | null
+      createdAt: string
+      revokedAt?: string | null
+      projects: Array<{ id: string; name: string }>
+    }
+  }
+}
 
 export type RevokeApiKeyMutationVariables = Exact<{
-  id: Scalars['ID']['input'];
-}>;
+  id: Scalars['ID']['input']
+}>
 
-
-export type RevokeApiKeyMutation = { revokeApiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } };
+export type RevokeApiKeyMutation = {
+  revokeApiKey: {
+    id: string
+    prefix: string
+    type: ApiKeyType
+    name: string
+    organizationId?: string | null
+    projectIds: Array<string>
+    branchNames: Array<string>
+    tableIds: Array<string>
+    readOnly: boolean
+    permissions?: { [key: string]: any } | string | number | boolean | null | null
+    allowedIps: Array<string>
+    expiresAt?: string | null
+    lastUsedAt?: string | null
+    createdAt: string
+    revokedAt?: string | null
+    projects: Array<{ id: string; name: string }>
+  }
+}
 
 export type RotateApiKeyMutationVariables = Exact<{
-  id: Scalars['ID']['input'];
-}>;
+  id: Scalars['ID']['input']
+}>
 
-
-export type RotateApiKeyMutation = { rotateApiKey: { secret: string, apiKey: { id: string, prefix: string, type: ApiKeyType, name: string, organizationId?: string | null, projectIds: Array<string>, branchNames: Array<string>, tableIds: Array<string>, readOnly: boolean, permissions?: { [key: string]: any } | string | number | boolean | null | null, allowedIps: Array<string>, expiresAt?: string | null, lastUsedAt?: string | null, createdAt: string, revokedAt?: string | null, projects: Array<{ id: string, name: string }> } } };
+export type RotateApiKeyMutation = {
+  rotateApiKey: {
+    secret: string
+    apiKey: {
+      id: string
+      prefix: string
+      type: ApiKeyType
+      name: string
+      organizationId?: string | null
+      projectIds: Array<string>
+      branchNames: Array<string>
+      tableIds: Array<string>
+      readOnly: boolean
+      permissions?: { [key: string]: any } | string | number | boolean | null | null
+      allowedIps: Array<string>
+      expiresAt?: string | null
+      lastUsedAt?: string | null
+      createdAt: string
+      revokedAt?: string | null
+      projects: Array<{ id: string; name: string }>
+    }
+  }
+}
 
 export type CreateProjectMutationVariables = Exact<{
-  data: CreateProjectInput;
-}>;
+  data: CreateProjectInput
+}>
 
-
-export type CreateProjectMutation = { createProject: { id: string, name: string, organizationId: string } };
+export type CreateProjectMutation = { createProject: { id: string; name: string; organizationId: string } }
 
 export type FindForeignKeyQueryVariables = Exact<{
-  data: GetRowsInput;
-}>;
+  data: GetRowsInput
+}>
 
+export type FindForeignKeyQuery = {
+  rows: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+    edges: Array<{ cursor: string; node: { id: string } }>
+  }
+}
 
-export type FindForeignKeyQuery = { rows: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string } }> } };
+export type AdminCacheStatsQueryVariables = Exact<{ [key: string]: never }>
+
+export type AdminCacheStatsQuery = {
+  adminCacheStats: {
+    totalHits: number
+    totalMisses: number
+    totalWrites: number
+    totalDeletes: number
+    totalClears: number
+    overallHitRate: number
+    byCategory: Array<{ key: string; hits: number; misses: number; writes: number; deletes: number; hitRate: number }>
+  }
+}
+
+export type AdminResetAllCacheMutationVariables = Exact<{ [key: string]: never }>
+
+export type AdminResetAllCacheMutation = { adminResetAllCache: boolean }
 
 export type AdminDashboardStatsQueryVariables = Exact<{
-  first: Scalars['Int']['input'];
-}>;
+  first: Scalars['Int']['input']
+}>
 
+export type AdminDashboardStatsQuery = { searchUsers: { totalCount: number } }
 
-export type AdminDashboardStatsQuery = { searchUsers: { totalCount: number } };
-
-export type AdminUserDetailFragment = { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } };
+export type AdminUserDetailFragment = {
+  id: string
+  email?: string | null
+  username?: string | null
+  role: { id: string; name: string }
+}
 
 export type AdminGetUserQueryVariables = Exact<{
-  userId: Scalars['String']['input'];
-}>;
+  userId: Scalars['String']['input']
+}>
 
-
-export type AdminGetUserQuery = { adminUser?: { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } } | null };
+export type AdminGetUserQuery = {
+  adminUser?: { id: string; email?: string | null; username?: string | null; role: { id: string; name: string } } | null
+}
 
 export type AdminResetPasswordMutationVariables = Exact<{
-  userId: Scalars['String']['input'];
-  newPassword: Scalars['String']['input'];
-}>;
+  userId: Scalars['String']['input']
+  newPassword: Scalars['String']['input']
+}>
 
+export type AdminResetPasswordMutation = { resetPassword: boolean }
 
-export type AdminResetPasswordMutation = { resetPassword: boolean };
-
-export type AdminUserItemFragment = { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } };
+export type AdminUserItemFragment = {
+  id: string
+  email?: string | null
+  username?: string | null
+  role: { id: string; name: string }
+}
 
 export type AdminUsersQueryVariables = Exact<{
-  search?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-}>;
+  search?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+}>
 
-
-export type AdminUsersQuery = { adminUsers: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } } }>, pageInfo: { hasNextPage: boolean, endCursor?: string | null } } };
+export type AdminUsersQuery = {
+  adminUsers: {
+    totalCount: number
+    edges: Array<{
+      cursor: string
+      node: { id: string; email?: string | null; username?: string | null; role: { id: string; name: string } }
+    }>
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+  }
+}
 
 export type AdminUserQueryVariables = Exact<{
-  userId: Scalars['String']['input'];
-}>;
+  userId: Scalars['String']['input']
+}>
 
+export type AdminUserQuery = {
+  adminUser?: { id: string; email?: string | null; username?: string | null; role: { id: string; name: string } } | null
+}
 
-export type AdminUserQuery = { adminUser?: { id: string, email?: string | null, username?: string | null, role: { id: string, name: string } } | null };
-
-export type AssetTableItemFragment = { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null };
+export type AssetTableItemFragment = {
+  id: string
+  versionId: string
+  count: number
+  schema: { [key: string]: any } | string | number | boolean | null
+}
 
 export type AssetsTablesDataQueryVariables = Exact<{
-  data: GetTablesInput;
-}>;
+  data: GetTablesInput
+}>
 
+export type AssetsTablesDataQuery = {
+  tables: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+    edges: Array<{
+      node: {
+        id: string
+        versionId: string
+        count: number
+        schema: { [key: string]: any } | string | number | boolean | null
+      }
+    }>
+  }
+}
 
-export type AssetsTablesDataQuery = { tables: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null } }> } };
-
-export type AssetRowItemFragment = { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null };
+export type AssetRowItemFragment = {
+  id: string
+  versionId: string
+  data: { [key: string]: any } | string | number | boolean | null
+}
 
 export type AssetsRowsDataQueryVariables = Exact<{
-  data: GetRowsInput;
-}>;
+  data: GetRowsInput
+}>
 
+export type AssetsRowsDataQuery = {
+  rows: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+    edges: Array<{
+      node: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
+    }>
+  }
+}
 
-export type AssetsRowsDataQuery = { rows: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } }> } };
-
-export type SubSchemaItemFragment = { fieldPath: string, data: { [key: string]: any } | string | number | boolean | null, table: { id: string, versionId: string }, row: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } };
+export type SubSchemaItemFragment = {
+  fieldPath: string
+  data: { [key: string]: any } | string | number | boolean | null
+  table: { id: string; versionId: string }
+  row: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
+}
 
 export type SubSchemaItemsDataQueryVariables = Exact<{
-  data: GetSubSchemaItemsInput;
-}>;
+  data: GetSubSchemaItemsInput
+}>
 
+export type SubSchemaItemsDataQuery = {
+  subSchemaItems: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+    edges: Array<{
+      node: {
+        fieldPath: string
+        data: { [key: string]: any } | string | number | boolean | null
+        table: { id: string; versionId: string }
+        row: { id: string; versionId: string; data: { [key: string]: any } | string | number | boolean | null }
+      }
+    }>
+  }
+}
 
-export type SubSchemaItemsDataQuery = { subSchemaItems: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { fieldPath: string, data: { [key: string]: any } | string | number | boolean | null, table: { id: string, versionId: string }, row: { id: string, versionId: string, data: { [key: string]: any } | string | number | boolean | null } } }> } };
-
-export type BranchItemFragment = { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, start: { id: string, createdAt: string }, parent?: { revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } | null };
+export type BranchItemFragment = {
+  id: string
+  name: string
+  isRoot: boolean
+  touched: boolean
+  createdAt: string
+  start: { id: string; createdAt: string }
+  parent?: {
+    revision: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; branch: { id: string; name: string } }
+  } | null
+}
 
 export type GetProjectBranchesQueryVariables = Exact<{
-  data: GetBranchesInput;
-}>;
+  data: GetBranchesInput
+}>
 
-
-export type GetProjectBranchesQuery = { branches: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, start: { id: string, createdAt: string }, parent?: { revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } | null } }> } };
+export type GetProjectBranchesQuery = {
+  branches: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+    edges: Array<{
+      cursor: string
+      node: {
+        id: string
+        name: string
+        isRoot: boolean
+        touched: boolean
+        createdAt: string
+        start: { id: string; createdAt: string }
+        parent?: {
+          revision: {
+            id: string
+            isDraft: boolean
+            isHead: boolean
+            createdAt: string
+            branch: { id: string; name: string }
+          }
+        } | null
+      }
+    }>
+  }
+}
 
 export type DeleteBranchMutationVariables = Exact<{
-  data: DeleteBranchInput;
-}>;
+  data: DeleteBranchInput
+}>
 
+export type DeleteBranchMutation = { deleteBranch: boolean }
 
-export type DeleteBranchMutation = { deleteBranch: boolean };
-
-export type RevisionForSelectFragment = { id: string, isDraft: boolean, isHead: boolean, createdAt: string, comment: string };
+export type RevisionForSelectFragment = {
+  id: string
+  isDraft: boolean
+  isHead: boolean
+  createdAt: string
+  comment: string
+}
 
 export type GetBranchesForSelectQueryVariables = Exact<{
-  data: GetBranchesInput;
-}>;
+  data: GetBranchesInput
+}>
 
-
-export type GetBranchesForSelectQuery = { branches: { edges: Array<{ node: { id: string, name: string, isRoot: boolean } }> } };
+export type GetBranchesForSelectQuery = {
+  branches: { edges: Array<{ node: { id: string; name: string; isRoot: boolean } }> }
+}
 
 export type GetBranchRevisionsForCreateQueryVariables = Exact<{
-  data: GetBranchInput;
-  revisionsData: GetBranchRevisionsInput;
-}>;
+  data: GetBranchInput
+  revisionsData: GetBranchRevisionsInput
+}>
 
-
-export type GetBranchRevisionsForCreateQuery = { branch: { id: string, revisions: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, comment: string } }> } } };
+export type GetBranchRevisionsForCreateQuery = {
+  branch: {
+    id: string
+    revisions: {
+      totalCount: number
+      pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+      edges: Array<{ node: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; comment: string } }>
+    }
+  }
+}
 
 export type CreateBranchMutationVariables = Exact<{
-  data: CreateBranchInput;
-}>;
+  data: CreateBranchInput
+}>
 
-
-export type CreateBranchMutation = { createBranch: { id: string, name: string } };
+export type CreateBranchMutation = { createBranch: { id: string; name: string } }
 
 export type GetRevisionChangesQueryVariables = Exact<{
-  revisionId: Scalars['String']['input'];
-  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>;
-  includeSystem?: InputMaybe<Scalars['Boolean']['input']>;
-}>;
+  revisionId: Scalars['String']['input']
+  compareWithRevisionId?: InputMaybe<Scalars['String']['input']>
+  includeSystem?: InputMaybe<Scalars['Boolean']['input']>
+}>
 
-
-export type GetRevisionChangesQuery = { revisionChanges: { revisionId: string, parentRevisionId?: string | null, totalChanges: number, tablesSummary: { added: number, modified: number, removed: number, renamed: number, total: number }, rowsSummary: { added: number, modified: number, removed: number, renamed: number, total: number } } };
+export type GetRevisionChangesQuery = {
+  revisionChanges: {
+    revisionId: string
+    parentRevisionId?: string | null
+    totalChanges: number
+    tablesSummary: { added: number; modified: number; removed: number; renamed: number; total: number }
+    rowsSummary: { added: number; modified: number; removed: number; renamed: number; total: number }
+  }
+}
 
 export type GetTableChangesQueryVariables = Exact<{
-  revisionId: Scalars['String']['input'];
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<TableChangesFiltersInput>;
-}>;
+  revisionId: Scalars['String']['input']
+  first: Scalars['Int']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<TableChangesFiltersInput>
+}>
 
-
-export type GetTableChangesQuery = { tableChanges: { totalCount: number, edges: Array<{ cursor: string, node: { tableId: string, changeType: ChangeType, oldTableId?: string | null, newTableId?: string | null, rowChangesCount: number, addedRowsCount: number, modifiedRowsCount: number, removedRowsCount: number, renamedRowsCount: number, schemaMigrations: Array<{ migrationType: MigrationType, migrationId: string, oldTableId?: string | null, newTableId?: string | null, patches?: Array<{ op: JsonPatchOp, path: string, value?: { [key: string]: any } | string | number | boolean | null | null, from?: string | null }> | null }>, viewsChanges: { hasChanges: boolean, addedCount: number, modifiedCount: number, removedCount: number, renamedCount: number, changes: Array<{ viewId: string, viewName: string, changeType: ChangeType, oldViewName?: string | null }> } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+export type GetTableChangesQuery = {
+  tableChanges: {
+    totalCount: number
+    edges: Array<{
+      cursor: string
+      node: {
+        tableId: string
+        changeType: ChangeType
+        oldTableId?: string | null
+        newTableId?: string | null
+        rowChangesCount: number
+        addedRowsCount: number
+        modifiedRowsCount: number
+        removedRowsCount: number
+        renamedRowsCount: number
+        schemaMigrations: Array<{
+          migrationType: MigrationType
+          migrationId: string
+          oldTableId?: string | null
+          newTableId?: string | null
+          patches?: Array<{
+            op: JsonPatchOp
+            path: string
+            value?: { [key: string]: any } | string | number | boolean | null | null
+            from?: string | null
+          }> | null
+        }>
+        viewsChanges: {
+          hasChanges: boolean
+          addedCount: number
+          modifiedCount: number
+          removedCount: number
+          renamedCount: number
+          changes: Array<{ viewId: string; viewName: string; changeType: ChangeType; oldViewName?: string | null }>
+        }
+      }
+    }>
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+  }
+}
 
 export type ConfirmEmailCodeMutationVariables = Exact<{
-  data: ConfirmEmailCodeInput;
-}>;
+  data: ConfirmEmailCodeInput
+}>
 
+export type ConfirmEmailCodeMutation = { confirmEmailCode: { accessToken: string } }
 
-export type ConfirmEmailCodeMutation = { confirmEmailCode: { accessToken: string } };
+export type EndpointFragment = {
+  id: string
+  type: EndpointType
+  createdAt: string
+  revisionId: string
+  revision: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; branch: { id: string; name: string } }
+}
 
-export type EndpointFragment = { id: string, type: EndpointType, createdAt: string, revisionId: string, revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } };
+export type RevisionWithEndpointsFragment = {
+  id: string
+  comment: string
+  isDraft: boolean
+  isHead: boolean
+  isStart: boolean
+  createdAt: string
+  endpoints: Array<{ id: string; type: EndpointType }>
+}
 
-export type RevisionWithEndpointsFragment = { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, endpoints: Array<{ id: string, type: EndpointType }> };
-
-export type EndpointBranchFragment = { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } };
+export type EndpointBranchFragment = {
+  id: string
+  name: string
+  isRoot: boolean
+  head: { id: string }
+  draft: { id: string }
+}
 
 export type GetEndpointBranchesQueryVariables = Exact<{
-  data: GetBranchesInput;
-}>;
+  data: GetBranchesInput
+}>
 
-
-export type GetEndpointBranchesQuery = { branches: { totalCount: number, edges: Array<{ node: { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } } }> } };
+export type GetEndpointBranchesQuery = {
+  branches: {
+    totalCount: number
+    edges: Array<{ node: { id: string; name: string; isRoot: boolean; head: { id: string }; draft: { id: string } } }>
+  }
+}
 
 export type GetProjectEndpointsQueryVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-  branchId?: InputMaybe<Scalars['String']['input']>;
-  type?: InputMaybe<EndpointType>;
-}>;
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  first: Scalars['Int']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+  branchId?: InputMaybe<Scalars['String']['input']>
+  type?: InputMaybe<EndpointType>
+}>
 
-
-export type GetProjectEndpointsQuery = { projectEndpoints: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, type: EndpointType, createdAt: string, revisionId: string, revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+export type GetProjectEndpointsQuery = {
+  projectEndpoints: {
+    totalCount: number
+    edges: Array<{
+      cursor: string
+      node: {
+        id: string
+        type: EndpointType
+        createdAt: string
+        revisionId: string
+        revision: {
+          id: string
+          isDraft: boolean
+          isHead: boolean
+          createdAt: string
+          branch: { id: string; name: string }
+        }
+      }
+    }>
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+  }
+}
 
 export type GetBranchRevisionsQueryVariables = Exact<{
-  data: GetBranchInput;
-  revisionsData: GetBranchRevisionsInput;
-}>;
+  data: GetBranchInput
+  revisionsData: GetBranchRevisionsInput
+}>
 
-
-export type GetBranchRevisionsQuery = { branch: { revisions: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, endpoints: Array<{ id: string, type: EndpointType }> } }> } } };
+export type GetBranchRevisionsQuery = {
+  branch: {
+    revisions: {
+      totalCount: number
+      pageInfo: {
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+        startCursor?: string | null
+        endCursor?: string | null
+      }
+      edges: Array<{
+        cursor: string
+        node: {
+          id: string
+          comment: string
+          isDraft: boolean
+          isHead: boolean
+          isStart: boolean
+          createdAt: string
+          endpoints: Array<{ id: string; type: EndpointType }>
+        }
+      }>
+    }
+  }
+}
 
 export type CreateEndpointMutationVariables = Exact<{
-  data: CreateEndpointInput;
-}>;
+  data: CreateEndpointInput
+}>
 
-
-export type CreateEndpointMutation = { createEndpoint: { id: string, type: EndpointType, createdAt: string, revisionId: string, revision: { id: string, isDraft: boolean, isHead: boolean, createdAt: string, branch: { id: string, name: string } } } };
+export type CreateEndpointMutation = {
+  createEndpoint: {
+    id: string
+    type: EndpointType
+    createdAt: string
+    revisionId: string
+    revision: { id: string; isDraft: boolean; isHead: boolean; createdAt: string; branch: { id: string; name: string } }
+  }
+}
 
 export type DeleteEndpointMutationVariables = Exact<{
-  data: DeleteEndpointInput;
-}>;
+  data: DeleteEndpointInput
+}>
 
-
-export type DeleteEndpointMutation = { deleteEndpoint: boolean };
+export type DeleteEndpointMutation = { deleteEndpoint: boolean }
 
 export type LoginGithubMutationVariables = Exact<{
-  data: LoginGithubInput;
-}>;
+  data: LoginGithubInput
+}>
 
-
-export type LoginGithubMutation = { loginGithub: { accessToken: string } };
+export type LoginGithubMutation = { loginGithub: { accessToken: string } }
 
 export type LoginGoogleMutationVariables = Exact<{
-  data: LoginGoogleInput;
-}>;
+  data: LoginGoogleInput
+}>
 
-
-export type LoginGoogleMutation = { loginGoogle: { accessToken: string } };
+export type LoginGoogleMutation = { loginGoogle: { accessToken: string } }
 
 export type LoginMutationVariables = Exact<{
-  data: LoginInput;
-}>;
+  data: LoginInput
+}>
 
+export type LoginMutation = { login: { accessToken: string } }
 
-export type LoginMutation = { login: { accessToken: string } };
-
-export type MigrationBranchFragment = { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } };
+export type MigrationBranchFragment = {
+  id: string
+  name: string
+  isRoot: boolean
+  head: { id: string }
+  draft: { id: string }
+}
 
 export type GetMigrationBranchesQueryVariables = Exact<{
-  data: GetBranchesInput;
-}>;
+  data: GetBranchesInput
+}>
 
-
-export type GetMigrationBranchesQuery = { branches: { totalCount: number, edges: Array<{ node: { id: string, name: string, isRoot: boolean, head: { id: string }, draft: { id: string } } }> } };
+export type GetMigrationBranchesQuery = {
+  branches: {
+    totalCount: number
+    edges: Array<{ node: { id: string; name: string; isRoot: boolean; head: { id: string }; draft: { id: string } } }>
+  }
+}
 
 export type GetBranchMigrationsQueryVariables = Exact<{
-  data: GetRevisionInput;
-}>;
+  data: GetRevisionInput
+}>
 
-
-export type GetBranchMigrationsQuery = { revision: { id: string, migrations: Array<{ [key: string]: any } | string | number | boolean | null> } };
+export type GetBranchMigrationsQuery = {
+  revision: { id: string; migrations: Array<{ [key: string]: any } | string | number | boolean | null> }
+}
 
 export type ApplyMigrationsMutationVariables = Exact<{
-  data: ApplyMigrationsInput;
-}>;
+  data: ApplyMigrationsInput
+}>
 
-
-export type ApplyMigrationsMutation = { applyMigrations: Array<{ id: string, status: ApplyMigrationStatus, error?: string | null }> };
+export type ApplyMigrationsMutation = {
+  applyMigrations: Array<{ id: string; status: ApplyMigrationStatus; error?: string | null }>
+}
 
 export type GetMigrationsQueryVariables = Exact<{
-  data: GetRevisionInput;
-}>;
+  data: GetRevisionInput
+}>
 
-
-export type GetMigrationsQuery = { revision: { id: string, migrations: Array<{ [key: string]: any } | string | number | boolean | null> } };
+export type GetMigrationsQuery = {
+  revision: { id: string; migrations: Array<{ [key: string]: any } | string | number | boolean | null> }
+}
 
 export type ActivateEarlyAccessMutationVariables = Exact<{
-  data: ActivateEarlyAccessInput;
-}>;
+  data: ActivateEarlyAccessInput
+}>
 
-
-export type ActivateEarlyAccessMutation = { activateEarlyAccess: { planId: string, status: BillingStatus, provider?: string | null, interval?: string | null, currentPeriodStart?: string | null, currentPeriodEnd?: string | null, cancelAt?: string | null } };
+export type ActivateEarlyAccessMutation = {
+  activateEarlyAccess: {
+    planId: string
+    status: BillingStatus
+    provider?: string | null
+    interval?: string | null
+    currentPeriodStart?: string | null
+    currentPeriodEnd?: string | null
+    cancelAt?: string | null
+  }
+}
 
 export type CreateCheckoutMutationVariables = Exact<{
-  data: CreateCheckoutInput;
-}>;
+  data: CreateCheckoutInput
+}>
 
-
-export type CreateCheckoutMutation = { createCheckout: { checkoutUrl: string } };
+export type CreateCheckoutMutation = { createCheckout: { checkoutUrl: string } }
 
 export type CancelSubscriptionMutationVariables = Exact<{
-  data: CancelSubscriptionInput;
-}>;
+  data: CancelSubscriptionInput
+}>
 
+export type CancelSubscriptionMutation = { cancelSubscription: boolean }
 
-export type CancelSubscriptionMutation = { cancelSubscription: boolean };
+export type UsageMetricFragment = { current: number; limit?: number | null; percentage?: number | null }
 
-export type UsageMetricFragment = { current: number, limit?: number | null, percentage?: number | null };
+export type LimitsPageSubscriptionFragment = {
+  planId: string
+  status: BillingStatus
+  provider?: string | null
+  interval?: string | null
+  currentPeriodStart?: string | null
+  currentPeriodEnd?: string | null
+  cancelAt?: string | null
+}
 
-export type LimitsPageSubscriptionFragment = { planId: string, status: BillingStatus, provider?: string | null, interval?: string | null, currentPeriodStart?: string | null, currentPeriodEnd?: string | null, cancelAt?: string | null };
-
-export type LimitsPagePlanFragment = { id: string, name: string, isPublic: boolean, monthlyPriceUsd: number, yearlyPriceUsd: number, features: { [key: string]: any } | string | number | boolean | null, limits: { rowVersions?: number | null, projects?: number | null, seats?: number | null, storageBytes?: number | null } };
+export type LimitsPagePlanFragment = {
+  id: string
+  name: string
+  isPublic: boolean
+  monthlyPriceUsd: number
+  yearlyPriceUsd: number
+  features: { [key: string]: any } | string | number | boolean | null
+  limits: { rowVersions?: number | null; projects?: number | null; seats?: number | null; storageBytes?: number | null }
+}
 
 export type GetLimitsPageDataQueryVariables = Exact<{
-  data: GetOrganizationInput;
-}>;
+  data: GetOrganizationInput
+}>
 
+export type GetLimitsPageDataQuery = {
+  configuration: { billing: { enabled: boolean } }
+  organization: {
+    id: string
+    subscription?: {
+      planId: string
+      status: BillingStatus
+      provider?: string | null
+      interval?: string | null
+      currentPeriodStart?: string | null
+      currentPeriodEnd?: string | null
+      cancelAt?: string | null
+    } | null
+    usage?: {
+      rowVersions: { current: number; limit?: number | null; percentage?: number | null }
+      projects: { current: number; limit?: number | null; percentage?: number | null }
+      seats: { current: number; limit?: number | null; percentage?: number | null }
+      storageBytes: { current: number; limit?: number | null; percentage?: number | null }
+    } | null
+  }
+}
 
-export type GetLimitsPageDataQuery = { configuration: { billing: { enabled: boolean } }, organization: { id: string, subscription?: { planId: string, status: BillingStatus, provider?: string | null, interval?: string | null, currentPeriodStart?: string | null, currentPeriodEnd?: string | null, cancelAt?: string | null } | null, usage?: { rowVersions: { current: number, limit?: number | null, percentage?: number | null }, projects: { current: number, limit?: number | null, percentage?: number | null }, seats: { current: number, limit?: number | null, percentage?: number | null }, storageBytes: { current: number, limit?: number | null, percentage?: number | null } } | null } };
+export type GetLimitsPagePlansQueryVariables = Exact<{ [key: string]: never }>
 
-export type GetLimitsPagePlansQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetLimitsPagePlansQuery = {
+  plans: Array<{
+    id: string
+    name: string
+    isPublic: boolean
+    monthlyPriceUsd: number
+    yearlyPriceUsd: number
+    features: { [key: string]: any } | string | number | boolean | null
+    limits: {
+      rowVersions?: number | null
+      projects?: number | null
+      seats?: number | null
+      storageBytes?: number | null
+    }
+  }>
+}
 
-
-export type GetLimitsPagePlansQuery = { plans: Array<{ id: string, name: string, isPublic: boolean, monthlyPriceUsd: number, yearlyPriceUsd: number, features: { [key: string]: any } | string | number | boolean | null, limits: { rowVersions?: number | null, projects?: number | null, seats?: number | null, storageBytes?: number | null } }> };
-
-export type UserOrganizationItemFragment = { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } };
+export type UserOrganizationItemFragment = {
+  id: string
+  user: { id: string; email?: string | null; username?: string | null }
+  role: { id: string; name: string }
+}
 
 export type GetUsersOrganizationQueryVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-}>;
+  organizationId: Scalars['String']['input']
+  first: Scalars['Int']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+}>
 
-
-export type GetUsersOrganizationQuery = { usersOrganization: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+export type GetUsersOrganizationQuery = {
+  usersOrganization: {
+    totalCount: number
+    edges: Array<{
+      cursor: string
+      node: {
+        id: string
+        user: { id: string; email?: string | null; username?: string | null }
+        role: { id: string; name: string }
+      }
+    }>
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+  }
+}
 
 export type AddUserToOrganizationMutationVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-  roleId: UserOrganizationRoles;
-}>;
+  organizationId: Scalars['String']['input']
+  userId: Scalars['String']['input']
+  roleId: UserOrganizationRoles
+}>
 
-
-export type AddUserToOrganizationMutation = { addUserToOrganization: boolean };
+export type AddUserToOrganizationMutation = { addUserToOrganization: boolean }
 
 export type RemoveUserFromOrganizationMutationVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-}>;
+  organizationId: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}>
 
-
-export type RemoveUserFromOrganizationMutation = { removeUserFromOrganization: boolean };
+export type RemoveUserFromOrganizationMutation = { removeUserFromOrganization: boolean }
 
 export type UpdateProjectMutationVariables = Exact<{
-  data: UpdateProjectInput;
-}>;
+  data: UpdateProjectInput
+}>
 
-
-export type UpdateProjectMutation = { updateProject: boolean };
+export type UpdateProjectMutation = { updateProject: boolean }
 
 export type DeleteProjectForSettingsMutationVariables = Exact<{
-  data: DeleteProjectInput;
-}>;
+  data: DeleteProjectInput
+}>
 
-
-export type DeleteProjectForSettingsMutation = { deleteProject: boolean };
+export type DeleteProjectForSettingsMutation = { deleteProject: boolean }
 
 export type FetchTableForStackQueryVariables = Exact<{
-  data: GetTableInput;
-}>;
+  data: GetTableInput
+}>
 
+export type FetchTableForStackQuery = {
+  table?: {
+    id: string
+    versionId: string
+    readonly: boolean
+    count: number
+    schema: { [key: string]: any } | string | number | boolean | null
+  } | null
+}
 
-export type FetchTableForStackQuery = { table?: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } | null };
-
-export type TableStackFragmentFragment = { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
+export type TableStackFragmentFragment = {
+  id: string
+  versionId: string
+  readonly: boolean
+  count: number
+  schema: { [key: string]: any } | string | number | boolean | null
+}
 
 export type CreateTableForStackMutationVariables = Exact<{
-  data: CreateTableInput;
-}>;
+  data: CreateTableInput
+}>
 
-
-export type CreateTableForStackMutation = { createTable: { table: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } } };
+export type CreateTableForStackMutation = {
+  createTable: {
+    table: {
+      id: string
+      versionId: string
+      readonly: boolean
+      count: number
+      schema: { [key: string]: any } | string | number | boolean | null
+    }
+  }
+}
 
 export type UpdateTableForStackMutationVariables = Exact<{
-  data: UpdateTableInput;
-}>;
+  data: UpdateTableInput
+}>
 
-
-export type UpdateTableForStackMutation = { updateTable: { previousVersionTableId: string, table: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } } };
+export type UpdateTableForStackMutation = {
+  updateTable: {
+    previousVersionTableId: string
+    table: {
+      id: string
+      versionId: string
+      readonly: boolean
+      count: number
+      schema: { [key: string]: any } | string | number | boolean | null
+    }
+  }
+}
 
 export type RenameTableForStackMutationVariables = Exact<{
-  data: RenameTableInput;
-}>;
+  data: RenameTableInput
+}>
 
-
-export type RenameTableForStackMutation = { renameTable: { previousVersionTableId: string, table: { id: string, versionId: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } } };
+export type RenameTableForStackMutation = {
+  renameTable: {
+    previousVersionTableId: string
+    table: {
+      id: string
+      versionId: string
+      readonly: boolean
+      count: number
+      schema: { [key: string]: any } | string | number | boolean | null
+    }
+  }
+}
 
 export type RowPageDataQueryVariables = Exact<{
-  rowData: GetRowInput;
-  tableData: GetTableInput;
-  foreignKeysData: GetRowCountForeignKeysByInput;
-}>;
+  rowData: GetRowInput
+  tableData: GetTableInput
+  foreignKeysData: GetRowCountForeignKeysByInput
+}>
 
-
-export type RowPageDataQuery = { getRowCountForeignKeysTo: number, row?: { id: string, data: { [key: string]: any } | string | number | boolean | null } | null, table?: { id: string, schema: { [key: string]: any } | string | number | boolean | null } | null };
+export type RowPageDataQuery = {
+  getRowCountForeignKeysTo: number
+  row?: { id: string; data: { [key: string]: any } | string | number | boolean | null } | null
+  table?: { id: string; schema: { [key: string]: any } | string | number | boolean | null } | null
+}
 
 export type SignUpMutationVariables = Exact<{
-  data: SignUpInput;
-}>;
+  data: SignUpInput
+}>
 
-
-export type SignUpMutation = { signUp: boolean };
+export type SignUpMutation = { signUp: boolean }
 
 export type SetUsernameMutationVariables = Exact<{
-  data: SetUsernameInput;
-}>;
+  data: SetUsernameInput
+}>
 
+export type SetUsernameMutation = { setUsername: boolean }
 
-export type SetUsernameMutation = { setUsername: boolean };
-
-export type UserProjectItemFragment = { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } };
+export type UserProjectItemFragment = {
+  id: string
+  user: { id: string; email?: string | null; username?: string | null }
+  role: { id: string; name: string }
+}
 
 export type GetUsersProjectQueryVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-}>;
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  first: Scalars['Int']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+}>
 
-
-export type GetUsersProjectQuery = { usersProject: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, user: { id: string, email?: string | null, username?: string | null }, role: { id: string, name: string } } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+export type GetUsersProjectQuery = {
+  usersProject: {
+    totalCount: number
+    edges: Array<{
+      cursor: string
+      node: {
+        id: string
+        user: { id: string; email?: string | null; username?: string | null }
+        role: { id: string; name: string }
+      }
+    }>
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+  }
+}
 
 export type SearchUsersQueryVariables = Exact<{
-  search?: InputMaybe<Scalars['String']['input']>;
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-}>;
+  search?: InputMaybe<Scalars['String']['input']>
+  first: Scalars['Int']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+}>
 
-
-export type SearchUsersQuery = { searchUsers: { totalCount: number, edges: Array<{ cursor: string, node: { id: string, email?: string | null, username?: string | null } }>, pageInfo: { hasNextPage: boolean, endCursor?: string | null } } };
+export type SearchUsersQuery = {
+  searchUsers: {
+    totalCount: number
+    edges: Array<{ cursor: string; node: { id: string; email?: string | null; username?: string | null } }>
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+  }
+}
 
 export type AddUserToProjectMutationVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-  roleId: UserProjectRoles;
-}>;
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  userId: Scalars['String']['input']
+  roleId: UserProjectRoles
+}>
 
-
-export type AddUserToProjectMutation = { addUserToProject: boolean };
+export type AddUserToProjectMutation = { addUserToProject: boolean }
 
 export type RemoveUserFromProjectMutationVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-}>;
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  userId: Scalars['String']['input']
+}>
 
-
-export type RemoveUserFromProjectMutation = { removeUserFromProject: boolean };
+export type RemoveUserFromProjectMutation = { removeUserFromProject: boolean }
 
 export type UpdateUserProjectRoleMutationVariables = Exact<{
-  organizationId: Scalars['String']['input'];
-  projectName: Scalars['String']['input'];
-  userId: Scalars['String']['input'];
-  roleId: UserProjectRoles;
-}>;
+  organizationId: Scalars['String']['input']
+  projectName: Scalars['String']['input']
+  userId: Scalars['String']['input']
+  roleId: UserProjectRoles
+}>
 
-
-export type UpdateUserProjectRoleMutation = { updateUserProjectRole: boolean };
+export type UpdateUserProjectRoleMutation = { updateUserProjectRole: boolean }
 
 export type CreateUserMutationVariables = Exact<{
-  username: Scalars['String']['input'];
-  password: Scalars['String']['input'];
-  email?: InputMaybe<Scalars['String']['input']>;
-  roleId: UserSystemRole;
-}>;
+  username: Scalars['String']['input']
+  password: Scalars['String']['input']
+  email?: InputMaybe<Scalars['String']['input']>
+  roleId: UserSystemRole
+}>
 
+export type CreateUserMutation = { createUser: boolean }
 
-export type CreateUserMutation = { createUser: boolean };
+export type PageInfoFragment = {
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  startCursor?: string | null
+  endCursor?: string | null
+}
 
-export type PageInfoFragment = { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null };
+export type ConfigurationQueryVariables = Exact<{ [key: string]: never }>
 
-export type ConfigurationQueryVariables = Exact<{ [key: string]: never; }>;
+export type ConfigurationQuery = {
+  configuration: {
+    availableEmailSignUp: boolean
+    noAuth: boolean
+    billing: { enabled: boolean }
+    google: { available: boolean; clientId?: string | null }
+    github: { available: boolean; clientId?: string | null }
+    cache: { enabled: boolean }
+    plugins: { file: boolean }
+  }
+}
 
+export type UserFragment = {
+  id: string
+  username?: string | null
+  email?: string | null
+  hasPassword: boolean
+  organizationId?: string | null
+  role?: {
+    id: string
+    name: string
+    permissions: Array<{
+      id: string
+      action: string
+      subject: string
+      condition?: { [key: string]: any } | string | number | boolean | null | null
+    }>
+  } | null
+  organization?: {
+    id: string
+    userOrganization?: {
+      role: {
+        name: string
+        permissions: Array<{
+          id: string
+          action: string
+          subject: string
+          condition?: { [key: string]: any } | string | number | boolean | null | null
+        }>
+      }
+    } | null
+  } | null
+}
 
-export type ConfigurationQuery = { configuration: { availableEmailSignUp: boolean, noAuth: boolean, billing: { enabled: boolean }, google: { available: boolean, clientId?: string | null }, github: { available: boolean, clientId?: string | null }, plugins: { file: boolean } } };
+export type GetMeQueryVariables = Exact<{ [key: string]: never }>
 
-export type UserFragment = { id: string, username?: string | null, email?: string | null, hasPassword: boolean, organizationId?: string | null, role?: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } | null, organization?: { id: string, userOrganization?: { role: { name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } | null };
+export type GetMeQuery = {
+  me: {
+    id: string
+    username?: string | null
+    email?: string | null
+    hasPassword: boolean
+    organizationId?: string | null
+    role?: {
+      id: string
+      name: string
+      permissions: Array<{
+        id: string
+        action: string
+        subject: string
+        condition?: { [key: string]: any } | string | number | boolean | null | null
+      }>
+    } | null
+    organization?: {
+      id: string
+      userOrganization?: {
+        role: {
+          name: string
+          permissions: Array<{
+            id: string
+            action: string
+            subject: string
+            condition?: { [key: string]: any } | string | number | boolean | null | null
+          }>
+        }
+      } | null
+    } | null
+  }
+}
 
-export type GetMeQueryVariables = Exact<{ [key: string]: never; }>;
+export type RevisionMapRevisionBaseFragment = {
+  id: string
+  comment: string
+  isDraft: boolean
+  isHead: boolean
+  isStart: boolean
+  createdAt: string
+  parent?: { id: string } | null
+  endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+  childBranches: Array<{ branch: { id: string; name: string } }>
+}
 
-
-export type GetMeQuery = { me: { id: string, username?: string | null, email?: string | null, hasPassword: boolean, organizationId?: string | null, role?: { id: string, name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } | null, organization?: { id: string, userOrganization?: { role: { name: string, permissions: Array<{ id: string, action: string, subject: string, condition?: { [key: string]: any } | string | number | boolean | null | null }> } } | null } | null } };
-
-export type RevisionMapRevisionBaseFragment = { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> };
-
-export type RevisionMapBranchFullFragment = { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, head: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, draft: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, start: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, parent?: { revision: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, branch: { id: string, name: string } } | null, revisions: { totalCount: number } };
+export type RevisionMapBranchFullFragment = {
+  id: string
+  name: string
+  isRoot: boolean
+  touched: boolean
+  createdAt: string
+  head: {
+    id: string
+    comment: string
+    isDraft: boolean
+    isHead: boolean
+    isStart: boolean
+    createdAt: string
+    parent?: { id: string } | null
+    endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+    childBranches: Array<{ branch: { id: string; name: string } }>
+  }
+  draft: {
+    id: string
+    comment: string
+    isDraft: boolean
+    isHead: boolean
+    isStart: boolean
+    createdAt: string
+    parent?: { id: string } | null
+    endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+    childBranches: Array<{ branch: { id: string; name: string } }>
+  }
+  start: {
+    id: string
+    comment: string
+    isDraft: boolean
+    isHead: boolean
+    isStart: boolean
+    createdAt: string
+    parent?: { id: string } | null
+    endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+    childBranches: Array<{ branch: { id: string; name: string } }>
+  }
+  parent?: {
+    revision: {
+      id: string
+      comment: string
+      isDraft: boolean
+      isHead: boolean
+      isStart: boolean
+      createdAt: string
+      parent?: { id: string } | null
+      endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+      childBranches: Array<{ branch: { id: string; name: string } }>
+    }
+    branch: { id: string; name: string }
+  } | null
+  revisions: { totalCount: number }
+}
 
 export type GetProjectGraphQueryVariables = Exact<{
-  data: GetBranchesInput;
-}>;
+  data: GetBranchesInput
+}>
 
+export type GetProjectGraphQuery = {
+  branches: {
+    totalCount: number
+    edges: Array<{
+      node: {
+        id: string
+        name: string
+        isRoot: boolean
+        touched: boolean
+        createdAt: string
+        head: {
+          id: string
+          comment: string
+          isDraft: boolean
+          isHead: boolean
+          isStart: boolean
+          createdAt: string
+          parent?: { id: string } | null
+          endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+          childBranches: Array<{ branch: { id: string; name: string } }>
+        }
+        draft: {
+          id: string
+          comment: string
+          isDraft: boolean
+          isHead: boolean
+          isStart: boolean
+          createdAt: string
+          parent?: { id: string } | null
+          endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+          childBranches: Array<{ branch: { id: string; name: string } }>
+        }
+        start: {
+          id: string
+          comment: string
+          isDraft: boolean
+          isHead: boolean
+          isStart: boolean
+          createdAt: string
+          parent?: { id: string } | null
+          endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+          childBranches: Array<{ branch: { id: string; name: string } }>
+        }
+        parent?: {
+          revision: {
+            id: string
+            comment: string
+            isDraft: boolean
+            isHead: boolean
+            isStart: boolean
+            createdAt: string
+            parent?: { id: string } | null
+            endpoints: Array<{ id: string; type: EndpointType; createdAt: string }>
+            childBranches: Array<{ branch: { id: string; name: string } }>
+          }
+          branch: { id: string; name: string }
+        } | null
+        revisions: { totalCount: number }
+      }
+    }>
+  }
+}
 
-export type GetProjectGraphQuery = { branches: { totalCount: number, edges: Array<{ node: { id: string, name: string, isRoot: boolean, touched: boolean, createdAt: string, head: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, draft: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, start: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, parent?: { revision: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string, parent?: { id: string } | null, endpoints: Array<{ id: string, type: EndpointType, createdAt: string }>, childBranches: Array<{ branch: { id: string, name: string } }> }, branch: { id: string, name: string } } | null, revisions: { totalCount: number } } }> } };
-
-export type FindBranchFragment = { id: string, name: string, isRoot: boolean, touched: boolean, parent?: { revision: { branch: { id: string } } } | null };
+export type FindBranchFragment = {
+  id: string
+  name: string
+  isRoot: boolean
+  touched: boolean
+  parent?: { revision: { branch: { id: string } } } | null
+}
 
 export type FindBranchesQueryVariables = Exact<{
-  data: GetBranchesInput;
-}>;
+  data: GetBranchesInput
+}>
 
+export type FindBranchesQuery = {
+  branches: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+    edges: Array<{
+      cursor: string
+      node: {
+        id: string
+        name: string
+        isRoot: boolean
+        touched: boolean
+        parent?: { revision: { branch: { id: string } } } | null
+      }
+    }>
+  }
+}
 
-export type FindBranchesQuery = { branches: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, isRoot: boolean, touched: boolean, parent?: { revision: { branch: { id: string } } } | null } }> } };
-
-export type FindRevisionFragment = { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string };
+export type FindRevisionFragment = {
+  id: string
+  comment: string
+  isDraft: boolean
+  isHead: boolean
+  isStart: boolean
+  createdAt: string
+}
 
 export type FindRevisionsQueryVariables = Exact<{
-  data: GetBranchInput;
-  revisionsData: GetBranchRevisionsInput;
-}>;
+  data: GetBranchInput
+  revisionsData: GetBranchRevisionsInput
+}>
 
+export type FindRevisionsQuery = {
+  branch: {
+    revisions: {
+      totalCount: number
+      pageInfo: {
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+        startCursor?: string | null
+        endCursor?: string | null
+      }
+      edges: Array<{
+        cursor: string
+        node: { id: string; comment: string; isDraft: boolean; isHead: boolean; isStart: boolean; createdAt: string }
+      }>
+    }
+  }
+}
 
-export type FindRevisionsQuery = { branch: { revisions: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, comment: string, isDraft: boolean, isHead: boolean, isStart: boolean, createdAt: string } }> } } };
-
-export type MeProjectListItemFragment = { id: string, name: string, organizationId: string, rootBranch: { name: string, touched: boolean } };
+export type MeProjectListItemFragment = {
+  id: string
+  name: string
+  organizationId: string
+  rootBranch: { name: string; touched: boolean }
+}
 
 export type MeProjectsListQueryVariables = Exact<{
-  data: GetMeProjectsInput;
-}>;
+  data: GetMeProjectsInput
+}>
 
+export type MeProjectsListQuery = {
+  meProjects: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+    edges: Array<{
+      cursor: string
+      node: { id: string; name: string; organizationId: string; rootBranch: { name: string; touched: boolean } }
+    }>
+  }
+}
 
-export type MeProjectsListQuery = { meProjects: { totalCount: number, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ cursor: string, node: { id: string, name: string, organizationId: string, rootBranch: { name: string, touched: boolean } } }> } };
+export type RowChangeRowFieldsFragment = { id: string }
 
-export type RowChangeRowFieldsFragment = { id: string };
+export type RowChangeTableFieldsFragment = { id: string }
 
-export type RowChangeTableFieldsFragment = { id: string };
-
-export type FieldChangeFieldsFragment = { fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null };
+export type FieldChangeFieldsFragment = {
+  fieldPath: string
+  changeType: RowChangeDetailType
+  oldValue?: { [key: string]: any } | string | number | boolean | null | null
+  newValue?: { [key: string]: any } | string | number | boolean | null | null
+  movedFrom?: string | null
+}
 
 export type GetRowChangesQueryVariables = Exact<{
-  revisionId: Scalars['String']['input'];
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-  filters?: InputMaybe<RowChangesFiltersInput>;
-}>;
+  revisionId: Scalars['String']['input']
+  first: Scalars['Int']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+  filters?: InputMaybe<RowChangesFiltersInput>
+}>
 
-
-export type GetRowChangesQuery = { rowChanges: { totalCount: number, edges: Array<{ cursor: string, node: { changeType: ChangeType, row: { id: string }, table: { id: string }, fieldChanges: Array<{ fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null }> } | { changeType: ChangeType, row: { id: string }, fromRow: { id: string }, table: { id: string }, fromTable: { id: string }, fieldChanges: Array<{ fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null }> } | { changeType: ChangeType, fromRow: { id: string }, fromTable: { id: string }, fieldChanges: Array<{ fieldPath: string, changeType: RowChangeDetailType, oldValue?: { [key: string]: any } | string | number | boolean | null | null, newValue?: { [key: string]: any } | string | number | boolean | null | null, movedFrom?: string | null }> } }>, pageInfo: { hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } };
+export type GetRowChangesQuery = {
+  rowChanges: {
+    totalCount: number
+    edges: Array<{
+      cursor: string
+      node:
+        | {
+            changeType: ChangeType
+            row: { id: string }
+            table: { id: string }
+            fieldChanges: Array<{
+              fieldPath: string
+              changeType: RowChangeDetailType
+              oldValue?: { [key: string]: any } | string | number | boolean | null | null
+              newValue?: { [key: string]: any } | string | number | boolean | null | null
+              movedFrom?: string | null
+            }>
+          }
+        | {
+            changeType: ChangeType
+            row: { id: string }
+            fromRow: { id: string }
+            table: { id: string }
+            fromTable: { id: string }
+            fieldChanges: Array<{
+              fieldPath: string
+              changeType: RowChangeDetailType
+              oldValue?: { [key: string]: any } | string | number | boolean | null | null
+              newValue?: { [key: string]: any } | string | number | boolean | null | null
+              movedFrom?: string | null
+            }>
+          }
+        | {
+            changeType: ChangeType
+            fromRow: { id: string }
+            fromTable: { id: string }
+            fieldChanges: Array<{
+              fieldPath: string
+              changeType: RowChangeDetailType
+              oldValue?: { [key: string]: any } | string | number | boolean | null | null
+              newValue?: { [key: string]: any } | string | number | boolean | null | null
+              movedFrom?: string | null
+            }>
+          }
+    }>
+    pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; startCursor?: string | null; endCursor?: string | null }
+  }
+}
 
 export type GetTableChangesForFilterQueryVariables = Exact<{
-  revisionId: Scalars['String']['input'];
-}>;
+  revisionId: Scalars['String']['input']
+}>
 
+export type GetTableChangesForFilterQuery = {
+  tableChanges: {
+    edges: Array<{
+      node: {
+        tableId: string
+        changeType: ChangeType
+        oldTableId?: string | null
+        newTableId?: string | null
+        rowChangesCount: number
+      }
+    }>
+  }
+}
 
-export type GetTableChangesForFilterQuery = { tableChanges: { edges: Array<{ node: { tableId: string, changeType: ChangeType, oldTableId?: string | null, newTableId?: string | null, rowChangesCount: number } }> } };
+export type ForeignKeyTableItemFragment = {
+  id: string
+  versionId: string
+  createdId: string
+  createdAt: string
+  updatedAt: string
+  readonly: boolean
+  count: number
+  schema: { [key: string]: any } | string | number | boolean | null
+}
 
-export type ForeignKeyTableItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
-
-export type ForeignKeyRowItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null };
+export type ForeignKeyRowItemFragment = {
+  id: string
+  versionId: string
+  createdId: string
+  createdAt: string
+  updatedAt: string
+  readonly: boolean
+  data: { [key: string]: any } | string | number | boolean | null
+}
 
 export type ForeignKeyTableWithRowsQueryVariables = Exact<{
-  tableData: GetTableInput;
-  rowsData: GetRowsInput;
-}>;
+  tableData: GetTableInput
+  rowsData: GetRowsInput
+}>
 
+export type ForeignKeyTableWithRowsQuery = {
+  table?: {
+    id: string
+    versionId: string
+    createdId: string
+    createdAt: string
+    updatedAt: string
+    readonly: boolean
+    count: number
+    schema: { [key: string]: any } | string | number | boolean | null
+  } | null
+  rows: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+    edges: Array<{
+      node: {
+        id: string
+        versionId: string
+        createdId: string
+        createdAt: string
+        updatedAt: string
+        readonly: boolean
+        data: { [key: string]: any } | string | number | boolean | null
+      }
+    }>
+  }
+}
 
-export type ForeignKeyTableWithRowsQuery = { table?: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null } | null, rows: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } }> } };
+export type RowMutationItemFragment = {
+  id: string
+  versionId: string
+  createdId: string
+  createdAt: string
+  updatedAt: string
+  readonly: boolean
+  data: { [key: string]: any } | string | number | boolean | null
+}
 
-export type RowMutationItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null };
-
-export type TableMutationItemFragment = { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null };
+export type TableMutationItemFragment = {
+  id: string
+  versionId: string
+  createdId: string
+  createdAt: string
+  updatedAt: string
+  readonly: boolean
+  count: number
+  schema: { [key: string]: any } | string | number | boolean | null
+}
 
 export type CreateRowForStackMutationVariables = Exact<{
-  data: CreateRowInput;
-}>;
+  data: CreateRowInput
+}>
 
-
-export type CreateRowForStackMutation = { createRow: { previousVersionTableId: string, table: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null }, row: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } } };
+export type CreateRowForStackMutation = {
+  createRow: {
+    previousVersionTableId: string
+    table: {
+      id: string
+      versionId: string
+      createdId: string
+      createdAt: string
+      updatedAt: string
+      readonly: boolean
+      count: number
+      schema: { [key: string]: any } | string | number | boolean | null
+    }
+    row: {
+      id: string
+      versionId: string
+      createdId: string
+      createdAt: string
+      updatedAt: string
+      readonly: boolean
+      data: { [key: string]: any } | string | number | boolean | null
+    }
+  }
+}
 
 export type UpdateRowForStackMutationVariables = Exact<{
-  data: UpdateRowInput;
-}>;
+  data: UpdateRowInput
+}>
 
-
-export type UpdateRowForStackMutation = { updateRow: { previousVersionTableId: string, previousVersionRowId: string, table: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null }, row: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } } };
+export type UpdateRowForStackMutation = {
+  updateRow: {
+    previousVersionTableId: string
+    previousVersionRowId: string
+    table: {
+      id: string
+      versionId: string
+      createdId: string
+      createdAt: string
+      updatedAt: string
+      readonly: boolean
+      count: number
+      schema: { [key: string]: any } | string | number | boolean | null
+    }
+    row: {
+      id: string
+      versionId: string
+      createdId: string
+      createdAt: string
+      updatedAt: string
+      readonly: boolean
+      data: { [key: string]: any } | string | number | boolean | null
+    }
+  }
+}
 
 export type RenameRowForStackMutationVariables = Exact<{
-  data: RenameRowInput;
-}>;
+  data: RenameRowInput
+}>
 
+export type RenameRowForStackMutation = {
+  renameRow: {
+    previousVersionTableId: string
+    previousVersionRowId: string
+    table: {
+      id: string
+      versionId: string
+      createdId: string
+      createdAt: string
+      updatedAt: string
+      readonly: boolean
+      count: number
+      schema: { [key: string]: any } | string | number | boolean | null
+    }
+    row: {
+      id: string
+      versionId: string
+      createdId: string
+      createdAt: string
+      updatedAt: string
+      readonly: boolean
+      data: { [key: string]: any } | string | number | boolean | null
+    }
+  }
+}
 
-export type RenameRowForStackMutation = { renameRow: { previousVersionTableId: string, previousVersionRowId: string, table: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, count: number, schema: { [key: string]: any } | string | number | boolean | null }, row: { id: string, versionId: string, createdId: string, createdAt: string, updatedAt: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null } } };
-
-export type RowListItemFragment = { id: string, versionId: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null, createdAt: string, updatedAt: string, publishedAt: string, createdId: string };
+export type RowListItemFragment = {
+  id: string
+  versionId: string
+  readonly: boolean
+  data: { [key: string]: any } | string | number | boolean | null
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  createdId: string
+}
 
 export type RowListRowsQueryVariables = Exact<{
-  data: GetRowsInput;
-}>;
+  data: GetRowsInput
+}>
 
-
-export type RowListRowsQuery = { rows: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null, createdAt: string, updatedAt: string, publishedAt: string, createdId: string } }> } };
+export type RowListRowsQuery = {
+  rows: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+    edges: Array<{
+      node: {
+        id: string
+        versionId: string
+        readonly: boolean
+        data: { [key: string]: any } | string | number | boolean | null
+        createdAt: string
+        updatedAt: string
+        publishedAt: string
+        createdId: string
+      }
+    }>
+  }
+}
 
 export type DeleteRowMutationVariables = Exact<{
-  data: DeleteRowInput;
-}>;
+  data: DeleteRowInput
+}>
 
-
-export type DeleteRowMutation = { deleteRow: { branch: { id: string } } };
+export type DeleteRowMutation = { deleteRow: { branch: { id: string } } }
 
 export type DeleteRowsMutationVariables = Exact<{
-  data: DeleteRowsInput;
-}>;
+  data: DeleteRowsInput
+}>
 
-
-export type DeleteRowsMutation = { deleteRows: { branch: { id: string } } };
+export type DeleteRowsMutation = { deleteRows: { branch: { id: string } } }
 
 export type PatchRowInlineMutationVariables = Exact<{
-  data: PatchRowInput;
-}>;
+  data: PatchRowInput
+}>
 
+export type PatchRowInlineMutation = {
+  patchRow: {
+    row: {
+      id: string
+      versionId: string
+      readonly: boolean
+      data: { [key: string]: any } | string | number | boolean | null
+      createdAt: string
+      updatedAt: string
+      publishedAt: string
+      createdId: string
+    }
+  }
+}
 
-export type PatchRowInlineMutation = { patchRow: { row: { id: string, versionId: string, readonly: boolean, data: { [key: string]: any } | string | number | boolean | null, createdAt: string, updatedAt: string, publishedAt: string, createdId: string } } };
-
-export type TableViewsDataFragment = { version: number, defaultViewId: string, views: Array<{ id: string, name: string, description?: string | null, filters?: { [key: string]: any } | string | number | boolean | null | null, search?: string | null, columns?: Array<{ field: string, width?: number | null, pinned?: string | null }> | null, sorts?: Array<{ field: string, direction: string }> | null }> };
+export type TableViewsDataFragment = {
+  version: number
+  defaultViewId: string
+  views: Array<{
+    id: string
+    name: string
+    description?: string | null
+    filters?: { [key: string]: any } | string | number | boolean | null | null
+    search?: string | null
+    columns?: Array<{ field: string; width?: number | null; pinned?: string | null }> | null
+    sorts?: Array<{ field: string; direction: string }> | null
+  }>
+}
 
 export type GetTableViewsQueryVariables = Exact<{
-  data: GetTableInput;
-}>;
+  data: GetTableInput
+}>
 
-
-export type GetTableViewsQuery = { table?: { id: string, views: { version: number, defaultViewId: string, views: Array<{ id: string, name: string, description?: string | null, filters?: { [key: string]: any } | string | number | boolean | null | null, search?: string | null, columns?: Array<{ field: string, width?: number | null, pinned?: string | null }> | null, sorts?: Array<{ field: string, direction: string }> | null }> } } | null };
+export type GetTableViewsQuery = {
+  table?: {
+    id: string
+    views: {
+      version: number
+      defaultViewId: string
+      views: Array<{
+        id: string
+        name: string
+        description?: string | null
+        filters?: { [key: string]: any } | string | number | boolean | null | null
+        search?: string | null
+        columns?: Array<{ field: string; width?: number | null; pinned?: string | null }> | null
+        sorts?: Array<{ field: string; direction: string }> | null
+      }>
+    }
+  } | null
+}
 
 export type UpdateTableViewsMutationVariables = Exact<{
-  data: UpdateTableViewsInput;
-}>;
+  data: UpdateTableViewsInput
+}>
 
+export type UpdateTableViewsMutation = {
+  updateTableViews: {
+    version: number
+    defaultViewId: string
+    views: Array<{
+      id: string
+      name: string
+      description?: string | null
+      filters?: { [key: string]: any } | string | number | boolean | null | null
+      search?: string | null
+      columns?: Array<{ field: string; width?: number | null; pinned?: string | null }> | null
+      sorts?: Array<{ field: string; direction: string }> | null
+    }>
+  }
+}
 
-export type UpdateTableViewsMutation = { updateTableViews: { version: number, defaultViewId: string, views: Array<{ id: string, name: string, description?: string | null, filters?: { [key: string]: any } | string | number | boolean | null | null, search?: string | null, columns?: Array<{ field: string, width?: number | null, pinned?: string | null }> | null, sorts?: Array<{ field: string, direction: string }> | null }> } };
-
-export type SearchResultFragment = { row: { id: string }, table: { id: string }, matches: Array<{ value: { [key: string]: any } | string | number | boolean | null, path: string, highlight?: string | null }> };
+export type SearchResultFragment = {
+  row: { id: string }
+  table: { id: string }
+  matches: Array<{
+    value: { [key: string]: any } | string | number | boolean | null
+    path: string
+    highlight?: string | null
+  }>
+}
 
 export type SearchRowsQueryVariables = Exact<{
-  data: SearchRowsInput;
-}>;
+  data: SearchRowsInput
+}>
 
-
-export type SearchRowsQuery = { searchRows: { totalCount: number, edges: Array<{ cursor: string, node: { row: { id: string }, table: { id: string }, matches: Array<{ value: { [key: string]: any } | string | number | boolean | null, path: string, highlight?: string | null }> } }> } };
+export type SearchRowsQuery = {
+  searchRows: {
+    totalCount: number
+    edges: Array<{
+      cursor: string
+      node: {
+        row: { id: string }
+        table: { id: string }
+        matches: Array<{
+          value: { [key: string]: any } | string | number | boolean | null
+          path: string
+          highlight?: string | null
+        }>
+      }
+    }>
+  }
+}
 
 export type RevertChangesForSidebarMutationVariables = Exact<{
-  data: RevertChangesInput;
-}>;
+  data: RevertChangesInput
+}>
 
-
-export type RevertChangesForSidebarMutation = { revertChanges: { id: string } };
+export type RevertChangesForSidebarMutation = { revertChanges: { id: string } }
 
 export type CreateRevisionForSidebarMutationVariables = Exact<{
-  data: CreateRevisionInput;
-}>;
+  data: CreateRevisionInput
+}>
 
-
-export type CreateRevisionForSidebarMutation = { createRevision: { id: string } };
+export type CreateRevisionForSidebarMutation = { createRevision: { id: string } }
 
 export type CreateBranchForSidebarMutationVariables = Exact<{
-  data: CreateBranchInput;
-}>;
+  data: CreateBranchInput
+}>
 
-
-export type CreateBranchForSidebarMutation = { createBranch: { id: string } };
+export type CreateBranchForSidebarMutation = { createBranch: { id: string } }
 
 export type DeleteTableForListMutationVariables = Exact<{
-  data: DeleteTableInput;
-}>;
+  data: DeleteTableInput
+}>
 
+export type DeleteTableForListMutation = { deleteTable: { branch: { id: string } } }
 
-export type DeleteTableForListMutation = { deleteTable: { branch: { id: string } } };
-
-export type TableListItemFragment = { id: string, versionId: string, readonly: boolean, count: number };
+export type TableListItemFragment = { id: string; versionId: string; readonly: boolean; count: number }
 
 export type TableListDataQueryVariables = Exact<{
-  data: GetTablesInput;
-}>;
+  data: GetTablesInput
+}>
 
+export type TableListDataQuery = {
+  tables: {
+    totalCount: number
+    pageInfo: { hasNextPage: boolean; endCursor?: string | null }
+    edges: Array<{ node: { id: string; versionId: string; readonly: boolean; count: number } }>
+  }
+}
 
-export type TableListDataQuery = { tables: { totalCount: number, pageInfo: { hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ node: { id: string, versionId: string, readonly: boolean, count: number } }> } };
-
-export type TableRelationsItemFragment = { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null };
+export type TableRelationsItemFragment = {
+  id: string
+  versionId: string
+  count: number
+  schema: { [key: string]: any } | string | number | boolean | null
+}
 
 export type TableRelationsDataQueryVariables = Exact<{
-  data: GetTablesInput;
-}>;
+  data: GetTablesInput
+}>
 
-
-export type TableRelationsDataQuery = { tables: { totalCount: number, edges: Array<{ node: { id: string, versionId: string, count: number, schema: { [key: string]: any } | string | number | boolean | null } }> } };
+export type TableRelationsDataQuery = {
+  tables: {
+    totalCount: number
+    edges: Array<{
+      node: {
+        id: string
+        versionId: string
+        count: number
+        schema: { [key: string]: any } | string | number | boolean | null
+      }
+    }>
+  }
+}
 
 export const BranchLoaderFragmentFragmentDoc = gql`
-    fragment BranchLoaderFragment on BranchModel {
-  id
-  createdAt
-  name
-  touched
-  projectId
-  head {
+  fragment BranchLoaderFragment on BranchModel {
     id
+    createdAt
+    name
+    touched
+    projectId
+    head {
+      id
+    }
+    draft {
+      id
+    }
   }
-  draft {
-    id
-  }
-}
-    `;
+`
 export const OrganizationProjectItemFragmentDoc = gql`
-    fragment OrganizationProjectItem on ProjectModel {
-  id
-  name
-  organizationId
-  isPublic
-  rootBranch {
+  fragment OrganizationProjectItem on ProjectModel {
+    id
     name
-    touched
+    organizationId
+    isPublic
+    rootBranch {
+      name
+      touched
+    }
   }
-}
-    `;
+`
 export const BranchFragmentFragmentDoc = gql`
-    fragment BranchFragment on BranchModel {
-  id
-  createdAt
-  name
-  touched
-  projectId
-  head {
-    id
-  }
-  draft {
-    id
-  }
-}
-    `;
-export const ProjectLoaderFragmentFragmentDoc = gql`
-    fragment ProjectLoaderFragment on ProjectModel {
-  id
-  organizationId
-  createdAt
-  name
-  isPublic
-  rootBranch {
-    ...BranchFragment
-  }
-  userProject {
-    id
-    role {
-      id
-      name
-      permissions {
-        id
-        action
-        subject
-        condition
-      }
-    }
-  }
-  organization {
-    id
-    userOrganization {
-      id
-      role {
-        id
-        name
-        permissions {
-          id
-          action
-          subject
-          condition
-        }
-      }
-    }
-  }
-}
-    ${BranchFragmentFragmentDoc}`;
-export const RowLoaderFragmentFragmentDoc = gql`
-    fragment RowLoaderFragment on RowModel {
-  createdId
-  id
-  versionId
-  createdAt
-  updatedAt
-  readonly
-  data
-}
-    `;
-export const TableLoaderFragmentFragmentDoc = gql`
-    fragment TableLoaderFragment on TableModel {
-  createdId
-  id
-  versionId
-  createdAt
-  updatedAt
-  readonly
-  count
-  schema
-}
-    `;
-export const ApiKeyFieldsFragmentDoc = gql`
-    fragment ApiKeyFields on ApiKeyModel {
-  id
-  prefix
-  type
-  name
-  organizationId
-  projectIds
-  projects {
-    id
-    name
-  }
-  branchNames
-  tableIds
-  readOnly
-  permissions
-  allowedIps
-  expiresAt
-  lastUsedAt
-  createdAt
-  revokedAt
-}
-    `;
-export const AdminUserDetailFragmentDoc = gql`
-    fragment AdminUserDetail on UserModel {
-  id
-  email
-  username
-  role {
-    id
-    name
-  }
-}
-    `;
-export const AdminUserItemFragmentDoc = gql`
-    fragment AdminUserItem on UserModel {
-  id
-  email
-  username
-  role {
-    id
-    name
-  }
-}
-    `;
-export const AssetTableItemFragmentDoc = gql`
-    fragment AssetTableItem on TableModel {
-  id
-  versionId
-  count
-  schema
-}
-    `;
-export const AssetRowItemFragmentDoc = gql`
-    fragment AssetRowItem on RowModel {
-  id
-  versionId
-  data
-}
-    `;
-export const SubSchemaItemFragmentDoc = gql`
-    fragment SubSchemaItem on SubSchemaItemModel {
-  table {
-    id
-    versionId
-  }
-  row {
-    id
-    versionId
-    data
-  }
-  fieldPath
-  data
-}
-    `;
-export const BranchItemFragmentDoc = gql`
-    fragment BranchItem on BranchModel {
-  id
-  name
-  isRoot
-  touched
-  createdAt
-  start {
+  fragment BranchFragment on BranchModel {
     id
     createdAt
-  }
-  parent {
-    revision {
-      id
-      isDraft
-      isHead
-      createdAt
-      branch {
-        id
-        name
-      }
-    }
-  }
-}
-    `;
-export const RevisionForSelectFragmentDoc = gql`
-    fragment RevisionForSelect on RevisionModel {
-  id
-  isDraft
-  isHead
-  createdAt
-  comment
-}
-    `;
-export const EndpointFragmentDoc = gql`
-    fragment Endpoint on EndpointModel {
-  id
-  type
-  createdAt
-  revisionId
-  revision {
-    id
-    isDraft
-    isHead
-    createdAt
-    branch {
-      id
-      name
-    }
-  }
-}
-    `;
-export const RevisionWithEndpointsFragmentDoc = gql`
-    fragment RevisionWithEndpoints on RevisionModel {
-  id
-  comment
-  isDraft
-  isHead
-  isStart
-  createdAt
-  endpoints {
-    id
-    type
-  }
-}
-    `;
-export const EndpointBranchFragmentDoc = gql`
-    fragment EndpointBranch on BranchModel {
-  id
-  name
-  isRoot
-  head {
-    id
-  }
-  draft {
-    id
-  }
-}
-    `;
-export const MigrationBranchFragmentDoc = gql`
-    fragment MigrationBranch on BranchModel {
-  id
-  name
-  isRoot
-  head {
-    id
-  }
-  draft {
-    id
-  }
-}
-    `;
-export const UsageMetricFragmentDoc = gql`
-    fragment UsageMetric on UsageMetricModel {
-  current
-  limit
-  percentage
-}
-    `;
-export const LimitsPageSubscriptionFragmentDoc = gql`
-    fragment LimitsPageSubscription on SubscriptionModel {
-  planId
-  status
-  provider
-  interval
-  currentPeriodStart
-  currentPeriodEnd
-  cancelAt
-}
-    `;
-export const LimitsPagePlanFragmentDoc = gql`
-    fragment LimitsPagePlan on PlanModel {
-  id
-  name
-  isPublic
-  monthlyPriceUsd
-  yearlyPriceUsd
-  limits {
-    rowVersions
-    projects
-    seats
-    storageBytes
-  }
-  features
-}
-    `;
-export const UserOrganizationItemFragmentDoc = gql`
-    fragment UserOrganizationItem on UsersOrganizationModel {
-  id
-  user {
-    id
-    email
-    username
-  }
-  role {
-    id
-    name
-  }
-}
-    `;
-export const TableStackFragmentFragmentDoc = gql`
-    fragment TableStackFragment on TableModel {
-  id
-  versionId
-  readonly
-  count
-  schema
-}
-    `;
-export const UserProjectItemFragmentDoc = gql`
-    fragment UserProjectItem on UsersProjectModel {
-  id
-  user {
-    id
-    email
-    username
-  }
-  role {
-    id
-    name
-  }
-}
-    `;
-export const PageInfoFragmentDoc = gql`
-    fragment PageInfo on PageInfo {
-  hasNextPage
-  hasPreviousPage
-  startCursor
-  endCursor
-}
-    `;
-export const UserFragmentDoc = gql`
-    fragment User on MeModel {
-  id
-  username
-  email
-  hasPassword
-  organizationId
-  role {
-    id
-    name
-    permissions {
-      id
-      action
-      subject
-      condition
-    }
-  }
-  organization {
-    id
-    userOrganization {
-      role {
-        name
-        permissions {
-          id
-          action
-          subject
-          condition
-        }
-      }
-    }
-  }
-}
-    `;
-export const RevisionMapRevisionBaseFragmentDoc = gql`
-    fragment RevisionMapRevisionBase on RevisionModel {
-  id
-  comment
-  isDraft
-  isHead
-  isStart
-  createdAt
-  parent {
-    id
-  }
-  endpoints {
-    id
-    type
-    createdAt
-  }
-  childBranches {
-    branch {
-      id
-      name
-    }
-  }
-}
-    `;
-export const RevisionMapBranchFullFragmentDoc = gql`
-    fragment RevisionMapBranchFull on BranchModel {
-  id
-  name
-  isRoot
-  touched
-  createdAt
-  head {
-    ...RevisionMapRevisionBase
-  }
-  draft {
-    ...RevisionMapRevisionBase
-  }
-  start {
-    ...RevisionMapRevisionBase
-  }
-  parent {
-    revision {
-      ...RevisionMapRevisionBase
-    }
-    branch {
-      id
-      name
-    }
-  }
-  revisions(data: {first: 1000}) {
-    totalCount
-  }
-}
-    ${RevisionMapRevisionBaseFragmentDoc}`;
-export const FindBranchFragmentDoc = gql`
-    fragment FindBranch on BranchModel {
-  id
-  name
-  isRoot
-  touched
-  parent {
-    revision {
-      branch {
-        id
-      }
-    }
-  }
-}
-    `;
-export const FindRevisionFragmentDoc = gql`
-    fragment FindRevision on RevisionModel {
-  id
-  comment
-  isDraft
-  isHead
-  isStart
-  createdAt
-}
-    `;
-export const MeProjectListItemFragmentDoc = gql`
-    fragment MeProjectListItem on ProjectModel {
-  id
-  name
-  organizationId
-  rootBranch {
     name
     touched
-  }
-}
-    `;
-export const RowChangeRowFieldsFragmentDoc = gql`
-    fragment RowChangeRowFields on RowChangeRowModel {
-  id
-}
-    `;
-export const RowChangeTableFieldsFragmentDoc = gql`
-    fragment RowChangeTableFields on RowChangeTableModel {
-  id
-}
-    `;
-export const FieldChangeFieldsFragmentDoc = gql`
-    fragment FieldChangeFields on FieldChangeModel {
-  fieldPath
-  changeType
-  oldValue
-  newValue
-  movedFrom
-}
-    `;
-export const ForeignKeyTableItemFragmentDoc = gql`
-    fragment ForeignKeyTableItem on TableModel {
-  id
-  versionId
-  createdId
-  createdAt
-  updatedAt
-  readonly
-  count
-  schema
-}
-    `;
-export const ForeignKeyRowItemFragmentDoc = gql`
-    fragment ForeignKeyRowItem on RowModel {
-  id
-  versionId
-  createdId
-  createdAt
-  updatedAt
-  readonly
-  data
-}
-    `;
-export const RowMutationItemFragmentDoc = gql`
-    fragment RowMutationItem on RowModel {
-  id
-  versionId
-  createdId
-  createdAt
-  updatedAt
-  readonly
-  data
-}
-    `;
-export const TableMutationItemFragmentDoc = gql`
-    fragment TableMutationItem on TableModel {
-  id
-  versionId
-  createdId
-  createdAt
-  updatedAt
-  readonly
-  count
-  schema
-}
-    `;
-export const RowListItemFragmentDoc = gql`
-    fragment RowListItem on RowModel {
-  id
-  versionId
-  readonly
-  data
-  createdAt
-  updatedAt
-  publishedAt
-  createdId
-}
-    `;
-export const TableViewsDataFragmentDoc = gql`
-    fragment TableViewsData on TableViewsDataModel {
-  version
-  defaultViewId
-  views {
-    id
-    name
-    description
-    columns {
-      field
-      width
-      pinned
+    projectId
+    head {
+      id
     }
-    filters
-    sorts {
-      field
-      direction
-    }
-    search
-  }
-}
-    `;
-export const SearchResultFragmentDoc = gql`
-    fragment SearchResult on SearchResult {
-  row {
-    id
-  }
-  table {
-    id
-  }
-  matches {
-    value
-    path
-    highlight
-  }
-}
-    `;
-export const TableListItemFragmentDoc = gql`
-    fragment TableListItem on TableModel {
-  id
-  versionId
-  readonly
-  count
-}
-    `;
-export const TableRelationsItemFragmentDoc = gql`
-    fragment TableRelationsItem on TableModel {
-  id
-  versionId
-  count
-  schema
-}
-    `;
-export const GetBranchForLoaderDocument = gql`
-    query getBranchForLoader($data: GetBranchInput!) {
-  branch(data: $data) {
-    ...BranchLoaderFragment
-  }
-}
-    ${BranchLoaderFragmentFragmentDoc}`;
-export const OrganizationProjectsDocument = gql`
-    query organizationProjects($data: GetProjectsInput!) {
-  projects(data: $data) {
-    totalCount
-    pageInfo {
-      ...PageInfo
-    }
-    edges {
-      cursor
-      node {
-        ...OrganizationProjectItem
-      }
+    draft {
+      id
     }
   }
-}
-    ${PageInfoFragmentDoc}
-${OrganizationProjectItemFragmentDoc}`;
-export const GetProjectDocument = gql`
-    query getProject($data: GetProjectInput!) {
-  project(data: $data) {
+`
+export const ProjectLoaderFragmentFragmentDoc = gql`
+  fragment ProjectLoaderFragment on ProjectModel {
     id
     organizationId
     createdAt
     name
     isPublic
+    rootBranch {
+      ...BranchFragment
+    }
     userProject {
       id
       role {
@@ -3479,1431 +4164,3270 @@ export const GetProjectDocument = gql`
       }
     }
   }
-}
-    `;
-export const GetProjectForLoaderDocument = gql`
-    query getProjectForLoader($data: GetProjectInput!) {
-  project(data: $data) {
-    ...ProjectLoaderFragment
-  }
-}
-    ${ProjectLoaderFragmentFragmentDoc}`;
-export const GetRevisionForLoaderDocument = gql`
-    query getRevisionForLoader($data: GetRevisionInput!) {
-  revision(data: $data) {
+  ${BranchFragmentFragmentDoc}
+`
+export const RowLoaderFragmentFragmentDoc = gql`
+  fragment RowLoaderFragment on RowModel {
+    createdId
     id
+    versionId
+    createdAt
+    updatedAt
+    readonly
+    data
   }
-}
-    `;
-export const GetRowForLoaderDocument = gql`
-    query getRowForLoader($data: GetRowInput!) {
-  row(data: $data) {
-    ...RowLoaderFragment
-  }
-}
-    ${RowLoaderFragmentFragmentDoc}`;
-export const GetRowCountForeignKeysToForLoaderDocument = gql`
-    query getRowCountForeignKeysToForLoader($data: GetRowInput!) {
-  row(data: $data) {
+`
+export const TableLoaderFragmentFragmentDoc = gql`
+  fragment TableLoaderFragment on TableModel {
+    createdId
     id
-    countForeignKeysTo
+    versionId
+    createdAt
+    updatedAt
+    readonly
+    count
+    schema
   }
-}
-    `;
-export const ForeignKeysByDocument = gql`
-    query ForeignKeysBy($tableData: GetTableInput!, $foreignKeyTablesData: GetTableForeignKeysInput!) {
-  table(data: $tableData) {
+`
+export const ApiKeyFieldsFragmentDoc = gql`
+  fragment ApiKeyFields on ApiKeyModel {
     id
-    foreignKeysBy(data: $foreignKeyTablesData) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
+    prefix
+    type
+    name
+    organizationId
+    projectIds
+    projects {
+      id
+      name
+    }
+    branchNames
+    tableIds
+    readOnly
+    permissions
+    allowedIps
+    expiresAt
+    lastUsedAt
+    createdAt
+    revokedAt
+  }
+`
+export const AdminUserDetailFragmentDoc = gql`
+  fragment AdminUserDetail on UserModel {
+    id
+    email
+    username
+    role {
+      id
+      name
+    }
+  }
+`
+export const AdminUserItemFragmentDoc = gql`
+  fragment AdminUserItem on UserModel {
+    id
+    email
+    username
+    role {
+      id
+      name
+    }
+  }
+`
+export const AssetTableItemFragmentDoc = gql`
+  fragment AssetTableItem on TableModel {
+    id
+    versionId
+    count
+    schema
+  }
+`
+export const AssetRowItemFragmentDoc = gql`
+  fragment AssetRowItem on RowModel {
+    id
+    versionId
+    data
+  }
+`
+export const SubSchemaItemFragmentDoc = gql`
+  fragment SubSchemaItem on SubSchemaItemModel {
+    table {
+      id
+      versionId
+    }
+    row {
+      id
+      versionId
+      data
+    }
+    fieldPath
+    data
+  }
+`
+export const BranchItemFragmentDoc = gql`
+  fragment BranchItem on BranchModel {
+    id
+    name
+    isRoot
+    touched
+    createdAt
+    start {
+      id
+      createdAt
+    }
+    parent {
+      revision {
+        id
+        isDraft
+        isHead
+        createdAt
+        branch {
+          id
+          name
+        }
       }
-      edges {
-        node {
+    }
+  }
+`
+export const RevisionForSelectFragmentDoc = gql`
+  fragment RevisionForSelect on RevisionModel {
+    id
+    isDraft
+    isHead
+    createdAt
+    comment
+  }
+`
+export const EndpointFragmentDoc = gql`
+  fragment Endpoint on EndpointModel {
+    id
+    type
+    createdAt
+    revisionId
+    revision {
+      id
+      isDraft
+      isHead
+      createdAt
+      branch {
+        id
+        name
+      }
+    }
+  }
+`
+export const RevisionWithEndpointsFragmentDoc = gql`
+  fragment RevisionWithEndpoints on RevisionModel {
+    id
+    comment
+    isDraft
+    isHead
+    isStart
+    createdAt
+    endpoints {
+      id
+      type
+    }
+  }
+`
+export const EndpointBranchFragmentDoc = gql`
+  fragment EndpointBranch on BranchModel {
+    id
+    name
+    isRoot
+    head {
+      id
+    }
+    draft {
+      id
+    }
+  }
+`
+export const MigrationBranchFragmentDoc = gql`
+  fragment MigrationBranch on BranchModel {
+    id
+    name
+    isRoot
+    head {
+      id
+    }
+    draft {
+      id
+    }
+  }
+`
+export const UsageMetricFragmentDoc = gql`
+  fragment UsageMetric on UsageMetricModel {
+    current
+    limit
+    percentage
+  }
+`
+export const LimitsPageSubscriptionFragmentDoc = gql`
+  fragment LimitsPageSubscription on SubscriptionModel {
+    planId
+    status
+    provider
+    interval
+    currentPeriodStart
+    currentPeriodEnd
+    cancelAt
+  }
+`
+export const LimitsPagePlanFragmentDoc = gql`
+  fragment LimitsPagePlan on PlanModel {
+    id
+    name
+    isPublic
+    monthlyPriceUsd
+    yearlyPriceUsd
+    limits {
+      rowVersions
+      projects
+      seats
+      storageBytes
+    }
+    features
+  }
+`
+export const UserOrganizationItemFragmentDoc = gql`
+  fragment UserOrganizationItem on UsersOrganizationModel {
+    id
+    user {
+      id
+      email
+      username
+    }
+    role {
+      id
+      name
+    }
+  }
+`
+export const TableStackFragmentFragmentDoc = gql`
+  fragment TableStackFragment on TableModel {
+    id
+    versionId
+    readonly
+    count
+    schema
+  }
+`
+export const UserProjectItemFragmentDoc = gql`
+  fragment UserProjectItem on UsersProjectModel {
+    id
+    user {
+      id
+      email
+      username
+    }
+    role {
+      id
+      name
+    }
+  }
+`
+export const PageInfoFragmentDoc = gql`
+  fragment PageInfo on PageInfo {
+    hasNextPage
+    hasPreviousPage
+    startCursor
+    endCursor
+  }
+`
+export const UserFragmentDoc = gql`
+  fragment User on MeModel {
+    id
+    username
+    email
+    hasPassword
+    organizationId
+    role {
+      id
+      name
+      permissions {
+        id
+        action
+        subject
+        condition
+      }
+    }
+    organization {
+      id
+      userOrganization {
+        role {
+          name
+          permissions {
+            id
+            action
+            subject
+            condition
+          }
+        }
+      }
+    }
+  }
+`
+export const RevisionMapRevisionBaseFragmentDoc = gql`
+  fragment RevisionMapRevisionBase on RevisionModel {
+    id
+    comment
+    isDraft
+    isHead
+    isStart
+    createdAt
+    parent {
+      id
+    }
+    endpoints {
+      id
+      type
+      createdAt
+    }
+    childBranches {
+      branch {
+        id
+        name
+      }
+    }
+  }
+`
+export const RevisionMapBranchFullFragmentDoc = gql`
+  fragment RevisionMapBranchFull on BranchModel {
+    id
+    name
+    isRoot
+    touched
+    createdAt
+    head {
+      ...RevisionMapRevisionBase
+    }
+    draft {
+      ...RevisionMapRevisionBase
+    }
+    start {
+      ...RevisionMapRevisionBase
+    }
+    parent {
+      revision {
+        ...RevisionMapRevisionBase
+      }
+      branch {
+        id
+        name
+      }
+    }
+    revisions(data: { first: 1000 }) {
+      totalCount
+    }
+  }
+  ${RevisionMapRevisionBaseFragmentDoc}
+`
+export const FindBranchFragmentDoc = gql`
+  fragment FindBranch on BranchModel {
+    id
+    name
+    isRoot
+    touched
+    parent {
+      revision {
+        branch {
           id
         }
       }
     }
   }
-}
-    `;
-export const ForeignKeysByRowsDocument = gql`
-    query ForeignKeysByRows($rowData: GetRowInput!, $foreignKeyRowsData: GetRowForeignKeysInput!) {
-  row(data: $rowData) {
+`
+export const FindRevisionFragmentDoc = gql`
+  fragment FindRevision on RevisionModel {
     id
-    rowForeignKeysBy(data: $foreignKeyRowsData) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          id
-          versionId
-          data
-        }
-      }
-    }
+    comment
+    isDraft
+    isHead
+    isStart
+    createdAt
   }
-}
-    `;
-export const GetTableForLoaderDocument = gql`
-    query getTableForLoader($data: GetTableInput!) {
-  table(data: $data) {
-    ...TableLoaderFragment
-  }
-}
-    ${TableLoaderFragmentFragmentDoc}`;
-export const UpdatePasswordDocument = gql`
-    mutation updatePassword($data: UpdatePasswordInput!) {
-  updatePassword(data: $data)
-}
-    `;
-export const MyApiKeysDocument = gql`
-    query myApiKeys {
-  myApiKeys {
-    ...ApiKeyFields
-  }
-}
-    ${ApiKeyFieldsFragmentDoc}`;
-export const ServiceApiKeysDocument = gql`
-    query serviceApiKeys($organizationId: String!) {
-  serviceApiKeys(organizationId: $organizationId) {
-    ...ApiKeyFields
-  }
-}
-    ${ApiKeyFieldsFragmentDoc}`;
-export const ApiKeyByIdDocument = gql`
-    query apiKeyById($id: ID!) {
-  apiKeyById(id: $id) {
-    ...ApiKeyFields
-  }
-}
-    ${ApiKeyFieldsFragmentDoc}`;
-export const CreatePersonalApiKeyDocument = gql`
-    mutation createPersonalApiKey($data: CreatePersonalApiKeyInput!) {
-  createPersonalApiKey(data: $data) {
-    apiKey {
-      ...ApiKeyFields
-    }
-    secret
-  }
-}
-    ${ApiKeyFieldsFragmentDoc}`;
-export const CreateServiceApiKeyDocument = gql`
-    mutation createServiceApiKey($data: CreateServiceApiKeyInput!) {
-  createServiceApiKey(data: $data) {
-    apiKey {
-      ...ApiKeyFields
-    }
-    secret
-  }
-}
-    ${ApiKeyFieldsFragmentDoc}`;
-export const RevokeApiKeyDocument = gql`
-    mutation revokeApiKey($id: ID!) {
-  revokeApiKey(id: $id) {
-    ...ApiKeyFields
-  }
-}
-    ${ApiKeyFieldsFragmentDoc}`;
-export const RotateApiKeyDocument = gql`
-    mutation rotateApiKey($id: ID!) {
-  rotateApiKey(id: $id) {
-    apiKey {
-      ...ApiKeyFields
-    }
-    secret
-  }
-}
-    ${ApiKeyFieldsFragmentDoc}`;
-export const CreateProjectDocument = gql`
-    mutation createProject($data: CreateProjectInput!) {
-  createProject(data: $data) {
+`
+export const MeProjectListItemFragmentDoc = gql`
+  fragment MeProjectListItem on ProjectModel {
     id
     name
     organizationId
-  }
-}
-    `;
-export const FindForeignKeyDocument = gql`
-    query findForeignKey($data: GetRowsInput!) {
-  rows(data: $data) {
-    totalCount
-    pageInfo {
-      ...PageInfo
-    }
-    edges {
-      cursor
-      node {
-        id
-      }
+    rootBranch {
+      name
+      touched
     }
   }
-}
-    ${PageInfoFragmentDoc}`;
-export const AdminDashboardStatsDocument = gql`
-    query AdminDashboardStats($first: Int!) {
-  searchUsers(data: {first: $first}) {
-    totalCount
-  }
-}
-    `;
-export const AdminGetUserDocument = gql`
-    query adminGetUser($userId: String!) {
-  adminUser(data: {userId: $userId}) {
-    ...AdminUserDetail
-  }
-}
-    ${AdminUserDetailFragmentDoc}`;
-export const AdminResetPasswordDocument = gql`
-    mutation adminResetPassword($userId: String!, $newPassword: String!) {
-  resetPassword(data: {userId: $userId, newPassword: $newPassword})
-}
-    `;
-export const AdminUsersDocument = gql`
-    query adminUsers($search: String, $first: Int!, $after: String) {
-  adminUsers(data: {search: $search, first: $first, after: $after}) {
-    edges {
-      node {
-        ...AdminUserItem
-      }
-      cursor
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    totalCount
-  }
-}
-    ${AdminUserItemFragmentDoc}`;
-export const AdminUserDocument = gql`
-    query adminUser($userId: String!) {
-  adminUser(data: {userId: $userId}) {
-    ...AdminUserItem
-  }
-}
-    ${AdminUserItemFragmentDoc}`;
-export const AssetsTablesDataDocument = gql`
-    query assetsTablesData($data: GetTablesInput!) {
-  tables(data: $data) {
-    totalCount
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    edges {
-      node {
-        ...AssetTableItem
-      }
-    }
-  }
-}
-    ${AssetTableItemFragmentDoc}`;
-export const AssetsRowsDataDocument = gql`
-    query assetsRowsData($data: GetRowsInput!) {
-  rows(data: $data) {
-    totalCount
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    edges {
-      node {
-        ...AssetRowItem
-      }
-    }
-  }
-}
-    ${AssetRowItemFragmentDoc}`;
-export const SubSchemaItemsDataDocument = gql`
-    query subSchemaItemsData($data: GetSubSchemaItemsInput!) {
-  subSchemaItems(data: $data) {
-    totalCount
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    edges {
-      node {
-        ...SubSchemaItem
-      }
-    }
-  }
-}
-    ${SubSchemaItemFragmentDoc}`;
-export const GetProjectBranchesDocument = gql`
-    query getProjectBranches($data: GetBranchesInput!) {
-  branches(data: $data) {
-    totalCount
-    pageInfo {
-      ...PageInfo
-    }
-    edges {
-      cursor
-      node {
-        ...BranchItem
-      }
-    }
-  }
-}
-    ${PageInfoFragmentDoc}
-${BranchItemFragmentDoc}`;
-export const DeleteBranchDocument = gql`
-    mutation deleteBranch($data: DeleteBranchInput!) {
-  deleteBranch(data: $data)
-}
-    `;
-export const GetBranchesForSelectDocument = gql`
-    query getBranchesForSelect($data: GetBranchesInput!) {
-  branches(data: $data) {
-    edges {
-      node {
-        id
-        name
-        isRoot
-      }
-    }
-  }
-}
-    `;
-export const GetBranchRevisionsForCreateDocument = gql`
-    query getBranchRevisionsForCreate($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
-  branch(data: $data) {
+`
+export const RowChangeRowFieldsFragmentDoc = gql`
+  fragment RowChangeRowFields on RowChangeRowModel {
     id
-    revisions(data: $revisionsData) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-      edges {
-        node {
-          ...RevisionForSelect
-        }
-      }
-    }
   }
-}
-    ${RevisionForSelectFragmentDoc}`;
-export const CreateBranchDocument = gql`
-    mutation createBranch($data: CreateBranchInput!) {
-  createBranch(data: $data) {
+`
+export const RowChangeTableFieldsFragmentDoc = gql`
+  fragment RowChangeTableFields on RowChangeTableModel {
     id
-    name
   }
-}
-    `;
-export const GetRevisionChangesDocument = gql`
-    query GetRevisionChanges($revisionId: String!, $compareWithRevisionId: String, $includeSystem: Boolean) {
-  revisionChanges(
-    data: {revisionId: $revisionId, compareWithRevisionId: $compareWithRevisionId, includeSystem: $includeSystem}
-  ) {
-    revisionId
-    parentRevisionId
-    totalChanges
-    tablesSummary {
-      added
-      modified
-      removed
-      renamed
-      total
-    }
-    rowsSummary {
-      added
-      modified
-      removed
-      renamed
-      total
-    }
+`
+export const FieldChangeFieldsFragmentDoc = gql`
+  fragment FieldChangeFields on FieldChangeModel {
+    fieldPath
+    changeType
+    oldValue
+    newValue
+    movedFrom
   }
-}
-    `;
-export const GetTableChangesDocument = gql`
-    query GetTableChanges($revisionId: String!, $first: Int!, $after: String, $filters: TableChangesFiltersInput) {
-  tableChanges(
-    data: {revisionId: $revisionId, first: $first, after: $after, filters: $filters}
-  ) {
-    edges {
-      node {
-        tableId
-        changeType
-        oldTableId
-        newTableId
-        schemaMigrations {
-          migrationType
-          migrationId
-          oldTableId
-          newTableId
-          patches {
-            op
-            path
-            value
-            from
-          }
-        }
-        viewsChanges {
-          hasChanges
-          changes {
-            viewId
-            viewName
-            changeType
-            oldViewName
-          }
-          addedCount
-          modifiedCount
-          removedCount
-          renamedCount
-        }
-        rowChangesCount
-        addedRowsCount
-        modifiedRowsCount
-        removedRowsCount
-        renamedRowsCount
-      }
-      cursor
-    }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-    totalCount
-  }
-}
-    `;
-export const ConfirmEmailCodeDocument = gql`
-    mutation confirmEmailCode($data: ConfirmEmailCodeInput!) {
-  confirmEmailCode(data: $data) {
-    accessToken
-  }
-}
-    `;
-export const GetEndpointBranchesDocument = gql`
-    query getEndpointBranches($data: GetBranchesInput!) {
-  branches(data: $data) {
-    totalCount
-    edges {
-      node {
-        ...EndpointBranch
-      }
-    }
-  }
-}
-    ${EndpointBranchFragmentDoc}`;
-export const GetProjectEndpointsDocument = gql`
-    query getProjectEndpoints($organizationId: String!, $projectName: String!, $first: Int!, $after: String, $branchId: String, $type: EndpointType) {
-  projectEndpoints(
-    data: {organizationId: $organizationId, projectName: $projectName, first: $first, after: $after, branchId: $branchId, type: $type}
-  ) {
-    edges {
-      node {
-        ...Endpoint
-      }
-      cursor
-    }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-    totalCount
-  }
-}
-    ${EndpointFragmentDoc}`;
-export const GetBranchRevisionsDocument = gql`
-    query getBranchRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
-  branch(data: $data) {
-    revisions(data: $revisionsData) {
-      totalCount
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-      }
-      edges {
-        cursor
-        node {
-          ...RevisionWithEndpoints
-        }
-      }
-    }
-  }
-}
-    ${RevisionWithEndpointsFragmentDoc}`;
-export const CreateEndpointDocument = gql`
-    mutation createEndpoint($data: CreateEndpointInput!) {
-  createEndpoint(data: $data) {
-    ...Endpoint
-  }
-}
-    ${EndpointFragmentDoc}`;
-export const DeleteEndpointDocument = gql`
-    mutation deleteEndpoint($data: DeleteEndpointInput!) {
-  deleteEndpoint(data: $data)
-}
-    `;
-export const LoginGithubDocument = gql`
-    mutation loginGithub($data: LoginGithubInput!) {
-  loginGithub(data: $data) {
-    accessToken
-  }
-}
-    `;
-export const LoginGoogleDocument = gql`
-    mutation loginGoogle($data: LoginGoogleInput!) {
-  loginGoogle(data: $data) {
-    accessToken
-  }
-}
-    `;
-export const LoginDocument = gql`
-    mutation login($data: LoginInput!) {
-  login(data: $data) {
-    accessToken
-  }
-}
-    `;
-export const GetMigrationBranchesDocument = gql`
-    query getMigrationBranches($data: GetBranchesInput!) {
-  branches(data: $data) {
-    totalCount
-    edges {
-      node {
-        ...MigrationBranch
-      }
-    }
-  }
-}
-    ${MigrationBranchFragmentDoc}`;
-export const GetBranchMigrationsDocument = gql`
-    query getBranchMigrations($data: GetRevisionInput!) {
-  revision(data: $data) {
+`
+export const ForeignKeyTableItemFragmentDoc = gql`
+  fragment ForeignKeyTableItem on TableModel {
     id
-    migrations
-  }
-}
-    `;
-export const ApplyMigrationsDocument = gql`
-    mutation applyMigrations($data: ApplyMigrationsInput!) {
-  applyMigrations(data: $data) {
-    id
-    status
-    error
-  }
-}
-    `;
-export const GetMigrationsDocument = gql`
-    query getMigrations($data: GetRevisionInput!) {
-  revision(data: $data) {
-    id
-    migrations
-  }
-}
-    `;
-export const ActivateEarlyAccessDocument = gql`
-    mutation activateEarlyAccess($data: ActivateEarlyAccessInput!) {
-  activateEarlyAccess(data: $data) {
-    ...LimitsPageSubscription
-  }
-}
-    ${LimitsPageSubscriptionFragmentDoc}`;
-export const CreateCheckoutDocument = gql`
-    mutation createCheckout($data: CreateCheckoutInput!) {
-  createCheckout(data: $data) {
-    checkoutUrl
-  }
-}
-    `;
-export const CancelSubscriptionDocument = gql`
-    mutation cancelSubscription($data: CancelSubscriptionInput!) {
-  cancelSubscription(data: $data)
-}
-    `;
-export const GetLimitsPageDataDocument = gql`
-    query getLimitsPageData($data: GetOrganizationInput!) {
-  configuration {
-    billing {
-      enabled
-    }
-  }
-  organization(data: $data) {
-    id
-    subscription {
-      ...LimitsPageSubscription
-    }
-    usage {
-      rowVersions {
-        ...UsageMetric
-      }
-      projects {
-        ...UsageMetric
-      }
-      seats {
-        ...UsageMetric
-      }
-      storageBytes {
-        ...UsageMetric
-      }
-    }
-  }
-}
-    ${LimitsPageSubscriptionFragmentDoc}
-${UsageMetricFragmentDoc}`;
-export const GetLimitsPagePlansDocument = gql`
-    query getLimitsPagePlans {
-  plans {
-    ...LimitsPagePlan
-  }
-}
-    ${LimitsPagePlanFragmentDoc}`;
-export const GetUsersOrganizationDocument = gql`
-    query getUsersOrganization($organizationId: String!, $first: Int!, $after: String) {
-  usersOrganization(
-    data: {organizationId: $organizationId, first: $first, after: $after}
-  ) {
-    edges {
-      node {
-        ...UserOrganizationItem
-      }
-      cursor
-    }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-    totalCount
-  }
-}
-    ${UserOrganizationItemFragmentDoc}`;
-export const AddUserToOrganizationDocument = gql`
-    mutation addUserToOrganization($organizationId: String!, $userId: String!, $roleId: UserOrganizationRoles!) {
-  addUserToOrganization(
-    data: {organizationId: $organizationId, userId: $userId, roleId: $roleId}
-  )
-}
-    `;
-export const RemoveUserFromOrganizationDocument = gql`
-    mutation removeUserFromOrganization($organizationId: String!, $userId: String!) {
-  removeUserFromOrganization(
-    data: {organizationId: $organizationId, userId: $userId}
-  )
-}
-    `;
-export const UpdateProjectDocument = gql`
-    mutation updateProject($data: UpdateProjectInput!) {
-  updateProject(data: $data)
-}
-    `;
-export const DeleteProjectForSettingsDocument = gql`
-    mutation deleteProjectForSettings($data: DeleteProjectInput!) {
-  deleteProject(data: $data)
-}
-    `;
-export const FetchTableForStackDocument = gql`
-    query fetchTableForStack($data: GetTableInput!) {
-  table(data: $data) {
-    ...TableStackFragment
-  }
-}
-    ${TableStackFragmentFragmentDoc}`;
-export const CreateTableForStackDocument = gql`
-    mutation createTableForStack($data: CreateTableInput!) {
-  createTable(data: $data) {
-    table {
-      ...TableStackFragment
-    }
-  }
-}
-    ${TableStackFragmentFragmentDoc}`;
-export const UpdateTableForStackDocument = gql`
-    mutation updateTableForStack($data: UpdateTableInput!) {
-  updateTable(data: $data) {
-    table {
-      ...TableStackFragment
-    }
-    previousVersionTableId
-  }
-}
-    ${TableStackFragmentFragmentDoc}`;
-export const RenameTableForStackDocument = gql`
-    mutation renameTableForStack($data: RenameTableInput!) {
-  renameTable(data: $data) {
-    table {
-      ...TableStackFragment
-    }
-    previousVersionTableId
-  }
-}
-    ${TableStackFragmentFragmentDoc}`;
-export const RowPageDataDocument = gql`
-    query rowPageData($rowData: GetRowInput!, $tableData: GetTableInput!, $foreignKeysData: GetRowCountForeignKeysByInput!) {
-  row(data: $rowData) {
-    id
-    data
-  }
-  table(data: $tableData) {
-    id
+    versionId
+    createdId
+    createdAt
+    updatedAt
+    readonly
+    count
     schema
   }
-  getRowCountForeignKeysTo(data: $foreignKeysData)
-}
-    `;
-export const SignUpDocument = gql`
-    mutation signUp($data: SignUpInput!) {
-  signUp(data: $data)
-}
-    `;
-export const SetUsernameDocument = gql`
-    mutation setUsername($data: SetUsernameInput!) {
-  setUsername(data: $data)
-}
-    `;
-export const GetUsersProjectDocument = gql`
-    query getUsersProject($organizationId: String!, $projectName: String!, $first: Int!, $after: String) {
-  usersProject(
-    data: {organizationId: $organizationId, projectName: $projectName, first: $first, after: $after}
-  ) {
-    edges {
-      node {
-        ...UserProjectItem
+`
+export const ForeignKeyRowItemFragmentDoc = gql`
+  fragment ForeignKeyRowItem on RowModel {
+    id
+    versionId
+    createdId
+    createdAt
+    updatedAt
+    readonly
+    data
+  }
+`
+export const RowMutationItemFragmentDoc = gql`
+  fragment RowMutationItem on RowModel {
+    id
+    versionId
+    createdId
+    createdAt
+    updatedAt
+    readonly
+    data
+  }
+`
+export const TableMutationItemFragmentDoc = gql`
+  fragment TableMutationItem on TableModel {
+    id
+    versionId
+    createdId
+    createdAt
+    updatedAt
+    readonly
+    count
+    schema
+  }
+`
+export const RowListItemFragmentDoc = gql`
+  fragment RowListItem on RowModel {
+    id
+    versionId
+    readonly
+    data
+    createdAt
+    updatedAt
+    publishedAt
+    createdId
+  }
+`
+export const TableViewsDataFragmentDoc = gql`
+  fragment TableViewsData on TableViewsDataModel {
+    version
+    defaultViewId
+    views {
+      id
+      name
+      description
+      columns {
+        field
+        width
+        pinned
       }
-      cursor
-    }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-    totalCount
-  }
-}
-    ${UserProjectItemFragmentDoc}`;
-export const SearchUsersDocument = gql`
-    query searchUsers($search: String, $first: Int!, $after: String) {
-  searchUsers(data: {search: $search, first: $first, after: $after}) {
-    edges {
-      node {
-        id
-        email
-        username
+      filters
+      sorts {
+        field
+        direction
       }
-      cursor
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    totalCount
-  }
-}
-    `;
-export const AddUserToProjectDocument = gql`
-    mutation addUserToProject($organizationId: String!, $projectName: String!, $userId: String!, $roleId: UserProjectRoles!) {
-  addUserToProject(
-    data: {organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId}
-  )
-}
-    `;
-export const RemoveUserFromProjectDocument = gql`
-    mutation removeUserFromProject($organizationId: String!, $projectName: String!, $userId: String!) {
-  removeUserFromProject(
-    data: {organizationId: $organizationId, projectName: $projectName, userId: $userId}
-  )
-}
-    `;
-export const UpdateUserProjectRoleDocument = gql`
-    mutation updateUserProjectRole($organizationId: String!, $projectName: String!, $userId: String!, $roleId: UserProjectRoles!) {
-  updateUserProjectRole(
-    data: {organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId}
-  )
-}
-    `;
-export const CreateUserDocument = gql`
-    mutation createUser($username: String!, $password: String!, $email: String, $roleId: UserSystemRole!) {
-  createUser(
-    data: {username: $username, password: $password, email: $email, roleId: $roleId}
-  )
-}
-    `;
-export const ConfigurationDocument = gql`
-    query configuration {
-  configuration {
-    availableEmailSignUp
-    noAuth
-    billing {
-      enabled
-    }
-    google {
-      available
-      clientId
-    }
-    github {
-      available
-      clientId
-    }
-    plugins {
-      file
+      search
     }
   }
-}
-    `;
-export const GetMeDocument = gql`
-    query getMe {
-  me {
-    ...User
-  }
-}
-    ${UserFragmentDoc}`;
-export const GetProjectGraphDocument = gql`
-    query getProjectGraph($data: GetBranchesInput!) {
-  branches(data: $data) {
-    totalCount
-    edges {
-      node {
-        ...RevisionMapBranchFull
-      }
+`
+export const SearchResultFragmentDoc = gql`
+  fragment SearchResult on SearchResult {
+    row {
+      id
+    }
+    table {
+      id
+    }
+    matches {
+      value
+      path
+      highlight
     }
   }
-}
-    ${RevisionMapBranchFullFragmentDoc}`;
-export const FindBranchesDocument = gql`
-    query findBranches($data: GetBranchesInput!) {
-  branches(data: $data) {
-    totalCount
-    pageInfo {
-      ...PageInfo
-    }
-    edges {
-      cursor
-      node {
-        ...FindBranch
-      }
+`
+export const TableListItemFragmentDoc = gql`
+  fragment TableListItem on TableModel {
+    id
+    versionId
+    readonly
+    count
+  }
+`
+export const TableRelationsItemFragmentDoc = gql`
+  fragment TableRelationsItem on TableModel {
+    id
+    versionId
+    count
+    schema
+  }
+`
+export const GetBranchForLoaderDocument = gql`
+  query getBranchForLoader($data: GetBranchInput!) {
+    branch(data: $data) {
+      ...BranchLoaderFragment
     }
   }
-}
-    ${PageInfoFragmentDoc}
-${FindBranchFragmentDoc}`;
-export const FindRevisionsDocument = gql`
-    query findRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
-  branch(data: $data) {
-    revisions(data: $revisionsData) {
+  ${BranchLoaderFragmentFragmentDoc}
+`
+export const OrganizationProjectsDocument = gql`
+  query organizationProjects($data: GetProjectsInput!) {
+    projects(data: $data) {
       totalCount
+      pageInfo {
+        ...PageInfo
+      }
+      edges {
+        cursor
+        node {
+          ...OrganizationProjectItem
+        }
+      }
+    }
+  }
+  ${PageInfoFragmentDoc}
+  ${OrganizationProjectItemFragmentDoc}
+`
+export const GetProjectDocument = gql`
+  query getProject($data: GetProjectInput!) {
+    project(data: $data) {
+      id
+      organizationId
+      createdAt
+      name
+      isPublic
+      userProject {
+        id
+        role {
+          id
+          name
+          permissions {
+            id
+            action
+            subject
+            condition
+          }
+        }
+      }
+      organization {
+        id
+        userOrganization {
+          id
+          role {
+            id
+            name
+            permissions {
+              id
+              action
+              subject
+              condition
+            }
+          }
+        }
+      }
+    }
+  }
+`
+export const GetProjectForLoaderDocument = gql`
+  query getProjectForLoader($data: GetProjectInput!) {
+    project(data: $data) {
+      ...ProjectLoaderFragment
+    }
+  }
+  ${ProjectLoaderFragmentFragmentDoc}
+`
+export const GetRevisionForLoaderDocument = gql`
+  query getRevisionForLoader($data: GetRevisionInput!) {
+    revision(data: $data) {
+      id
+    }
+  }
+`
+export const GetRowForLoaderDocument = gql`
+  query getRowForLoader($data: GetRowInput!) {
+    row(data: $data) {
+      ...RowLoaderFragment
+    }
+  }
+  ${RowLoaderFragmentFragmentDoc}
+`
+export const GetRowCountForeignKeysToForLoaderDocument = gql`
+  query getRowCountForeignKeysToForLoader($data: GetRowInput!) {
+    row(data: $data) {
+      id
+      countForeignKeysTo
+    }
+  }
+`
+export const ForeignKeysByDocument = gql`
+  query ForeignKeysBy($tableData: GetTableInput!, $foreignKeyTablesData: GetTableForeignKeysInput!) {
+    table(data: $tableData) {
+      id
+      foreignKeysBy(data: $foreignKeyTablesData) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            id
+          }
+        }
+      }
+    }
+  }
+`
+export const ForeignKeysByRowsDocument = gql`
+  query ForeignKeysByRows($rowData: GetRowInput!, $foreignKeyRowsData: GetRowForeignKeysInput!) {
+    row(data: $rowData) {
+      id
+      rowForeignKeysBy(data: $foreignKeyRowsData) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            id
+            versionId
+            data
+          }
+        }
+      }
+    }
+  }
+`
+export const GetTableForLoaderDocument = gql`
+  query getTableForLoader($data: GetTableInput!) {
+    table(data: $data) {
+      ...TableLoaderFragment
+    }
+  }
+  ${TableLoaderFragmentFragmentDoc}
+`
+export const UpdatePasswordDocument = gql`
+  mutation updatePassword($data: UpdatePasswordInput!) {
+    updatePassword(data: $data)
+  }
+`
+export const MyApiKeysDocument = gql`
+  query myApiKeys {
+    myApiKeys {
+      ...ApiKeyFields
+    }
+  }
+  ${ApiKeyFieldsFragmentDoc}
+`
+export const ServiceApiKeysDocument = gql`
+  query serviceApiKeys($organizationId: String!) {
+    serviceApiKeys(organizationId: $organizationId) {
+      ...ApiKeyFields
+    }
+  }
+  ${ApiKeyFieldsFragmentDoc}
+`
+export const ApiKeyByIdDocument = gql`
+  query apiKeyById($id: ID!) {
+    apiKeyById(id: $id) {
+      ...ApiKeyFields
+    }
+  }
+  ${ApiKeyFieldsFragmentDoc}
+`
+export const CreatePersonalApiKeyDocument = gql`
+  mutation createPersonalApiKey($data: CreatePersonalApiKeyInput!) {
+    createPersonalApiKey(data: $data) {
+      apiKey {
+        ...ApiKeyFields
+      }
+      secret
+    }
+  }
+  ${ApiKeyFieldsFragmentDoc}
+`
+export const CreateServiceApiKeyDocument = gql`
+  mutation createServiceApiKey($data: CreateServiceApiKeyInput!) {
+    createServiceApiKey(data: $data) {
+      apiKey {
+        ...ApiKeyFields
+      }
+      secret
+    }
+  }
+  ${ApiKeyFieldsFragmentDoc}
+`
+export const RevokeApiKeyDocument = gql`
+  mutation revokeApiKey($id: ID!) {
+    revokeApiKey(id: $id) {
+      ...ApiKeyFields
+    }
+  }
+  ${ApiKeyFieldsFragmentDoc}
+`
+export const RotateApiKeyDocument = gql`
+  mutation rotateApiKey($id: ID!) {
+    rotateApiKey(id: $id) {
+      apiKey {
+        ...ApiKeyFields
+      }
+      secret
+    }
+  }
+  ${ApiKeyFieldsFragmentDoc}
+`
+export const CreateProjectDocument = gql`
+  mutation createProject($data: CreateProjectInput!) {
+    createProject(data: $data) {
+      id
+      name
+      organizationId
+    }
+  }
+`
+export const FindForeignKeyDocument = gql`
+  query findForeignKey($data: GetRowsInput!) {
+    rows(data: $data) {
+      totalCount
+      pageInfo {
+        ...PageInfo
+      }
+      edges {
+        cursor
+        node {
+          id
+        }
+      }
+    }
+  }
+  ${PageInfoFragmentDoc}
+`
+export const AdminCacheStatsDocument = gql`
+  query adminCacheStats {
+    adminCacheStats {
+      totalHits
+      totalMisses
+      totalWrites
+      totalDeletes
+      totalClears
+      overallHitRate
+      byCategory {
+        key
+        hits
+        misses
+        writes
+        deletes
+        hitRate
+      }
+    }
+  }
+`
+export const AdminResetAllCacheDocument = gql`
+  mutation adminResetAllCache {
+    adminResetAllCache
+  }
+`
+export const AdminDashboardStatsDocument = gql`
+  query AdminDashboardStats($first: Int!) {
+    searchUsers(data: { first: $first }) {
+      totalCount
+    }
+  }
+`
+export const AdminGetUserDocument = gql`
+  query adminGetUser($userId: String!) {
+    adminUser(data: { userId: $userId }) {
+      ...AdminUserDetail
+    }
+  }
+  ${AdminUserDetailFragmentDoc}
+`
+export const AdminResetPasswordDocument = gql`
+  mutation adminResetPassword($userId: String!, $newPassword: String!) {
+    resetPassword(data: { userId: $userId, newPassword: $newPassword })
+  }
+`
+export const AdminUsersDocument = gql`
+  query adminUsers($search: String, $first: Int!, $after: String) {
+    adminUsers(data: { search: $search, first: $first, after: $after }) {
+      edges {
+        node {
+          ...AdminUserItem
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${AdminUserItemFragmentDoc}
+`
+export const AdminUserDocument = gql`
+  query adminUser($userId: String!) {
+    adminUser(data: { userId: $userId }) {
+      ...AdminUserItem
+    }
+  }
+  ${AdminUserItemFragmentDoc}
+`
+export const AssetsTablesDataDocument = gql`
+  query assetsTablesData($data: GetTablesInput!) {
+    tables(data: $data) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          ...AssetTableItem
+        }
+      }
+    }
+  }
+  ${AssetTableItemFragmentDoc}
+`
+export const AssetsRowsDataDocument = gql`
+  query assetsRowsData($data: GetRowsInput!) {
+    rows(data: $data) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          ...AssetRowItem
+        }
+      }
+    }
+  }
+  ${AssetRowItemFragmentDoc}
+`
+export const SubSchemaItemsDataDocument = gql`
+  query subSchemaItemsData($data: GetSubSchemaItemsInput!) {
+    subSchemaItems(data: $data) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          ...SubSchemaItem
+        }
+      }
+    }
+  }
+  ${SubSchemaItemFragmentDoc}
+`
+export const GetProjectBranchesDocument = gql`
+  query getProjectBranches($data: GetBranchesInput!) {
+    branches(data: $data) {
+      totalCount
+      pageInfo {
+        ...PageInfo
+      }
+      edges {
+        cursor
+        node {
+          ...BranchItem
+        }
+      }
+    }
+  }
+  ${PageInfoFragmentDoc}
+  ${BranchItemFragmentDoc}
+`
+export const DeleteBranchDocument = gql`
+  mutation deleteBranch($data: DeleteBranchInput!) {
+    deleteBranch(data: $data)
+  }
+`
+export const GetBranchesForSelectDocument = gql`
+  query getBranchesForSelect($data: GetBranchesInput!) {
+    branches(data: $data) {
+      edges {
+        node {
+          id
+          name
+          isRoot
+        }
+      }
+    }
+  }
+`
+export const GetBranchRevisionsForCreateDocument = gql`
+  query getBranchRevisionsForCreate($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
+    branch(data: $data) {
+      id
+      revisions(data: $revisionsData) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          node {
+            ...RevisionForSelect
+          }
+        }
+      }
+    }
+  }
+  ${RevisionForSelectFragmentDoc}
+`
+export const CreateBranchDocument = gql`
+  mutation createBranch($data: CreateBranchInput!) {
+    createBranch(data: $data) {
+      id
+      name
+    }
+  }
+`
+export const GetRevisionChangesDocument = gql`
+  query GetRevisionChanges($revisionId: String!, $compareWithRevisionId: String, $includeSystem: Boolean) {
+    revisionChanges(
+      data: { revisionId: $revisionId, compareWithRevisionId: $compareWithRevisionId, includeSystem: $includeSystem }
+    ) {
+      revisionId
+      parentRevisionId
+      totalChanges
+      tablesSummary {
+        added
+        modified
+        removed
+        renamed
+        total
+      }
+      rowsSummary {
+        added
+        modified
+        removed
+        renamed
+        total
+      }
+    }
+  }
+`
+export const GetTableChangesDocument = gql`
+  query GetTableChanges($revisionId: String!, $first: Int!, $after: String, $filters: TableChangesFiltersInput) {
+    tableChanges(data: { revisionId: $revisionId, first: $first, after: $after, filters: $filters }) {
+      edges {
+        node {
+          tableId
+          changeType
+          oldTableId
+          newTableId
+          schemaMigrations {
+            migrationType
+            migrationId
+            oldTableId
+            newTableId
+            patches {
+              op
+              path
+              value
+              from
+            }
+          }
+          viewsChanges {
+            hasChanges
+            changes {
+              viewId
+              viewName
+              changeType
+              oldViewName
+            }
+            addedCount
+            modifiedCount
+            removedCount
+            renamedCount
+          }
+          rowChangesCount
+          addedRowsCount
+          modifiedRowsCount
+          removedRowsCount
+          renamedRowsCount
+        }
+        cursor
+      }
       pageInfo {
         hasNextPage
         hasPreviousPage
         startCursor
         endCursor
       }
+      totalCount
+    }
+  }
+`
+export const ConfirmEmailCodeDocument = gql`
+  mutation confirmEmailCode($data: ConfirmEmailCodeInput!) {
+    confirmEmailCode(data: $data) {
+      accessToken
+    }
+  }
+`
+export const GetEndpointBranchesDocument = gql`
+  query getEndpointBranches($data: GetBranchesInput!) {
+    branches(data: $data) {
+      totalCount
+      edges {
+        node {
+          ...EndpointBranch
+        }
+      }
+    }
+  }
+  ${EndpointBranchFragmentDoc}
+`
+export const GetProjectEndpointsDocument = gql`
+  query getProjectEndpoints(
+    $organizationId: String!
+    $projectName: String!
+    $first: Int!
+    $after: String
+    $branchId: String
+    $type: EndpointType
+  ) {
+    projectEndpoints(
+      data: {
+        organizationId: $organizationId
+        projectName: $projectName
+        first: $first
+        after: $after
+        branchId: $branchId
+        type: $type
+      }
+    ) {
+      edges {
+        node {
+          ...Endpoint
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${EndpointFragmentDoc}
+`
+export const GetBranchRevisionsDocument = gql`
+  query getBranchRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
+    branch(data: $data) {
+      revisions(data: $revisionsData) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        edges {
+          cursor
+          node {
+            ...RevisionWithEndpoints
+          }
+        }
+      }
+    }
+  }
+  ${RevisionWithEndpointsFragmentDoc}
+`
+export const CreateEndpointDocument = gql`
+  mutation createEndpoint($data: CreateEndpointInput!) {
+    createEndpoint(data: $data) {
+      ...Endpoint
+    }
+  }
+  ${EndpointFragmentDoc}
+`
+export const DeleteEndpointDocument = gql`
+  mutation deleteEndpoint($data: DeleteEndpointInput!) {
+    deleteEndpoint(data: $data)
+  }
+`
+export const LoginGithubDocument = gql`
+  mutation loginGithub($data: LoginGithubInput!) {
+    loginGithub(data: $data) {
+      accessToken
+    }
+  }
+`
+export const LoginGoogleDocument = gql`
+  mutation loginGoogle($data: LoginGoogleInput!) {
+    loginGoogle(data: $data) {
+      accessToken
+    }
+  }
+`
+export const LoginDocument = gql`
+  mutation login($data: LoginInput!) {
+    login(data: $data) {
+      accessToken
+    }
+  }
+`
+export const GetMigrationBranchesDocument = gql`
+  query getMigrationBranches($data: GetBranchesInput!) {
+    branches(data: $data) {
+      totalCount
+      edges {
+        node {
+          ...MigrationBranch
+        }
+      }
+    }
+  }
+  ${MigrationBranchFragmentDoc}
+`
+export const GetBranchMigrationsDocument = gql`
+  query getBranchMigrations($data: GetRevisionInput!) {
+    revision(data: $data) {
+      id
+      migrations
+    }
+  }
+`
+export const ApplyMigrationsDocument = gql`
+  mutation applyMigrations($data: ApplyMigrationsInput!) {
+    applyMigrations(data: $data) {
+      id
+      status
+      error
+    }
+  }
+`
+export const GetMigrationsDocument = gql`
+  query getMigrations($data: GetRevisionInput!) {
+    revision(data: $data) {
+      id
+      migrations
+    }
+  }
+`
+export const ActivateEarlyAccessDocument = gql`
+  mutation activateEarlyAccess($data: ActivateEarlyAccessInput!) {
+    activateEarlyAccess(data: $data) {
+      ...LimitsPageSubscription
+    }
+  }
+  ${LimitsPageSubscriptionFragmentDoc}
+`
+export const CreateCheckoutDocument = gql`
+  mutation createCheckout($data: CreateCheckoutInput!) {
+    createCheckout(data: $data) {
+      checkoutUrl
+    }
+  }
+`
+export const CancelSubscriptionDocument = gql`
+  mutation cancelSubscription($data: CancelSubscriptionInput!) {
+    cancelSubscription(data: $data)
+  }
+`
+export const GetLimitsPageDataDocument = gql`
+  query getLimitsPageData($data: GetOrganizationInput!) {
+    configuration {
+      billing {
+        enabled
+      }
+    }
+    organization(data: $data) {
+      id
+      subscription {
+        ...LimitsPageSubscription
+      }
+      usage {
+        rowVersions {
+          ...UsageMetric
+        }
+        projects {
+          ...UsageMetric
+        }
+        seats {
+          ...UsageMetric
+        }
+        storageBytes {
+          ...UsageMetric
+        }
+      }
+    }
+  }
+  ${LimitsPageSubscriptionFragmentDoc}
+  ${UsageMetricFragmentDoc}
+`
+export const GetLimitsPagePlansDocument = gql`
+  query getLimitsPagePlans {
+    plans {
+      ...LimitsPagePlan
+    }
+  }
+  ${LimitsPagePlanFragmentDoc}
+`
+export const GetUsersOrganizationDocument = gql`
+  query getUsersOrganization($organizationId: String!, $first: Int!, $after: String) {
+    usersOrganization(data: { organizationId: $organizationId, first: $first, after: $after }) {
+      edges {
+        node {
+          ...UserOrganizationItem
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${UserOrganizationItemFragmentDoc}
+`
+export const AddUserToOrganizationDocument = gql`
+  mutation addUserToOrganization($organizationId: String!, $userId: String!, $roleId: UserOrganizationRoles!) {
+    addUserToOrganization(data: { organizationId: $organizationId, userId: $userId, roleId: $roleId })
+  }
+`
+export const RemoveUserFromOrganizationDocument = gql`
+  mutation removeUserFromOrganization($organizationId: String!, $userId: String!) {
+    removeUserFromOrganization(data: { organizationId: $organizationId, userId: $userId })
+  }
+`
+export const UpdateProjectDocument = gql`
+  mutation updateProject($data: UpdateProjectInput!) {
+    updateProject(data: $data)
+  }
+`
+export const DeleteProjectForSettingsDocument = gql`
+  mutation deleteProjectForSettings($data: DeleteProjectInput!) {
+    deleteProject(data: $data)
+  }
+`
+export const FetchTableForStackDocument = gql`
+  query fetchTableForStack($data: GetTableInput!) {
+    table(data: $data) {
+      ...TableStackFragment
+    }
+  }
+  ${TableStackFragmentFragmentDoc}
+`
+export const CreateTableForStackDocument = gql`
+  mutation createTableForStack($data: CreateTableInput!) {
+    createTable(data: $data) {
+      table {
+        ...TableStackFragment
+      }
+    }
+  }
+  ${TableStackFragmentFragmentDoc}
+`
+export const UpdateTableForStackDocument = gql`
+  mutation updateTableForStack($data: UpdateTableInput!) {
+    updateTable(data: $data) {
+      table {
+        ...TableStackFragment
+      }
+      previousVersionTableId
+    }
+  }
+  ${TableStackFragmentFragmentDoc}
+`
+export const RenameTableForStackDocument = gql`
+  mutation renameTableForStack($data: RenameTableInput!) {
+    renameTable(data: $data) {
+      table {
+        ...TableStackFragment
+      }
+      previousVersionTableId
+    }
+  }
+  ${TableStackFragmentFragmentDoc}
+`
+export const RowPageDataDocument = gql`
+  query rowPageData(
+    $rowData: GetRowInput!
+    $tableData: GetTableInput!
+    $foreignKeysData: GetRowCountForeignKeysByInput!
+  ) {
+    row(data: $rowData) {
+      id
+      data
+    }
+    table(data: $tableData) {
+      id
+      schema
+    }
+    getRowCountForeignKeysTo(data: $foreignKeysData)
+  }
+`
+export const SignUpDocument = gql`
+  mutation signUp($data: SignUpInput!) {
+    signUp(data: $data)
+  }
+`
+export const SetUsernameDocument = gql`
+  mutation setUsername($data: SetUsernameInput!) {
+    setUsername(data: $data)
+  }
+`
+export const GetUsersProjectDocument = gql`
+  query getUsersProject($organizationId: String!, $projectName: String!, $first: Int!, $after: String) {
+    usersProject(data: { organizationId: $organizationId, projectName: $projectName, first: $first, after: $after }) {
+      edges {
+        node {
+          ...UserProjectItem
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+  ${UserProjectItemFragmentDoc}
+`
+export const SearchUsersDocument = gql`
+  query searchUsers($search: String, $first: Int!, $after: String) {
+    searchUsers(data: { search: $search, first: $first, after: $after }) {
+      edges {
+        node {
+          id
+          email
+          username
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+`
+export const AddUserToProjectDocument = gql`
+  mutation addUserToProject(
+    $organizationId: String!
+    $projectName: String!
+    $userId: String!
+    $roleId: UserProjectRoles!
+  ) {
+    addUserToProject(
+      data: { organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId }
+    )
+  }
+`
+export const RemoveUserFromProjectDocument = gql`
+  mutation removeUserFromProject($organizationId: String!, $projectName: String!, $userId: String!) {
+    removeUserFromProject(data: { organizationId: $organizationId, projectName: $projectName, userId: $userId })
+  }
+`
+export const UpdateUserProjectRoleDocument = gql`
+  mutation updateUserProjectRole(
+    $organizationId: String!
+    $projectName: String!
+    $userId: String!
+    $roleId: UserProjectRoles!
+  ) {
+    updateUserProjectRole(
+      data: { organizationId: $organizationId, projectName: $projectName, userId: $userId, roleId: $roleId }
+    )
+  }
+`
+export const CreateUserDocument = gql`
+  mutation createUser($username: String!, $password: String!, $email: String, $roleId: UserSystemRole!) {
+    createUser(data: { username: $username, password: $password, email: $email, roleId: $roleId })
+  }
+`
+export const ConfigurationDocument = gql`
+  query configuration {
+    configuration {
+      availableEmailSignUp
+      noAuth
+      billing {
+        enabled
+      }
+      google {
+        available
+        clientId
+      }
+      github {
+        available
+        clientId
+      }
+      cache {
+        enabled
+      }
+      plugins {
+        file
+      }
+    }
+  }
+`
+export const GetMeDocument = gql`
+  query getMe {
+    me {
+      ...User
+    }
+  }
+  ${UserFragmentDoc}
+`
+export const GetProjectGraphDocument = gql`
+  query getProjectGraph($data: GetBranchesInput!) {
+    branches(data: $data) {
+      totalCount
+      edges {
+        node {
+          ...RevisionMapBranchFull
+        }
+      }
+    }
+  }
+  ${RevisionMapBranchFullFragmentDoc}
+`
+export const FindBranchesDocument = gql`
+  query findBranches($data: GetBranchesInput!) {
+    branches(data: $data) {
+      totalCount
+      pageInfo {
+        ...PageInfo
+      }
       edges {
         cursor
         node {
-          ...FindRevision
+          ...FindBranch
         }
       }
     }
   }
-}
-    ${FindRevisionFragmentDoc}`;
+  ${PageInfoFragmentDoc}
+  ${FindBranchFragmentDoc}
+`
+export const FindRevisionsDocument = gql`
+  query findRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
+    branch(data: $data) {
+      revisions(data: $revisionsData) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        edges {
+          cursor
+          node {
+            ...FindRevision
+          }
+        }
+      }
+    }
+  }
+  ${FindRevisionFragmentDoc}
+`
 export const MeProjectsListDocument = gql`
-    query meProjectsList($data: GetMeProjectsInput!) {
-  meProjects(data: $data) {
-    totalCount
-    pageInfo {
-      ...PageInfo
-    }
-    edges {
-      cursor
-      node {
-        ...MeProjectListItem
+  query meProjectsList($data: GetMeProjectsInput!) {
+    meProjects(data: $data) {
+      totalCount
+      pageInfo {
+        ...PageInfo
+      }
+      edges {
+        cursor
+        node {
+          ...MeProjectListItem
+        }
       }
     }
   }
-}
-    ${PageInfoFragmentDoc}
-${MeProjectListItemFragmentDoc}`;
+  ${PageInfoFragmentDoc}
+  ${MeProjectListItemFragmentDoc}
+`
 export const GetRowChangesDocument = gql`
-    query GetRowChanges($revisionId: String!, $first: Int!, $after: String, $filters: RowChangesFiltersInput) {
-  rowChanges(
-    data: {revisionId: $revisionId, first: $first, after: $after, filters: $filters}
-  ) {
-    edges {
-      node {
-        ... on AddedRowChangeModel {
-          changeType
-          row {
-            ...RowChangeRowFields
+  query GetRowChanges($revisionId: String!, $first: Int!, $after: String, $filters: RowChangesFiltersInput) {
+    rowChanges(data: { revisionId: $revisionId, first: $first, after: $after, filters: $filters }) {
+      edges {
+        node {
+          ... on AddedRowChangeModel {
+            changeType
+            row {
+              ...RowChangeRowFields
+            }
+            table {
+              ...RowChangeTableFields
+            }
+            fieldChanges {
+              ...FieldChangeFields
+            }
           }
-          table {
-            ...RowChangeTableFields
+          ... on RemovedRowChangeModel {
+            changeType
+            fromRow {
+              ...RowChangeRowFields
+            }
+            fromTable {
+              ...RowChangeTableFields
+            }
+            fieldChanges {
+              ...FieldChangeFields
+            }
           }
-          fieldChanges {
-            ...FieldChangeFields
+          ... on ModifiedRowChangeModel {
+            changeType
+            row {
+              ...RowChangeRowFields
+            }
+            fromRow {
+              ...RowChangeRowFields
+            }
+            table {
+              ...RowChangeTableFields
+            }
+            fromTable {
+              ...RowChangeTableFields
+            }
+            fieldChanges {
+              ...FieldChangeFields
+            }
           }
         }
-        ... on RemovedRowChangeModel {
-          changeType
-          fromRow {
-            ...RowChangeRowFields
-          }
-          fromTable {
-            ...RowChangeTableFields
-          }
-          fieldChanges {
-            ...FieldChangeFields
-          }
-        }
-        ... on ModifiedRowChangeModel {
-          changeType
-          row {
-            ...RowChangeRowFields
-          }
-          fromRow {
-            ...RowChangeRowFields
-          }
-          table {
-            ...RowChangeTableFields
-          }
-          fromTable {
-            ...RowChangeTableFields
-          }
-          fieldChanges {
-            ...FieldChangeFields
-          }
-        }
+        cursor
       }
-      cursor
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
     }
-    pageInfo {
-      hasNextPage
-      hasPreviousPage
-      startCursor
-      endCursor
-    }
-    totalCount
   }
-}
-    ${RowChangeRowFieldsFragmentDoc}
-${RowChangeTableFieldsFragmentDoc}
-${FieldChangeFieldsFragmentDoc}`;
+  ${RowChangeRowFieldsFragmentDoc}
+  ${RowChangeTableFieldsFragmentDoc}
+  ${FieldChangeFieldsFragmentDoc}
+`
 export const GetTableChangesForFilterDocument = gql`
-    query GetTableChangesForFilter($revisionId: String!) {
-  tableChanges(
-    data: {revisionId: $revisionId, first: 1000, filters: {includeSystem: true}}
-  ) {
-    edges {
-      node {
-        tableId
-        changeType
-        oldTableId
-        newTableId
-        rowChangesCount
+  query GetTableChangesForFilter($revisionId: String!) {
+    tableChanges(data: { revisionId: $revisionId, first: 1000, filters: { includeSystem: true } }) {
+      edges {
+        node {
+          tableId
+          changeType
+          oldTableId
+          newTableId
+          rowChangesCount
+        }
       }
     }
   }
-}
-    `;
+`
 export const ForeignKeyTableWithRowsDocument = gql`
-    query foreignKeyTableWithRows($tableData: GetTableInput!, $rowsData: GetRowsInput!) {
-  table(data: $tableData) {
-    ...ForeignKeyTableItem
-  }
-  rows(data: $rowsData) {
-    totalCount
-    pageInfo {
-      hasNextPage
-      endCursor
+  query foreignKeyTableWithRows($tableData: GetTableInput!, $rowsData: GetRowsInput!) {
+    table(data: $tableData) {
+      ...ForeignKeyTableItem
     }
-    edges {
-      node {
-        ...ForeignKeyRowItem
+    rows(data: $rowsData) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          ...ForeignKeyRowItem
+        }
       }
     }
   }
-}
-    ${ForeignKeyTableItemFragmentDoc}
-${ForeignKeyRowItemFragmentDoc}`;
+  ${ForeignKeyTableItemFragmentDoc}
+  ${ForeignKeyRowItemFragmentDoc}
+`
 export const CreateRowForStackDocument = gql`
-    mutation createRowForStack($data: CreateRowInput!) {
-  createRow(data: $data) {
-    table {
-      ...TableMutationItem
-    }
-    previousVersionTableId
-    row {
-      ...RowMutationItem
+  mutation createRowForStack($data: CreateRowInput!) {
+    createRow(data: $data) {
+      table {
+        ...TableMutationItem
+      }
+      previousVersionTableId
+      row {
+        ...RowMutationItem
+      }
     }
   }
-}
-    ${TableMutationItemFragmentDoc}
-${RowMutationItemFragmentDoc}`;
+  ${TableMutationItemFragmentDoc}
+  ${RowMutationItemFragmentDoc}
+`
 export const UpdateRowForStackDocument = gql`
-    mutation updateRowForStack($data: UpdateRowInput!) {
-  updateRow(data: $data) {
-    table {
-      ...TableMutationItem
+  mutation updateRowForStack($data: UpdateRowInput!) {
+    updateRow(data: $data) {
+      table {
+        ...TableMutationItem
+      }
+      previousVersionTableId
+      row {
+        ...RowMutationItem
+      }
+      previousVersionRowId
     }
-    previousVersionTableId
-    row {
-      ...RowMutationItem
-    }
-    previousVersionRowId
   }
-}
-    ${TableMutationItemFragmentDoc}
-${RowMutationItemFragmentDoc}`;
+  ${TableMutationItemFragmentDoc}
+  ${RowMutationItemFragmentDoc}
+`
 export const RenameRowForStackDocument = gql`
-    mutation renameRowForStack($data: RenameRowInput!) {
-  renameRow(data: $data) {
-    table {
-      ...TableMutationItem
+  mutation renameRowForStack($data: RenameRowInput!) {
+    renameRow(data: $data) {
+      table {
+        ...TableMutationItem
+      }
+      previousVersionTableId
+      row {
+        ...RowMutationItem
+      }
+      previousVersionRowId
     }
-    previousVersionTableId
-    row {
-      ...RowMutationItem
-    }
-    previousVersionRowId
   }
-}
-    ${TableMutationItemFragmentDoc}
-${RowMutationItemFragmentDoc}`;
+  ${TableMutationItemFragmentDoc}
+  ${RowMutationItemFragmentDoc}
+`
 export const RowListRowsDocument = gql`
-    query RowListRows($data: GetRowsInput!) {
-  rows(data: $data) {
-    totalCount
-    pageInfo {
-      hasNextPage
-      endCursor
+  query RowListRows($data: GetRowsInput!) {
+    rows(data: $data) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          ...RowListItem
+        }
+      }
     }
-    edges {
-      node {
+  }
+  ${RowListItemFragmentDoc}
+`
+export const DeleteRowDocument = gql`
+  mutation DeleteRow($data: DeleteRowInput!) {
+    deleteRow(data: $data) {
+      branch {
+        id
+      }
+    }
+  }
+`
+export const DeleteRowsDocument = gql`
+  mutation DeleteRows($data: DeleteRowsInput!) {
+    deleteRows(data: $data) {
+      branch {
+        id
+      }
+    }
+  }
+`
+export const PatchRowInlineDocument = gql`
+  mutation PatchRowInline($data: PatchRowInput!) {
+    patchRow(data: $data) {
+      row {
         ...RowListItem
       }
     }
   }
-}
-    ${RowListItemFragmentDoc}`;
-export const DeleteRowDocument = gql`
-    mutation DeleteRow($data: DeleteRowInput!) {
-  deleteRow(data: $data) {
-    branch {
-      id
-    }
-  }
-}
-    `;
-export const DeleteRowsDocument = gql`
-    mutation DeleteRows($data: DeleteRowsInput!) {
-  deleteRows(data: $data) {
-    branch {
-      id
-    }
-  }
-}
-    `;
-export const PatchRowInlineDocument = gql`
-    mutation PatchRowInline($data: PatchRowInput!) {
-  patchRow(data: $data) {
-    row {
-      ...RowListItem
-    }
-  }
-}
-    ${RowListItemFragmentDoc}`;
+  ${RowListItemFragmentDoc}
+`
 export const GetTableViewsDocument = gql`
-    query GetTableViews($data: GetTableInput!) {
-  table(data: $data) {
-    id
-    views {
+  query GetTableViews($data: GetTableInput!) {
+    table(data: $data) {
+      id
+      views {
+        ...TableViewsData
+      }
+    }
+  }
+  ${TableViewsDataFragmentDoc}
+`
+export const UpdateTableViewsDocument = gql`
+  mutation UpdateTableViews($data: UpdateTableViewsInput!) {
+    updateTableViews(data: $data) {
       ...TableViewsData
     }
   }
-}
-    ${TableViewsDataFragmentDoc}`;
-export const UpdateTableViewsDocument = gql`
-    mutation UpdateTableViews($data: UpdateTableViewsInput!) {
-  updateTableViews(data: $data) {
-    ...TableViewsData
-  }
-}
-    ${TableViewsDataFragmentDoc}`;
+  ${TableViewsDataFragmentDoc}
+`
 export const SearchRowsDocument = gql`
-    query searchRows($data: SearchRowsInput!) {
-  searchRows(data: $data) {
-    edges {
-      cursor
-      node {
-        ...SearchResult
+  query searchRows($data: SearchRowsInput!) {
+    searchRows(data: $data) {
+      edges {
+        cursor
+        node {
+          ...SearchResult
+        }
       }
+      totalCount
     }
-    totalCount
   }
-}
-    ${SearchResultFragmentDoc}`;
+  ${SearchResultFragmentDoc}
+`
 export const RevertChangesForSidebarDocument = gql`
-    mutation revertChangesForSidebar($data: RevertChangesInput!) {
-  revertChanges(data: $data) {
-    id
-  }
-}
-    `;
-export const CreateRevisionForSidebarDocument = gql`
-    mutation createRevisionForSidebar($data: CreateRevisionInput!) {
-  createRevision(data: $data) {
-    id
-  }
-}
-    `;
-export const CreateBranchForSidebarDocument = gql`
-    mutation createBranchForSidebar($data: CreateBranchInput!) {
-  createBranch(data: $data) {
-    id
-  }
-}
-    `;
-export const DeleteTableForListDocument = gql`
-    mutation deleteTableForList($data: DeleteTableInput!) {
-  deleteTable(data: $data) {
-    branch {
+  mutation revertChangesForSidebar($data: RevertChangesInput!) {
+    revertChanges(data: $data) {
       id
     }
   }
-}
-    `;
+`
+export const CreateRevisionForSidebarDocument = gql`
+  mutation createRevisionForSidebar($data: CreateRevisionInput!) {
+    createRevision(data: $data) {
+      id
+    }
+  }
+`
+export const CreateBranchForSidebarDocument = gql`
+  mutation createBranchForSidebar($data: CreateBranchInput!) {
+    createBranch(data: $data) {
+      id
+    }
+  }
+`
+export const DeleteTableForListDocument = gql`
+  mutation deleteTableForList($data: DeleteTableInput!) {
+    deleteTable(data: $data) {
+      branch {
+        id
+      }
+    }
+  }
+`
 export const TableListDataDocument = gql`
-    query tableListData($data: GetTablesInput!) {
-  tables(data: $data) {
-    totalCount
-    pageInfo {
-      hasNextPage
-      endCursor
-    }
-    edges {
-      node {
-        ...TableListItem
+  query tableListData($data: GetTablesInput!) {
+    tables(data: $data) {
+      totalCount
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          ...TableListItem
+        }
       }
     }
   }
-}
-    ${TableListItemFragmentDoc}`;
+  ${TableListItemFragmentDoc}
+`
 export const TableRelationsDataDocument = gql`
-    query tableRelationsData($data: GetTablesInput!) {
-  tables(data: $data) {
-    totalCount
-    edges {
-      node {
-        ...TableRelationsItem
+  query tableRelationsData($data: GetTablesInput!) {
+    tables(data: $data) {
+      totalCount
+      edges {
+        node {
+          ...TableRelationsItem
+        }
       }
     }
   }
-}
-    ${TableRelationsItemFragmentDoc}`;
+  ${TableRelationsItemFragmentDoc}
+`
 
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>
 
-
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action()
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    getBranchForLoader(variables: GetBranchForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchForLoaderQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchForLoaderQuery>(GetBranchForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchForLoader', 'query', variables);
+    getBranchForLoader(
+      variables: GetBranchForLoaderQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetBranchForLoaderQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetBranchForLoaderQuery>(GetBranchForLoaderDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getBranchForLoader',
+        'query',
+        variables,
+      )
     },
-    organizationProjects(variables: OrganizationProjectsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<OrganizationProjectsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<OrganizationProjectsQuery>(OrganizationProjectsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'organizationProjects', 'query', variables);
+    organizationProjects(
+      variables: OrganizationProjectsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<OrganizationProjectsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<OrganizationProjectsQuery>(OrganizationProjectsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'organizationProjects',
+        'query',
+        variables,
+      )
     },
-    getProject(variables: GetProjectQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectQuery>(GetProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProject', 'query', variables);
+    getProject(
+      variables: GetProjectQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetProjectQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetProjectQuery>(GetProjectDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getProject',
+        'query',
+        variables,
+      )
     },
-    getProjectForLoader(variables: GetProjectForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectForLoaderQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectForLoaderQuery>(GetProjectForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectForLoader', 'query', variables);
+    getProjectForLoader(
+      variables: GetProjectForLoaderQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetProjectForLoaderQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetProjectForLoaderQuery>(GetProjectForLoaderDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getProjectForLoader',
+        'query',
+        variables,
+      )
     },
-    getRevisionForLoader(variables: GetRevisionForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRevisionForLoaderQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetRevisionForLoaderQuery>(GetRevisionForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getRevisionForLoader', 'query', variables);
+    getRevisionForLoader(
+      variables: GetRevisionForLoaderQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetRevisionForLoaderQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetRevisionForLoaderQuery>(GetRevisionForLoaderDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getRevisionForLoader',
+        'query',
+        variables,
+      )
     },
-    getRowForLoader(variables: GetRowForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRowForLoaderQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetRowForLoaderQuery>(GetRowForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getRowForLoader', 'query', variables);
+    getRowForLoader(
+      variables: GetRowForLoaderQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetRowForLoaderQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetRowForLoaderQuery>(GetRowForLoaderDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getRowForLoader',
+        'query',
+        variables,
+      )
     },
-    getRowCountForeignKeysToForLoader(variables: GetRowCountForeignKeysToForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRowCountForeignKeysToForLoaderQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetRowCountForeignKeysToForLoaderQuery>(GetRowCountForeignKeysToForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getRowCountForeignKeysToForLoader', 'query', variables);
+    getRowCountForeignKeysToForLoader(
+      variables: GetRowCountForeignKeysToForLoaderQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetRowCountForeignKeysToForLoaderQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetRowCountForeignKeysToForLoaderQuery>(GetRowCountForeignKeysToForLoaderDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getRowCountForeignKeysToForLoader',
+        'query',
+        variables,
+      )
     },
-    ForeignKeysBy(variables: ForeignKeysByQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ForeignKeysByQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ForeignKeysByQuery>(ForeignKeysByDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'ForeignKeysBy', 'query', variables);
+    ForeignKeysBy(
+      variables: ForeignKeysByQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ForeignKeysByQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ForeignKeysByQuery>(ForeignKeysByDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'ForeignKeysBy',
+        'query',
+        variables,
+      )
     },
-    ForeignKeysByRows(variables: ForeignKeysByRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ForeignKeysByRowsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ForeignKeysByRowsQuery>(ForeignKeysByRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'ForeignKeysByRows', 'query', variables);
+    ForeignKeysByRows(
+      variables: ForeignKeysByRowsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ForeignKeysByRowsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ForeignKeysByRowsQuery>(ForeignKeysByRowsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'ForeignKeysByRows',
+        'query',
+        variables,
+      )
     },
-    getTableForLoader(variables: GetTableForLoaderQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableForLoaderQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetTableForLoaderQuery>(GetTableForLoaderDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getTableForLoader', 'query', variables);
+    getTableForLoader(
+      variables: GetTableForLoaderQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetTableForLoaderQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetTableForLoaderQuery>(GetTableForLoaderDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getTableForLoader',
+        'query',
+        variables,
+      )
     },
-    updatePassword(variables: UpdatePasswordMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdatePasswordMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdatePasswordMutation>(UpdatePasswordDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updatePassword', 'mutation', variables);
+    updatePassword(
+      variables: UpdatePasswordMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UpdatePasswordMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdatePasswordMutation>(UpdatePasswordDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'updatePassword',
+        'mutation',
+        variables,
+      )
     },
-    myApiKeys(variables?: MyApiKeysQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MyApiKeysQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<MyApiKeysQuery>(MyApiKeysDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'myApiKeys', 'query', variables);
+    myApiKeys(
+      variables?: MyApiKeysQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<MyApiKeysQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<MyApiKeysQuery>(MyApiKeysDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
+        'myApiKeys',
+        'query',
+        variables,
+      )
     },
-    serviceApiKeys(variables: ServiceApiKeysQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ServiceApiKeysQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ServiceApiKeysQuery>(ServiceApiKeysDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'serviceApiKeys', 'query', variables);
+    serviceApiKeys(
+      variables: ServiceApiKeysQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ServiceApiKeysQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ServiceApiKeysQuery>(ServiceApiKeysDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'serviceApiKeys',
+        'query',
+        variables,
+      )
     },
-    apiKeyById(variables: ApiKeyByIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ApiKeyByIdQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ApiKeyByIdQuery>(ApiKeyByIdDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'apiKeyById', 'query', variables);
+    apiKeyById(
+      variables: ApiKeyByIdQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ApiKeyByIdQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ApiKeyByIdQuery>(ApiKeyByIdDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'apiKeyById',
+        'query',
+        variables,
+      )
     },
-    createPersonalApiKey(variables: CreatePersonalApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreatePersonalApiKeyMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreatePersonalApiKeyMutation>(CreatePersonalApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createPersonalApiKey', 'mutation', variables);
+    createPersonalApiKey(
+      variables: CreatePersonalApiKeyMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreatePersonalApiKeyMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreatePersonalApiKeyMutation>(CreatePersonalApiKeyDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createPersonalApiKey',
+        'mutation',
+        variables,
+      )
     },
-    createServiceApiKey(variables: CreateServiceApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateServiceApiKeyMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateServiceApiKeyMutation>(CreateServiceApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createServiceApiKey', 'mutation', variables);
+    createServiceApiKey(
+      variables: CreateServiceApiKeyMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateServiceApiKeyMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateServiceApiKeyMutation>(CreateServiceApiKeyDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createServiceApiKey',
+        'mutation',
+        variables,
+      )
     },
-    revokeApiKey(variables: RevokeApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RevokeApiKeyMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RevokeApiKeyMutation>(RevokeApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'revokeApiKey', 'mutation', variables);
+    revokeApiKey(
+      variables: RevokeApiKeyMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RevokeApiKeyMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RevokeApiKeyMutation>(RevokeApiKeyDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'revokeApiKey',
+        'mutation',
+        variables,
+      )
     },
-    rotateApiKey(variables: RotateApiKeyMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RotateApiKeyMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RotateApiKeyMutation>(RotateApiKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'rotateApiKey', 'mutation', variables);
+    rotateApiKey(
+      variables: RotateApiKeyMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RotateApiKeyMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RotateApiKeyMutation>(RotateApiKeyDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'rotateApiKey',
+        'mutation',
+        variables,
+      )
     },
-    createProject(variables: CreateProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateProjectMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateProjectMutation>(CreateProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createProject', 'mutation', variables);
+    createProject(
+      variables: CreateProjectMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateProjectMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateProjectMutation>(CreateProjectDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createProject',
+        'mutation',
+        variables,
+      )
     },
-    findForeignKey(variables: FindForeignKeyQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FindForeignKeyQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<FindForeignKeyQuery>(FindForeignKeyDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'findForeignKey', 'query', variables);
+    findForeignKey(
+      variables: FindForeignKeyQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FindForeignKeyQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FindForeignKeyQuery>(FindForeignKeyDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'findForeignKey',
+        'query',
+        variables,
+      )
     },
-    AdminDashboardStats(variables: AdminDashboardStatsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminDashboardStatsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AdminDashboardStatsQuery>(AdminDashboardStatsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'AdminDashboardStats', 'query', variables);
+    adminCacheStats(
+      variables?: AdminCacheStatsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminCacheStatsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminCacheStatsQuery>(AdminCacheStatsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'adminCacheStats',
+        'query',
+        variables,
+      )
     },
-    adminGetUser(variables: AdminGetUserQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminGetUserQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AdminGetUserQuery>(AdminGetUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminGetUser', 'query', variables);
+    adminResetAllCache(
+      variables?: AdminResetAllCacheMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminResetAllCacheMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminResetAllCacheMutation>(AdminResetAllCacheDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'adminResetAllCache',
+        'mutation',
+        variables,
+      )
     },
-    adminResetPassword(variables: AdminResetPasswordMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminResetPasswordMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AdminResetPasswordMutation>(AdminResetPasswordDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminResetPassword', 'mutation', variables);
+    AdminDashboardStats(
+      variables: AdminDashboardStatsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminDashboardStatsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminDashboardStatsQuery>(AdminDashboardStatsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'AdminDashboardStats',
+        'query',
+        variables,
+      )
     },
-    adminUsers(variables: AdminUsersQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminUsersQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AdminUsersQuery>(AdminUsersDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminUsers', 'query', variables);
+    adminGetUser(
+      variables: AdminGetUserQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminGetUserQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminGetUserQuery>(AdminGetUserDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'adminGetUser',
+        'query',
+        variables,
+      )
     },
-    adminUser(variables: AdminUserQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AdminUserQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AdminUserQuery>(AdminUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'adminUser', 'query', variables);
+    adminResetPassword(
+      variables: AdminResetPasswordMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminResetPasswordMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminResetPasswordMutation>(AdminResetPasswordDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'adminResetPassword',
+        'mutation',
+        variables,
+      )
     },
-    assetsTablesData(variables: AssetsTablesDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetsTablesDataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AssetsTablesDataQuery>(AssetsTablesDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetsTablesData', 'query', variables);
+    adminUsers(
+      variables: AdminUsersQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminUsersQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminUsersQuery>(AdminUsersDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'adminUsers',
+        'query',
+        variables,
+      )
     },
-    assetsRowsData(variables: AssetsRowsDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AssetsRowsDataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AssetsRowsDataQuery>(AssetsRowsDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'assetsRowsData', 'query', variables);
+    adminUser(
+      variables: AdminUserQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminUserQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminUserQuery>(AdminUserDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
+        'adminUser',
+        'query',
+        variables,
+      )
     },
-    subSchemaItemsData(variables: SubSchemaItemsDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SubSchemaItemsDataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SubSchemaItemsDataQuery>(SubSchemaItemsDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'subSchemaItemsData', 'query', variables);
+    assetsTablesData(
+      variables: AssetsTablesDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AssetsTablesDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AssetsTablesDataQuery>(AssetsTablesDataDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'assetsTablesData',
+        'query',
+        variables,
+      )
     },
-    getProjectBranches(variables: GetProjectBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectBranchesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectBranchesQuery>(GetProjectBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectBranches', 'query', variables);
+    assetsRowsData(
+      variables: AssetsRowsDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AssetsRowsDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AssetsRowsDataQuery>(AssetsRowsDataDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'assetsRowsData',
+        'query',
+        variables,
+      )
     },
-    deleteBranch(variables: DeleteBranchMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteBranchMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeleteBranchMutation>(DeleteBranchDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteBranch', 'mutation', variables);
+    subSchemaItemsData(
+      variables: SubSchemaItemsDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<SubSchemaItemsDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<SubSchemaItemsDataQuery>(SubSchemaItemsDataDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'subSchemaItemsData',
+        'query',
+        variables,
+      )
     },
-    getBranchesForSelect(variables: GetBranchesForSelectQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchesForSelectQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchesForSelectQuery>(GetBranchesForSelectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchesForSelect', 'query', variables);
+    getProjectBranches(
+      variables: GetProjectBranchesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetProjectBranchesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetProjectBranchesQuery>(GetProjectBranchesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getProjectBranches',
+        'query',
+        variables,
+      )
     },
-    getBranchRevisionsForCreate(variables: GetBranchRevisionsForCreateQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchRevisionsForCreateQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchRevisionsForCreateQuery>(GetBranchRevisionsForCreateDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchRevisionsForCreate', 'query', variables);
+    deleteBranch(
+      variables: DeleteBranchMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<DeleteBranchMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteBranchMutation>(DeleteBranchDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'deleteBranch',
+        'mutation',
+        variables,
+      )
     },
-    createBranch(variables: CreateBranchMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateBranchMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateBranchMutation>(CreateBranchDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createBranch', 'mutation', variables);
+    getBranchesForSelect(
+      variables: GetBranchesForSelectQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetBranchesForSelectQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetBranchesForSelectQuery>(GetBranchesForSelectDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getBranchesForSelect',
+        'query',
+        variables,
+      )
     },
-    GetRevisionChanges(variables: GetRevisionChangesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRevisionChangesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetRevisionChangesQuery>(GetRevisionChangesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetRevisionChanges', 'query', variables);
+    getBranchRevisionsForCreate(
+      variables: GetBranchRevisionsForCreateQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetBranchRevisionsForCreateQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetBranchRevisionsForCreateQuery>(GetBranchRevisionsForCreateDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getBranchRevisionsForCreate',
+        'query',
+        variables,
+      )
     },
-    GetTableChanges(variables: GetTableChangesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableChangesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetTableChangesQuery>(GetTableChangesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTableChanges', 'query', variables);
+    createBranch(
+      variables: CreateBranchMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateBranchMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateBranchMutation>(CreateBranchDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createBranch',
+        'mutation',
+        variables,
+      )
     },
-    confirmEmailCode(variables: ConfirmEmailCodeMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ConfirmEmailCodeMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ConfirmEmailCodeMutation>(ConfirmEmailCodeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'confirmEmailCode', 'mutation', variables);
+    GetRevisionChanges(
+      variables: GetRevisionChangesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetRevisionChangesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetRevisionChangesQuery>(GetRevisionChangesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'GetRevisionChanges',
+        'query',
+        variables,
+      )
     },
-    getEndpointBranches(variables: GetEndpointBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetEndpointBranchesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetEndpointBranchesQuery>(GetEndpointBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getEndpointBranches', 'query', variables);
+    GetTableChanges(
+      variables: GetTableChangesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetTableChangesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetTableChangesQuery>(GetTableChangesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'GetTableChanges',
+        'query',
+        variables,
+      )
     },
-    getProjectEndpoints(variables: GetProjectEndpointsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectEndpointsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectEndpointsQuery>(GetProjectEndpointsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectEndpoints', 'query', variables);
+    confirmEmailCode(
+      variables: ConfirmEmailCodeMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ConfirmEmailCodeMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ConfirmEmailCodeMutation>(ConfirmEmailCodeDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'confirmEmailCode',
+        'mutation',
+        variables,
+      )
     },
-    getBranchRevisions(variables: GetBranchRevisionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchRevisionsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchRevisionsQuery>(GetBranchRevisionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchRevisions', 'query', variables);
+    getEndpointBranches(
+      variables: GetEndpointBranchesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetEndpointBranchesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetEndpointBranchesQuery>(GetEndpointBranchesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getEndpointBranches',
+        'query',
+        variables,
+      )
     },
-    createEndpoint(variables: CreateEndpointMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateEndpointMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateEndpointMutation>(CreateEndpointDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createEndpoint', 'mutation', variables);
+    getProjectEndpoints(
+      variables: GetProjectEndpointsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetProjectEndpointsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetProjectEndpointsQuery>(GetProjectEndpointsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getProjectEndpoints',
+        'query',
+        variables,
+      )
     },
-    deleteEndpoint(variables: DeleteEndpointMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteEndpointMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeleteEndpointMutation>(DeleteEndpointDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteEndpoint', 'mutation', variables);
+    getBranchRevisions(
+      variables: GetBranchRevisionsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetBranchRevisionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetBranchRevisionsQuery>(GetBranchRevisionsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getBranchRevisions',
+        'query',
+        variables,
+      )
     },
-    loginGithub(variables: LoginGithubMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<LoginGithubMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<LoginGithubMutation>(LoginGithubDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'loginGithub', 'mutation', variables);
+    createEndpoint(
+      variables: CreateEndpointMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateEndpointMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateEndpointMutation>(CreateEndpointDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createEndpoint',
+        'mutation',
+        variables,
+      )
     },
-    loginGoogle(variables: LoginGoogleMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<LoginGoogleMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<LoginGoogleMutation>(LoginGoogleDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'loginGoogle', 'mutation', variables);
+    deleteEndpoint(
+      variables: DeleteEndpointMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<DeleteEndpointMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteEndpointMutation>(DeleteEndpointDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'deleteEndpoint',
+        'mutation',
+        variables,
+      )
+    },
+    loginGithub(
+      variables: LoginGithubMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<LoginGithubMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<LoginGithubMutation>(LoginGithubDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'loginGithub',
+        'mutation',
+        variables,
+      )
+    },
+    loginGoogle(
+      variables: LoginGoogleMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<LoginGoogleMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<LoginGoogleMutation>(LoginGoogleDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'loginGoogle',
+        'mutation',
+        variables,
+      )
     },
     login(variables: LoginMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<LoginMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<LoginMutation>(LoginDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'login', 'mutation', variables);
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<LoginMutation>(LoginDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
+        'login',
+        'mutation',
+        variables,
+      )
     },
-    getMigrationBranches(variables: GetMigrationBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetMigrationBranchesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetMigrationBranchesQuery>(GetMigrationBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getMigrationBranches', 'query', variables);
+    getMigrationBranches(
+      variables: GetMigrationBranchesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetMigrationBranchesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetMigrationBranchesQuery>(GetMigrationBranchesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getMigrationBranches',
+        'query',
+        variables,
+      )
     },
-    getBranchMigrations(variables: GetBranchMigrationsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetBranchMigrationsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetBranchMigrationsQuery>(GetBranchMigrationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getBranchMigrations', 'query', variables);
+    getBranchMigrations(
+      variables: GetBranchMigrationsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetBranchMigrationsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetBranchMigrationsQuery>(GetBranchMigrationsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getBranchMigrations',
+        'query',
+        variables,
+      )
     },
-    applyMigrations(variables: ApplyMigrationsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ApplyMigrationsMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ApplyMigrationsMutation>(ApplyMigrationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'applyMigrations', 'mutation', variables);
+    applyMigrations(
+      variables: ApplyMigrationsMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ApplyMigrationsMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ApplyMigrationsMutation>(ApplyMigrationsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'applyMigrations',
+        'mutation',
+        variables,
+      )
     },
-    getMigrations(variables: GetMigrationsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetMigrationsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetMigrationsQuery>(GetMigrationsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getMigrations', 'query', variables);
+    getMigrations(
+      variables: GetMigrationsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetMigrationsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetMigrationsQuery>(GetMigrationsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getMigrations',
+        'query',
+        variables,
+      )
     },
-    activateEarlyAccess(variables: ActivateEarlyAccessMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ActivateEarlyAccessMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ActivateEarlyAccessMutation>(ActivateEarlyAccessDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'activateEarlyAccess', 'mutation', variables);
+    activateEarlyAccess(
+      variables: ActivateEarlyAccessMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ActivateEarlyAccessMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ActivateEarlyAccessMutation>(ActivateEarlyAccessDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'activateEarlyAccess',
+        'mutation',
+        variables,
+      )
     },
-    createCheckout(variables: CreateCheckoutMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateCheckoutMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateCheckoutMutation>(CreateCheckoutDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createCheckout', 'mutation', variables);
+    createCheckout(
+      variables: CreateCheckoutMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateCheckoutMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateCheckoutMutation>(CreateCheckoutDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createCheckout',
+        'mutation',
+        variables,
+      )
     },
-    cancelSubscription(variables: CancelSubscriptionMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CancelSubscriptionMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CancelSubscriptionMutation>(CancelSubscriptionDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'cancelSubscription', 'mutation', variables);
+    cancelSubscription(
+      variables: CancelSubscriptionMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CancelSubscriptionMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CancelSubscriptionMutation>(CancelSubscriptionDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'cancelSubscription',
+        'mutation',
+        variables,
+      )
     },
-    getLimitsPageData(variables: GetLimitsPageDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetLimitsPageDataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetLimitsPageDataQuery>(GetLimitsPageDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getLimitsPageData', 'query', variables);
+    getLimitsPageData(
+      variables: GetLimitsPageDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetLimitsPageDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetLimitsPageDataQuery>(GetLimitsPageDataDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getLimitsPageData',
+        'query',
+        variables,
+      )
     },
-    getLimitsPagePlans(variables?: GetLimitsPagePlansQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetLimitsPagePlansQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetLimitsPagePlansQuery>(GetLimitsPagePlansDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getLimitsPagePlans', 'query', variables);
+    getLimitsPagePlans(
+      variables?: GetLimitsPagePlansQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetLimitsPagePlansQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetLimitsPagePlansQuery>(GetLimitsPagePlansDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getLimitsPagePlans',
+        'query',
+        variables,
+      )
     },
-    getUsersOrganization(variables: GetUsersOrganizationQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetUsersOrganizationQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetUsersOrganizationQuery>(GetUsersOrganizationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUsersOrganization', 'query', variables);
+    getUsersOrganization(
+      variables: GetUsersOrganizationQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetUsersOrganizationQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetUsersOrganizationQuery>(GetUsersOrganizationDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getUsersOrganization',
+        'query',
+        variables,
+      )
     },
-    addUserToOrganization(variables: AddUserToOrganizationMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AddUserToOrganizationMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AddUserToOrganizationMutation>(AddUserToOrganizationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'addUserToOrganization', 'mutation', variables);
+    addUserToOrganization(
+      variables: AddUserToOrganizationMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AddUserToOrganizationMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AddUserToOrganizationMutation>(AddUserToOrganizationDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'addUserToOrganization',
+        'mutation',
+        variables,
+      )
     },
-    removeUserFromOrganization(variables: RemoveUserFromOrganizationMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RemoveUserFromOrganizationMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RemoveUserFromOrganizationMutation>(RemoveUserFromOrganizationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'removeUserFromOrganization', 'mutation', variables);
+    removeUserFromOrganization(
+      variables: RemoveUserFromOrganizationMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RemoveUserFromOrganizationMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RemoveUserFromOrganizationMutation>(RemoveUserFromOrganizationDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'removeUserFromOrganization',
+        'mutation',
+        variables,
+      )
     },
-    updateProject(variables: UpdateProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateProjectMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateProjectMutation>(UpdateProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateProject', 'mutation', variables);
+    updateProject(
+      variables: UpdateProjectMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UpdateProjectMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateProjectMutation>(UpdateProjectDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'updateProject',
+        'mutation',
+        variables,
+      )
     },
-    deleteProjectForSettings(variables: DeleteProjectForSettingsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteProjectForSettingsMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeleteProjectForSettingsMutation>(DeleteProjectForSettingsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteProjectForSettings', 'mutation', variables);
+    deleteProjectForSettings(
+      variables: DeleteProjectForSettingsMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<DeleteProjectForSettingsMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteProjectForSettingsMutation>(DeleteProjectForSettingsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'deleteProjectForSettings',
+        'mutation',
+        variables,
+      )
     },
-    fetchTableForStack(variables: FetchTableForStackQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FetchTableForStackQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<FetchTableForStackQuery>(FetchTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'fetchTableForStack', 'query', variables);
+    fetchTableForStack(
+      variables: FetchTableForStackQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FetchTableForStackQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FetchTableForStackQuery>(FetchTableForStackDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'fetchTableForStack',
+        'query',
+        variables,
+      )
     },
-    createTableForStack(variables: CreateTableForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateTableForStackMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateTableForStackMutation>(CreateTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createTableForStack', 'mutation', variables);
+    createTableForStack(
+      variables: CreateTableForStackMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateTableForStackMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateTableForStackMutation>(CreateTableForStackDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createTableForStack',
+        'mutation',
+        variables,
+      )
     },
-    updateTableForStack(variables: UpdateTableForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateTableForStackMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateTableForStackMutation>(UpdateTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateTableForStack', 'mutation', variables);
+    updateTableForStack(
+      variables: UpdateTableForStackMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UpdateTableForStackMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateTableForStackMutation>(UpdateTableForStackDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'updateTableForStack',
+        'mutation',
+        variables,
+      )
     },
-    renameTableForStack(variables: RenameTableForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RenameTableForStackMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RenameTableForStackMutation>(RenameTableForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'renameTableForStack', 'mutation', variables);
+    renameTableForStack(
+      variables: RenameTableForStackMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RenameTableForStackMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RenameTableForStackMutation>(RenameTableForStackDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'renameTableForStack',
+        'mutation',
+        variables,
+      )
     },
-    rowPageData(variables: RowPageDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RowPageDataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RowPageDataQuery>(RowPageDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'rowPageData', 'query', variables);
+    rowPageData(
+      variables: RowPageDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RowPageDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RowPageDataQuery>(RowPageDataDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'rowPageData',
+        'query',
+        variables,
+      )
     },
     signUp(variables: SignUpMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SignUpMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SignUpMutation>(SignUpDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'signUp', 'mutation', variables);
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<SignUpMutation>(SignUpDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
+        'signUp',
+        'mutation',
+        variables,
+      )
     },
-    setUsername(variables: SetUsernameMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SetUsernameMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SetUsernameMutation>(SetUsernameDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'setUsername', 'mutation', variables);
+    setUsername(
+      variables: SetUsernameMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<SetUsernameMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<SetUsernameMutation>(SetUsernameDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'setUsername',
+        'mutation',
+        variables,
+      )
     },
-    getUsersProject(variables: GetUsersProjectQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetUsersProjectQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetUsersProjectQuery>(GetUsersProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUsersProject', 'query', variables);
+    getUsersProject(
+      variables: GetUsersProjectQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetUsersProjectQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetUsersProjectQuery>(GetUsersProjectDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getUsersProject',
+        'query',
+        variables,
+      )
     },
-    searchUsers(variables: SearchUsersQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SearchUsersQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SearchUsersQuery>(SearchUsersDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'searchUsers', 'query', variables);
+    searchUsers(
+      variables: SearchUsersQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<SearchUsersQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<SearchUsersQuery>(SearchUsersDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'searchUsers',
+        'query',
+        variables,
+      )
     },
-    addUserToProject(variables: AddUserToProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<AddUserToProjectMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AddUserToProjectMutation>(AddUserToProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'addUserToProject', 'mutation', variables);
+    addUserToProject(
+      variables: AddUserToProjectMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AddUserToProjectMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AddUserToProjectMutation>(AddUserToProjectDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'addUserToProject',
+        'mutation',
+        variables,
+      )
     },
-    removeUserFromProject(variables: RemoveUserFromProjectMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RemoveUserFromProjectMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RemoveUserFromProjectMutation>(RemoveUserFromProjectDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'removeUserFromProject', 'mutation', variables);
+    removeUserFromProject(
+      variables: RemoveUserFromProjectMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RemoveUserFromProjectMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RemoveUserFromProjectMutation>(RemoveUserFromProjectDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'removeUserFromProject',
+        'mutation',
+        variables,
+      )
     },
-    updateUserProjectRole(variables: UpdateUserProjectRoleMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateUserProjectRoleMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateUserProjectRoleMutation>(UpdateUserProjectRoleDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateUserProjectRole', 'mutation', variables);
+    updateUserProjectRole(
+      variables: UpdateUserProjectRoleMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UpdateUserProjectRoleMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateUserProjectRoleMutation>(UpdateUserProjectRoleDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'updateUserProjectRole',
+        'mutation',
+        variables,
+      )
     },
-    createUser(variables: CreateUserMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateUserMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateUserMutation>(CreateUserDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createUser', 'mutation', variables);
+    createUser(
+      variables: CreateUserMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateUserMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateUserMutation>(CreateUserDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createUser',
+        'mutation',
+        variables,
+      )
     },
-    configuration(variables?: ConfigurationQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ConfigurationQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ConfigurationQuery>(ConfigurationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'configuration', 'query', variables);
+    configuration(
+      variables?: ConfigurationQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ConfigurationQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ConfigurationQuery>(ConfigurationDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'configuration',
+        'query',
+        variables,
+      )
     },
     getMe(variables?: GetMeQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetMeQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetMeQuery>(GetMeDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getMe', 'query', variables);
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetMeQuery>(GetMeDocument, variables, { ...requestHeaders, ...wrappedRequestHeaders }),
+        'getMe',
+        'query',
+        variables,
+      )
     },
-    getProjectGraph(variables: GetProjectGraphQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetProjectGraphQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetProjectGraphQuery>(GetProjectGraphDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getProjectGraph', 'query', variables);
+    getProjectGraph(
+      variables: GetProjectGraphQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetProjectGraphQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetProjectGraphQuery>(GetProjectGraphDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'getProjectGraph',
+        'query',
+        variables,
+      )
     },
-    findBranches(variables: FindBranchesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FindBranchesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<FindBranchesQuery>(FindBranchesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'findBranches', 'query', variables);
+    findBranches(
+      variables: FindBranchesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FindBranchesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FindBranchesQuery>(FindBranchesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'findBranches',
+        'query',
+        variables,
+      )
     },
-    findRevisions(variables: FindRevisionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<FindRevisionsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<FindRevisionsQuery>(FindRevisionsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'findRevisions', 'query', variables);
+    findRevisions(
+      variables: FindRevisionsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FindRevisionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FindRevisionsQuery>(FindRevisionsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'findRevisions',
+        'query',
+        variables,
+      )
     },
-    meProjectsList(variables: MeProjectsListQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<MeProjectsListQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<MeProjectsListQuery>(MeProjectsListDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'meProjectsList', 'query', variables);
+    meProjectsList(
+      variables: MeProjectsListQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<MeProjectsListQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<MeProjectsListQuery>(MeProjectsListDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'meProjectsList',
+        'query',
+        variables,
+      )
     },
-    GetRowChanges(variables: GetRowChangesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetRowChangesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetRowChangesQuery>(GetRowChangesDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetRowChanges', 'query', variables);
+    GetRowChanges(
+      variables: GetRowChangesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetRowChangesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetRowChangesQuery>(GetRowChangesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'GetRowChanges',
+        'query',
+        variables,
+      )
     },
-    GetTableChangesForFilter(variables: GetTableChangesForFilterQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableChangesForFilterQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetTableChangesForFilterQuery>(GetTableChangesForFilterDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTableChangesForFilter', 'query', variables);
+    GetTableChangesForFilter(
+      variables: GetTableChangesForFilterQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetTableChangesForFilterQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetTableChangesForFilterQuery>(GetTableChangesForFilterDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'GetTableChangesForFilter',
+        'query',
+        variables,
+      )
     },
-    foreignKeyTableWithRows(variables: ForeignKeyTableWithRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<ForeignKeyTableWithRowsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ForeignKeyTableWithRowsQuery>(ForeignKeyTableWithRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'foreignKeyTableWithRows', 'query', variables);
+    foreignKeyTableWithRows(
+      variables: ForeignKeyTableWithRowsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<ForeignKeyTableWithRowsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ForeignKeyTableWithRowsQuery>(ForeignKeyTableWithRowsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'foreignKeyTableWithRows',
+        'query',
+        variables,
+      )
     },
-    createRowForStack(variables: CreateRowForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateRowForStackMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateRowForStackMutation>(CreateRowForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createRowForStack', 'mutation', variables);
+    createRowForStack(
+      variables: CreateRowForStackMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateRowForStackMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateRowForStackMutation>(CreateRowForStackDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createRowForStack',
+        'mutation',
+        variables,
+      )
     },
-    updateRowForStack(variables: UpdateRowForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateRowForStackMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateRowForStackMutation>(UpdateRowForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'updateRowForStack', 'mutation', variables);
+    updateRowForStack(
+      variables: UpdateRowForStackMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UpdateRowForStackMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateRowForStackMutation>(UpdateRowForStackDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'updateRowForStack',
+        'mutation',
+        variables,
+      )
     },
-    renameRowForStack(variables: RenameRowForStackMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RenameRowForStackMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RenameRowForStackMutation>(RenameRowForStackDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'renameRowForStack', 'mutation', variables);
+    renameRowForStack(
+      variables: RenameRowForStackMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RenameRowForStackMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RenameRowForStackMutation>(RenameRowForStackDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'renameRowForStack',
+        'mutation',
+        variables,
+      )
     },
-    RowListRows(variables: RowListRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RowListRowsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RowListRowsQuery>(RowListRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'RowListRows', 'query', variables);
+    RowListRows(
+      variables: RowListRowsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RowListRowsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RowListRowsQuery>(RowListRowsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'RowListRows',
+        'query',
+        variables,
+      )
     },
-    DeleteRow(variables: DeleteRowMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteRowMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeleteRowMutation>(DeleteRowDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'DeleteRow', 'mutation', variables);
+    DeleteRow(
+      variables: DeleteRowMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<DeleteRowMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteRowMutation>(DeleteRowDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'DeleteRow',
+        'mutation',
+        variables,
+      )
     },
-    DeleteRows(variables: DeleteRowsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteRowsMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeleteRowsMutation>(DeleteRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'DeleteRows', 'mutation', variables);
+    DeleteRows(
+      variables: DeleteRowsMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<DeleteRowsMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteRowsMutation>(DeleteRowsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'DeleteRows',
+        'mutation',
+        variables,
+      )
     },
-    PatchRowInline(variables: PatchRowInlineMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<PatchRowInlineMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PatchRowInlineMutation>(PatchRowInlineDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PatchRowInline', 'mutation', variables);
+    PatchRowInline(
+      variables: PatchRowInlineMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<PatchRowInlineMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PatchRowInlineMutation>(PatchRowInlineDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'PatchRowInline',
+        'mutation',
+        variables,
+      )
     },
-    GetTableViews(variables: GetTableViewsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetTableViewsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<GetTableViewsQuery>(GetTableViewsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetTableViews', 'query', variables);
+    GetTableViews(
+      variables: GetTableViewsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<GetTableViewsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetTableViewsQuery>(GetTableViewsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'GetTableViews',
+        'query',
+        variables,
+      )
     },
-    UpdateTableViews(variables: UpdateTableViewsMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpdateTableViewsMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<UpdateTableViewsMutation>(UpdateTableViewsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'UpdateTableViews', 'mutation', variables);
+    UpdateTableViews(
+      variables: UpdateTableViewsMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<UpdateTableViewsMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<UpdateTableViewsMutation>(UpdateTableViewsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'UpdateTableViews',
+        'mutation',
+        variables,
+      )
     },
-    searchRows(variables: SearchRowsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<SearchRowsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SearchRowsQuery>(SearchRowsDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'searchRows', 'query', variables);
+    searchRows(
+      variables: SearchRowsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<SearchRowsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<SearchRowsQuery>(SearchRowsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'searchRows',
+        'query',
+        variables,
+      )
     },
-    revertChangesForSidebar(variables: RevertChangesForSidebarMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<RevertChangesForSidebarMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<RevertChangesForSidebarMutation>(RevertChangesForSidebarDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'revertChangesForSidebar', 'mutation', variables);
+    revertChangesForSidebar(
+      variables: RevertChangesForSidebarMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<RevertChangesForSidebarMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<RevertChangesForSidebarMutation>(RevertChangesForSidebarDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'revertChangesForSidebar',
+        'mutation',
+        variables,
+      )
     },
-    createRevisionForSidebar(variables: CreateRevisionForSidebarMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateRevisionForSidebarMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateRevisionForSidebarMutation>(CreateRevisionForSidebarDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createRevisionForSidebar', 'mutation', variables);
+    createRevisionForSidebar(
+      variables: CreateRevisionForSidebarMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateRevisionForSidebarMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateRevisionForSidebarMutation>(CreateRevisionForSidebarDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createRevisionForSidebar',
+        'mutation',
+        variables,
+      )
     },
-    createBranchForSidebar(variables: CreateBranchForSidebarMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<CreateBranchForSidebarMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<CreateBranchForSidebarMutation>(CreateBranchForSidebarDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'createBranchForSidebar', 'mutation', variables);
+    createBranchForSidebar(
+      variables: CreateBranchForSidebarMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<CreateBranchForSidebarMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<CreateBranchForSidebarMutation>(CreateBranchForSidebarDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'createBranchForSidebar',
+        'mutation',
+        variables,
+      )
     },
-    deleteTableForList(variables: DeleteTableForListMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<DeleteTableForListMutation> {
-      return withWrapper((wrappedRequestHeaders) => client.request<DeleteTableForListMutation>(DeleteTableForListDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'deleteTableForList', 'mutation', variables);
+    deleteTableForList(
+      variables: DeleteTableForListMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<DeleteTableForListMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteTableForListMutation>(DeleteTableForListDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'deleteTableForList',
+        'mutation',
+        variables,
+      )
     },
-    tableListData(variables: TableListDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<TableListDataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<TableListDataQuery>(TableListDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'tableListData', 'query', variables);
+    tableListData(
+      variables: TableListDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<TableListDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<TableListDataQuery>(TableListDataDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'tableListData',
+        'query',
+        variables,
+      )
     },
-    tableRelationsData(variables: TableRelationsDataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<TableRelationsDataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<TableRelationsDataQuery>(TableRelationsDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'tableRelationsData', 'query', variables);
-    }
-  };
+    tableRelationsData(
+      variables: TableRelationsDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<TableRelationsDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<TableRelationsDataQuery>(TableRelationsDataDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'tableRelationsData',
+        'query',
+        variables,
+      )
+    },
+  }
 }
-export type Sdk = ReturnType<typeof getSdk>;
+export type Sdk = ReturnType<typeof getSdk>

--- a/src/__generated__/schema.graphql
+++ b/src/__generated__/schema.graphql
@@ -73,7 +73,9 @@ type ApplyMigrationResultModel {
   status: ApplyMigrationStatus!
 }
 
-"""Status of migration application"""
+"""
+Status of migration application
+"""
 enum ApplyMigrationStatus {
   applied
   failed
@@ -128,6 +130,30 @@ type BranchesConnection {
   totalCount: Int!
 }
 
+type CacheConfigModel {
+  enabled: Boolean!
+}
+
+type CacheMetricModel {
+  deletes: Int!
+  hitRate: Float!
+  hits: Int!
+  key: String!
+  misses: Int!
+  writes: Int!
+}
+
+type CacheStatsModel {
+  byKey: [CacheMetricModel!]!
+  enabled: Boolean!
+  overallHitRate: Float!
+  totalClears: Int!
+  totalDeletes: Int!
+  totalHits: Int!
+  totalMisses: Int!
+  totalWrites: Int!
+}
+
 input CancelSubscriptionInput {
   cancelAtPeriodEnd: Boolean
   organizationId: ID!
@@ -165,6 +191,7 @@ type ChildBranchModel {
 type ConfigurationModel {
   availableEmailSignUp: Boolean!
   billing: BillingConfigurationModel!
+  cache: CacheConfigModel!
   github: GithubOauth!
   google: GoogleOauth!
   noAuth: Boolean!
@@ -396,7 +423,9 @@ input GetBranchRevisionsInput {
   comment: String
   first: Int!
   inclusive: Boolean
-  """Sort order: asc (default) or desc"""
+  """
+  Sort order: asc (default) or desc
+  """
   sort: SortOrder
 }
 
@@ -585,7 +614,9 @@ input JsonFilter {
   path: [String!]
   search: String
   searchIn: SearchIn
-  """Default: simple"""
+  """
+  Default: simple
+  """
   searchLanguage: SearchLanguage
   searchType: SearchType
   string_contains: String
@@ -656,6 +687,7 @@ type Mutation {
   activateEarlyAccess(data: ActivateEarlyAccessInput!): SubscriptionModel!
   addUserToOrganization(data: AddUserToOrganizationInput!): Boolean!
   addUserToProject(data: AddUserToProjectInput!): Boolean!
+  adminResetAllCache: Boolean!
   applyMigrations(data: ApplyMigrationsInput!): [ApplyMigrationResultModel!]!
   cancelSubscription(data: CancelSubscriptionInput!): Boolean!
   confirmEmailCode(data: ConfirmEmailCodeInput!): LoginModel!
@@ -861,6 +893,7 @@ type ProjectsConnection {
 }
 
 type Query {
+  adminCacheStats: CacheStatsModel!
   adminUser(data: AdminUserInput!): UserModel
   adminUsers(data: SearchUsersInput!): UsersConnection!
   apiKeyById(id: ID!): ApiKeyModel!
@@ -868,7 +901,8 @@ type Query {
   branch(data: GetBranchInput!): BranchModel!
   branches(data: GetBranchesInput!): BranchesConnection!
   configuration: ConfigurationModel!
-  getRowCountForeignKeysTo(data: GetRowCountForeignKeysByInput!): Int! @deprecated(reason: "use RowModel.rowForeignKeysBy.totalCount")
+  getRowCountForeignKeysTo(data: GetRowCountForeignKeysByInput!): Int!
+    @deprecated(reason: "use RowModel.rowForeignKeysBy.totalCount")
   me: MeModel!
   meProjects(data: GetMeProjectsInput!): ProjectsConnection!
   myApiKeys: [ApiKeyModel!]!
@@ -1110,7 +1144,9 @@ enum SearchIn {
   values
 }
 
-"""Language for full-text search. Default: simple"""
+"""
+Language for full-text search. Default: simple
+"""
 enum SearchLanguage {
   arabic
   armenian

--- a/src/app/config/rootRoutes.tsx
+++ b/src/app/config/rootRoutes.tsx
@@ -6,6 +6,7 @@ import { checkGuest } from 'src/app/lib/checkGuest.ts'
 import { checkSignUp } from 'src/app/lib/checkSignUp.ts'
 import { composeLoaders } from 'src/app/lib/composeLoaders.ts'
 import { mainPageLoader } from 'src/app/lib/mainPageLoader.ts'
+import { AdminCachePage } from 'src/pages/AdminCachePage'
 import { AdminDashboardPage } from 'src/pages/AdminDashboardPage'
 import { AdminLayout } from 'src/pages/AdminLayout'
 import { AdminOrganizationsPage } from 'src/pages/AdminOrganizationsPage'
@@ -47,6 +48,7 @@ import { TablePage } from 'src/pages/TablePage'
 import { UsernamePage } from 'src/pages/UsernamePage'
 import { AssetsPage } from 'src/pages/AssetsPage'
 import {
+  ADMIN_CACHE_ROUTE,
   ADMIN_ORGANIZATIONS_ROUTE,
   ADMIN_ROUTE,
   ADMIN_USER_DETAIL_ROUTE,
@@ -361,6 +363,11 @@ export const ROOT_ROUTES: RouteObject[] = [
             path: ADMIN_ORGANIZATIONS_ROUTE,
             element: <AdminOrganizationsPage />,
             id: RouteIds.AdminOrganizations,
+          },
+          {
+            path: ADMIN_CACHE_ROUTE,
+            element: <AdminCachePage />,
+            id: RouteIds.AdminCache,
           },
         ],
       },

--- a/src/pages/AdminCachePage/api/admin-cache.graphql
+++ b/src/pages/AdminCachePage/api/admin-cache.graphql
@@ -1,0 +1,22 @@
+query adminCacheStats {
+  adminCacheStats {
+    totalHits
+    totalMisses
+    totalWrites
+    totalDeletes
+    totalClears
+    overallHitRate
+    byCategory {
+      key
+      hits
+      misses
+      writes
+      deletes
+      hitRate
+    }
+  }
+}
+
+mutation adminResetAllCache {
+  adminResetAllCache
+}

--- a/src/pages/AdminCachePage/index.ts
+++ b/src/pages/AdminCachePage/index.ts
@@ -1,0 +1,1 @@
+export { AdminCachePage } from './ui/AdminCachePage/AdminCachePage'

--- a/src/pages/AdminCachePage/model/AdminCacheViewModel.ts
+++ b/src/pages/AdminCachePage/model/AdminCacheViewModel.ts
@@ -1,0 +1,116 @@
+import { makeAutoObservable, runInAction } from 'mobx'
+import { AdminCacheStatsQuery } from 'src/__generated__/graphql-request'
+import { IViewModel } from 'src/shared/config/types'
+import { container } from 'src/shared/lib'
+import { ObservableRequest } from 'src/shared/lib/ObservableRequest'
+import { client } from 'src/shared/model/ApiService'
+import { ConfigurationService } from 'src/shared/model/ConfigurationService'
+
+type CacheMetric = NonNullable<AdminCacheStatsQuery['adminCacheStats']>['byCategory'][number]
+
+export class AdminCacheViewModel implements IViewModel {
+  private readonly statsRequest = ObservableRequest.of(client.adminCacheStats)
+  private readonly resetRequest = ObservableRequest.of(client.adminResetAllCache)
+  private readonly configurationService: ConfigurationService
+  private _resetSuccess: boolean = false
+  private _showConfirm: boolean = false
+
+  constructor(configurationService: ConfigurationService) {
+    this.configurationService = configurationService
+    makeAutoObservable(this, {}, { autoBind: true })
+  }
+
+  public get cacheEnabled(): boolean {
+    return this.configurationService.cacheEnabled
+  }
+
+  public get isLoading(): boolean {
+    return this.statsRequest.isLoading
+  }
+
+  public get isResetting(): boolean {
+    return this.resetRequest.isLoading
+  }
+
+  public get resetSuccess(): boolean {
+    return this._resetSuccess
+  }
+
+  public get showConfirm(): boolean {
+    return this._showConfirm
+  }
+
+  public get totalHits(): number {
+    return this.statsRequest.data?.adminCacheStats.totalHits ?? 0
+  }
+
+  public get totalMisses(): number {
+    return this.statsRequest.data?.adminCacheStats.totalMisses ?? 0
+  }
+
+  public get totalWrites(): number {
+    return this.statsRequest.data?.adminCacheStats.totalWrites ?? 0
+  }
+
+  public get totalDeletes(): number {
+    return this.statsRequest.data?.adminCacheStats.totalDeletes ?? 0
+  }
+
+  public get totalClears(): number {
+    return this.statsRequest.data?.adminCacheStats.totalClears ?? 0
+  }
+
+  public get overallHitRate(): number {
+    return this.statsRequest.data?.adminCacheStats.overallHitRate ?? 0
+  }
+
+  public get byCategory(): CacheMetric[] {
+    return this.statsRequest.data?.adminCacheStats.byCategory ?? []
+  }
+
+  public get resetError(): string | null {
+    return this.resetRequest.errorMessage ?? null
+  }
+
+  public openConfirm(): void {
+    this._showConfirm = true
+    this._resetSuccess = false
+  }
+
+  public closeConfirm(): void {
+    this._showConfirm = false
+  }
+
+  public async confirmReset(): Promise<void> {
+    this._showConfirm = false
+
+    const result = await this.resetRequest.fetch({})
+
+    if (result.isRight) {
+      runInAction(() => {
+        this._resetSuccess = true
+      })
+      void this.statsRequest.fetch({})
+    }
+  }
+
+  public init(): void {
+    if (this.cacheEnabled) {
+      void this.statsRequest.fetch({})
+    }
+  }
+
+  public dispose(): void {
+    this.statsRequest.abort()
+    this.resetRequest.abort()
+  }
+}
+
+container.register(
+  AdminCacheViewModel,
+  () => {
+    const configurationService = container.get(ConfigurationService)
+    return new AdminCacheViewModel(configurationService)
+  },
+  { scope: 'request' },
+)

--- a/src/pages/AdminCachePage/ui/AdminCachePage/AdminCachePage.tsx
+++ b/src/pages/AdminCachePage/ui/AdminCachePage/AdminCachePage.tsx
@@ -73,7 +73,7 @@ const KeyMetricRow: FC<KeyMetricRowProps> = ({ keyName, hits, misses, writes, de
         {hits} hits
       </Text>
       <Text fontSize="sm" color="gray.600" minWidth="80px" textAlign="right">
-        {misses} miss
+        {misses} misses
       </Text>
       <Text fontSize="sm" color="gray.600" minWidth="80px" textAlign="right">
         {writes} writes

--- a/src/pages/AdminCachePage/ui/AdminCachePage/AdminCachePage.tsx
+++ b/src/pages/AdminCachePage/ui/AdminCachePage/AdminCachePage.tsx
@@ -1,0 +1,225 @@
+import { Box, Button, Flex, Portal, Spinner, Text, VStack } from '@chakra-ui/react'
+import { Breadcrumb } from '@chakra-ui/react/breadcrumb'
+import {
+  DialogActionTrigger,
+  DialogBackdrop,
+  DialogBody,
+  DialogCloseTrigger,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+} from '@chakra-ui/react/dialog'
+import { observer } from 'mobx-react-lite'
+import { FC } from 'react'
+import { useViewModel } from 'src/shared/lib'
+import { AdminCacheViewModel } from '../../model/AdminCacheViewModel'
+
+interface StatCardProps {
+  label: string
+  value: string | number
+  isLoading: boolean
+}
+
+const StatCard: FC<StatCardProps> = ({ label, value, isLoading }) => {
+  return (
+    <Box
+      padding="24px"
+      borderRadius="8px"
+      border="1px solid"
+      borderColor="gray.200"
+      backgroundColor="white"
+      minWidth="160px"
+    >
+      <Text fontSize="sm" color="gray.500" marginBottom="8px">
+        {label}
+      </Text>
+      {isLoading ? (
+        <Spinner size="sm" color="gray.400" />
+      ) : (
+        <Text fontSize="2xl" fontWeight="600" color="gray.900">
+          {value}
+        </Text>
+      )}
+    </Box>
+  )
+}
+
+interface KeyMetricRowProps {
+  keyName: string
+  hits: number
+  misses: number
+  writes: number
+  deletes: number
+  hitRate: number
+}
+
+const KeyMetricRow: FC<KeyMetricRowProps> = ({ keyName, hits, misses, writes, deletes, hitRate }) => {
+  return (
+    <Flex
+      padding="12px 16px"
+      borderBottom="1px solid"
+      borderColor="gray.100"
+      alignItems="center"
+      gap="16px"
+      _last={{ borderBottom: 'none' }}
+    >
+      <Text flex="1" fontSize="sm" fontWeight="500" fontFamily="mono">
+        {keyName}
+      </Text>
+      <Text fontSize="sm" color="gray.600" minWidth="80px" textAlign="right">
+        {hits} hits
+      </Text>
+      <Text fontSize="sm" color="gray.600" minWidth="80px" textAlign="right">
+        {misses} miss
+      </Text>
+      <Text fontSize="sm" color="gray.600" minWidth="80px" textAlign="right">
+        {writes} writes
+      </Text>
+      <Text fontSize="sm" color="gray.600" minWidth="80px" textAlign="right">
+        {deletes} del
+      </Text>
+      <Text fontSize="sm" fontWeight="500" minWidth="60px" textAlign="right">
+        {(hitRate * 100).toFixed(1)}%
+      </Text>
+    </Flex>
+  )
+}
+
+export const AdminCachePage: FC = observer(() => {
+  const model = useViewModel(AdminCacheViewModel)
+
+  return (
+    <Flex flexDirection="column" height="100%">
+      <Flex
+        alignItems="center"
+        backgroundColor="white"
+        justifyContent="space-between"
+        width="100%"
+        position="sticky"
+        zIndex={1}
+        top={0}
+        padding="8px"
+      >
+        <Flex alignItems="center" gap="4px" height="40px">
+          <Breadcrumb.Root color="gray" fontWeight="600" fontSize="16px">
+            <Breadcrumb.List fontSize="16px">
+              <Breadcrumb.Item>
+                <Breadcrumb.CurrentLink color="gray">Cache</Breadcrumb.CurrentLink>
+              </Breadcrumb.Item>
+            </Breadcrumb.List>
+          </Breadcrumb.Root>
+        </Flex>
+      </Flex>
+
+      {!model.cacheEnabled ? (
+        <Box padding="8px" paddingTop="16px">
+          <Box padding="24px" borderRadius="8px" border="1px solid" borderColor="gray.200" backgroundColor="white">
+            <Text fontSize="md" fontWeight="500" color="gray.500">
+              Caching is disabled
+            </Text>
+            <Text fontSize="sm" color="gray.400" marginTop="4px">
+              Set CACHE_ENABLED=1 to enable caching.
+            </Text>
+          </Box>
+        </Box>
+      ) : (
+        <Box padding="8px" paddingTop="16px">
+          <Flex gap="16px" flexWrap="wrap" marginBottom="24px">
+            <StatCard
+              label="Hit Rate"
+              value={`${(model.overallHitRate * 100).toFixed(1)}%`}
+              isLoading={model.isLoading}
+            />
+            <StatCard label="Hits" value={model.totalHits} isLoading={model.isLoading} />
+            <StatCard label="Misses" value={model.totalMisses} isLoading={model.isLoading} />
+            <StatCard label="Writes" value={model.totalWrites} isLoading={model.isLoading} />
+            <StatCard label="Deletes" value={model.totalDeletes} isLoading={model.isLoading} />
+            <StatCard label="Clears" value={model.totalClears} isLoading={model.isLoading} />
+          </Flex>
+
+          {model.byCategory.length > 0 && (
+            <Box marginBottom="24px">
+              <Text fontSize="sm" fontWeight="600" color="gray.700" marginBottom="8px">
+                By Cache Type
+              </Text>
+              <Box border="1px solid" borderColor="gray.200" borderRadius="8px" backgroundColor="white">
+                {model.byCategory.map((metric) => (
+                  <KeyMetricRow
+                    key={metric.key}
+                    keyName={metric.key}
+                    hits={metric.hits}
+                    misses={metric.misses}
+                    writes={metric.writes}
+                    deletes={metric.deletes}
+                    hitRate={metric.hitRate}
+                  />
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          <Box>
+            <Button
+              colorPalette="red"
+              variant="outline"
+              size="sm"
+              onClick={model.openConfirm}
+              loading={model.isResetting}
+            >
+              Reset All Cache
+            </Button>
+
+            {model.resetSuccess && (
+              <Text fontSize="sm" color="green.500" marginTop="8px">
+                Cache has been cleared successfully
+              </Text>
+            )}
+
+            {model.resetError && (
+              <Text fontSize="sm" color="red.500" marginTop="8px">
+                {model.resetError}
+              </Text>
+            )}
+          </Box>
+        </Box>
+      )}
+
+      <DialogRoot open={model.showConfirm} onOpenChange={({ open }) => !open && model.closeConfirm()} size="md">
+        <Portal>
+          <DialogBackdrop />
+          <DialogPositioner>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Reset All Cache</DialogTitle>
+              </DialogHeader>
+
+              <DialogBody>
+                <VStack align="stretch" gap="1rem">
+                  <Text>Are you sure you want to clear the entire cache?</Text>
+                  <Text fontSize="sm" color="gray.600">
+                    This will flush all cached data including rows, revisions, auth, and billing caches. The cache will
+                    be rebuilt automatically as data is accessed.
+                  </Text>
+                </VStack>
+              </DialogBody>
+
+              <DialogFooter>
+                <DialogActionTrigger asChild>
+                  <Button variant="outline">Cancel</Button>
+                </DialogActionTrigger>
+                <Button colorPalette="red" onClick={model.confirmReset}>
+                  Reset Cache
+                </Button>
+              </DialogFooter>
+
+              <DialogCloseTrigger />
+            </DialogContent>
+          </DialogPositioner>
+        </Portal>
+      </DialogRoot>
+    </Flex>
+  )
+})

--- a/src/pages/AdminLayout/ui/AdminSidebar/AdminSidebar.tsx
+++ b/src/pages/AdminLayout/ui/AdminSidebar/AdminSidebar.tsx
@@ -1,9 +1,9 @@
 import { Box, Flex, Separator, Spacer, VStack } from '@chakra-ui/react'
 import { observer } from 'mobx-react-lite'
 import { FC, useCallback } from 'react'
-import { PiBuildingsLight, PiCaretCircleLeftLight, PiHouseLight, PiUsersLight } from 'react-icons/pi'
+import { PiBuildingsLight, PiCaretCircleLeftLight, PiDatabaseLight, PiHouseLight, PiUsersLight } from 'react-icons/pi'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { ADMIN_ORGANIZATIONS_ROUTE, ADMIN_ROUTE, ADMIN_USERS_ROUTE } from 'src/shared/config/routes'
+import { ADMIN_CACHE_ROUTE, ADMIN_ORGANIZATIONS_ROUTE, ADMIN_ROUTE, ADMIN_USERS_ROUTE } from 'src/shared/config/routes'
 import { SidebarToggleButton } from 'src/shared/ui'
 import { AccountButton } from 'src/widgets/AccountButton'
 
@@ -91,6 +91,7 @@ export const AdminSidebar: FC = observer(() => {
   const isAdminRoot = currentPath === `/${ADMIN_ROUTE}`
   const isUsers = currentPath.startsWith(`/${ADMIN_ROUTE}/${ADMIN_USERS_ROUTE}`)
   const isOrganizations = currentPath.startsWith(`/${ADMIN_ROUTE}/${ADMIN_ORGANIZATIONS_ROUTE}`)
+  const isCache = currentPath.startsWith(`/${ADMIN_ROUTE}/${ADMIN_CACHE_ROUTE}`)
 
   const handleBack = useCallback(() => {
     navigate('/')
@@ -117,6 +118,12 @@ export const AdminSidebar: FC = observer(() => {
           label="Organizations"
           icon={<PiBuildingsLight />}
           isActive={isOrganizations}
+        />
+        <NavigationButton
+          to={`/${ADMIN_ROUTE}/${ADMIN_CACHE_ROUTE}`}
+          label="Cache"
+          icon={<PiDatabaseLight />}
+          isActive={isCache}
         />
       </Flex>
 

--- a/src/shared/api/getConfiguration.graphql
+++ b/src/shared/api/getConfiguration.graphql
@@ -13,6 +13,9 @@ query configuration {
       available
       clientId
     }
+    cache {
+      enabled
+    }
     plugins {
       file
     }

--- a/src/shared/config/routes.ts
+++ b/src/shared/config/routes.ts
@@ -43,6 +43,7 @@ export const ADMIN_ROUTE = 'admin'
 export const ADMIN_USERS_ROUTE = 'users'
 export const ADMIN_USER_DETAIL_ROUTE = ':userId'
 export const ADMIN_ORGANIZATIONS_ROUTE = 'organizations'
+export const ADMIN_CACHE_ROUTE = 'cache'
 
 export enum RouteIds {
   Organization = 'organization',
@@ -74,4 +75,5 @@ export enum RouteIds {
   AdminUsers = 'adminUsers',
   AdminUserDetail = 'adminUserDetail',
   AdminOrganizations = 'adminOrganizations',
+  AdminCache = 'adminCache',
 }

--- a/src/shared/model/ConfigurationService.ts
+++ b/src/shared/model/ConfigurationService.ts
@@ -54,7 +54,7 @@ export class ConfigurationService {
   }
 
   public get cacheEnabled(): boolean {
-    return this.data?.cache.enabled ?? false
+    return this.data?.cache?.enabled ?? false
   }
 
   public get noAuth(): boolean {

--- a/src/shared/model/ConfigurationService.ts
+++ b/src/shared/model/ConfigurationService.ts
@@ -53,6 +53,10 @@ export class ConfigurationService {
     return this.data?.billing.enabled ?? false
   }
 
+  public get cacheEnabled(): boolean {
+    return this.data?.cache.enabled ?? false
+  }
+
   public get noAuth(): boolean {
     return this.data?.noAuth ?? false
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an Admin Cache page at /admin/cache to view cache stats and reset the cache. Requires CACHE_ENABLED=1 to enable caching and stats.

- **New Features**
  - New admin route and sidebar entry: `/${ADMIN_ROUTE}/${ADMIN_CACHE_ROUTE}`.
  - Stats cards: hit rate, hits, misses, writes, deletes, clears, plus per-category breakdown.
  - "Reset All Cache" with confirmation, loading, success, and error states.
  - GraphQL: `adminCacheStats` and `adminResetAllCache`; `configuration.cache.enabled` exposed via `ConfigurationService.cacheEnabled`.

- **Bug Fixes**
  - Corrected "misses" label text.
  - Added defensive access to cache config/stats to avoid errors when data is missing.

<sup>Written for commit 7357d3d37d2dafb1fc1c68efa687f629ec494d7b. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/325">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

