### PR TITLE
feat(auth): cookie-based session with silent refresh (ADR-0045)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -13,6 +13,16 @@ server {
   gzip_comp_level 6;
   gzip_types text/plain text/css text/xml application/json application/javascript application/xml application/xml+rss text/javascript application/wasm;
 
+  # Forwarded headers preserved on every proxied location so the upstream
+  # (revisium-core) can see the real client IP / scheme / host when the app
+  # enables `trust proxy`. Without these, req.ip and req.protocol resolve to
+  # this nginx pod, not the browser.
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Host $host;
+
   location ~* \.(?:js|css|woff|woff2|ttf|eot|ico|svg|png|jpg|jpeg|gif|webp|avif|wasm)$ {
     expires 1y;
     add_header Cache-Control "public, immutable";

--- a/src/app/lib/checkAuth.ts
+++ b/src/app/lib/checkAuth.ts
@@ -11,10 +11,15 @@ export const checkAuth = async ({ request }: LoaderFunctionArgs) => {
 
   if (!authService.user) {
     if (configurationService.noAuth) {
-      const result = await client.login({ data: { emailOrUsername: 'admin', password: '' } })
-      authService.setBearerToken(result.login.accessToken)
-      await authService.afterLogin()
-      return true
+      try {
+        const result = await client.login({ data: { emailOrUsername: 'admin', password: '' } })
+        authService.setBearerToken(result.login.accessToken)
+        await authService.afterLogin()
+        return true
+      } catch (e) {
+        console.error('noAuth bootstrap failed', e)
+        authService.setBearerToken(null)
+      }
     }
 
     const url = new URL(request.url)

--- a/src/app/lib/checkAuth.ts
+++ b/src/app/lib/checkAuth.ts
@@ -12,7 +12,8 @@ export const checkAuth = async ({ request }: LoaderFunctionArgs) => {
   if (!authService.user) {
     if (configurationService.noAuth) {
       const result = await client.login({ data: { emailOrUsername: 'admin', password: '' } })
-      await authService.setToken(result.login.accessToken)
+      authService.setBearerToken(result.login.accessToken)
+      await authService.afterLogin()
       return true
     }
 

--- a/src/app/lib/checkAuthOrPublic.ts
+++ b/src/app/lib/checkAuthOrPublic.ts
@@ -12,7 +12,8 @@ export const checkAuthOrPublic = async (_args: LoaderFunctionArgs) => {
   if (!authService.user) {
     if (configurationService.noAuth) {
       const result = await client.login({ data: { emailOrUsername: 'admin', password: '' } })
-      await authService.setToken(result.login.accessToken)
+      authService.setBearerToken(result.login.accessToken)
+      await authService.afterLogin()
       return true
     }
 

--- a/src/app/lib/checkAuthOrPublic.ts
+++ b/src/app/lib/checkAuthOrPublic.ts
@@ -11,9 +11,14 @@ export const checkAuthOrPublic = async (_args: LoaderFunctionArgs) => {
 
   if (!authService.user) {
     if (configurationService.noAuth) {
-      const result = await client.login({ data: { emailOrUsername: 'admin', password: '' } })
-      authService.setBearerToken(result.login.accessToken)
-      await authService.afterLogin()
+      try {
+        const result = await client.login({ data: { emailOrUsername: 'admin', password: '' } })
+        authService.setBearerToken(result.login.accessToken)
+        await authService.afterLogin()
+      } catch (e) {
+        console.error('noAuth bootstrap failed', e)
+        authService.setBearerToken(null)
+      }
       return true
     }
 

--- a/src/pages/ConfirmEmailCodePage/model/ConfirmEmailCodeViewModel.ts
+++ b/src/pages/ConfirmEmailCodePage/model/ConfirmEmailCodeViewModel.ts
@@ -38,7 +38,7 @@ export class ConfirmEmailCodeViewModel implements IViewModel {
           code,
         },
       })
-      await this.authService.setToken(result.confirmEmailCode.accessToken)
+      await this.authService.afterLogin(result.confirmEmailCode.accessToken)
       return true
     } catch (e) {
       console.error(e)

--- a/src/pages/LoginGithubPage/model/LoginGithubViewModel.ts
+++ b/src/pages/LoginGithubPage/model/LoginGithubViewModel.ts
@@ -35,7 +35,7 @@ export class LoginGithubViewModel implements IViewModel {
         },
       })
 
-      await this.authService.setToken(result.loginGithub.accessToken)
+      await this.authService.afterLogin(result.loginGithub.accessToken)
 
       return true
     } catch (e) {

--- a/src/pages/LoginGooglePage/model/LoginGoogleViewModel.ts
+++ b/src/pages/LoginGooglePage/model/LoginGoogleViewModel.ts
@@ -37,7 +37,7 @@ export class LoginGoogleViewModel implements IViewModel {
         },
       })
 
-      await this.authService.setToken(result.loginGoogle.accessToken)
+      await this.authService.afterLogin(result.loginGoogle.accessToken)
 
       return true
     } catch (e) {

--- a/src/pages/LoginPage/model/LoginViewModel.ts
+++ b/src/pages/LoginPage/model/LoginViewModel.ts
@@ -70,7 +70,7 @@ export class LoginViewModel implements IViewModel {
 
     try {
       const result = await loginRequest({ data: this.form.values })
-      await this.authService.setToken(result.login.accessToken)
+      await this.authService.afterLogin(result.login.accessToken)
       return true
     } catch (e) {
       console.error(e)

--- a/src/pages/LogoutPage/model/LogoutViewModel.ts
+++ b/src/pages/LogoutPage/model/LogoutViewModel.ts
@@ -12,9 +12,9 @@ export class LogoutViewModel implements IViewModel {
     makeAutoObservable(this)
   }
 
-  public logout() {
-    this.authService.logout()
+  public async logout(): Promise<void> {
     this.projectContext.clear()
+    await this.authService.logout()
   }
 
   dispose(): void {}

--- a/src/pages/LogoutPage/model/__tests__/LogoutViewModel.spec.ts
+++ b/src/pages/LogoutPage/model/__tests__/LogoutViewModel.spec.ts
@@ -1,0 +1,89 @@
+import { LogoutViewModel } from 'src/pages/LogoutPage/model/LogoutViewModel.ts'
+import { AuthService } from 'src/shared/model'
+import { ProjectContext } from 'src/entities/Project'
+
+jest.mock('src/shared/lib', () => ({
+  container: {
+    register: jest.fn(),
+    get: jest.fn(),
+  },
+}))
+
+jest.mock('src/shared/model', () => ({
+  AuthService: jest.fn(),
+}))
+
+jest.mock('src/entities/Project', () => ({
+  ProjectContext: jest.fn(),
+}))
+
+describe('LogoutViewModel', () => {
+  describe('logout()', () => {
+    it('returns a Promise that resolves only after authService.logout() resolves', async () => {
+      // This is the regression test for the bug where LogoutPage.useEffect
+      // called model.logout() without awaiting, then navigated to /login,
+      // and checkGuest bounced the user to / because authService.user was
+      // still set (the server fetch hadn't completed yet).
+      let authLogoutResolved = false
+      const authService = {
+        logout: jest.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              setTimeout(() => {
+                authLogoutResolved = true
+                resolve()
+              }, 20)
+            }),
+        ),
+      } as unknown as AuthService
+      const projectContext = {
+        clear: jest.fn(),
+      } as unknown as ProjectContext
+
+      const vm = new LogoutViewModel(authService, projectContext)
+      const promise = vm.logout()
+
+      expect(promise).toBeInstanceOf(Promise)
+      expect(authLogoutResolved).toBe(false)
+
+      await promise
+
+      expect(authLogoutResolved).toBe(true)
+      expect(authService.logout).toHaveBeenCalledTimes(1)
+      expect(projectContext.clear).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears projectContext before the auth server call starts', async () => {
+      const order: string[] = []
+      const authService = {
+        logout: jest.fn(async () => {
+          order.push('auth.logout')
+        }),
+      } as unknown as AuthService
+      const projectContext = {
+        clear: jest.fn(() => {
+          order.push('projectContext.clear')
+        }),
+      } as unknown as ProjectContext
+
+      const vm = new LogoutViewModel(authService, projectContext)
+      await vm.logout()
+
+      expect(order).toEqual(['projectContext.clear', 'auth.logout'])
+    })
+
+    it('propagates errors from authService.logout()', async () => {
+      const authService = {
+        logout: jest.fn().mockRejectedValue(new Error('network down')),
+      } as unknown as AuthService
+      const projectContext = {
+        clear: jest.fn(),
+      } as unknown as ProjectContext
+
+      const vm = new LogoutViewModel(authService, projectContext)
+      await expect(vm.logout()).rejects.toThrow('network down')
+      // Local state was still cleared before the failing remote call
+      expect(projectContext.clear).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/pages/LogoutPage/ui/LogoutPage/LogoutPage.tsx
+++ b/src/pages/LogoutPage/ui/LogoutPage/LogoutPage.tsx
@@ -10,8 +10,15 @@ export const LogoutPage: FC = observer(() => {
   const navigate = useNavigate()
 
   useEffect(() => {
-    model.logout()
-    navigate(`/${LOGIN_ROUTE}`)
+    let cancelled = false
+    void model.logout().finally(() => {
+      if (!cancelled) {
+        navigate(`/${LOGIN_ROUTE}`)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
   }, [model, navigate])
 
   return null

--- a/src/shared/model/ApiService.ts
+++ b/src/shared/model/ApiService.ts
@@ -1,12 +1,16 @@
-import { GraphQLClient } from 'graphql-request'
+import { ClientError, GraphQLClient, RequestDocument, Variables } from 'graphql-request'
 import { getSdk, Sdk } from 'src/__generated__/graphql-request.ts'
 import { container } from 'src/shared/lib'
 import { EnvironmentService } from 'src/shared/model/EnvironmentService.ts'
 import { toaster } from 'src/shared/ui'
 
+type UnauthorizedHandler = () => Promise<boolean>
+
 export class ApiService {
   private readonly graphQLClient: GraphQLClient
   public readonly client: Sdk
+
+  private onUnauthorized: UnauthorizedHandler | null = null
 
   constructor(private readonly environmentService: EnvironmentService) {
     const url = this.environmentService.get('REACT_APP_GRAPHQL_SERVER_URL')
@@ -16,8 +20,12 @@ export class ApiService {
     }
 
     this.graphQLClient = new GraphQLClient(url, {
+      credentials: 'include',
       responseMiddleware: (response) => {
-        const error = response['response']?.errors?.[0]?.message
+        if (response instanceof ClientError && ApiService.isUnauthorized(response)) {
+          return
+        }
+        const error = (response as { response?: { errors?: { message?: string }[] } })?.response?.errors?.[0]?.message
 
         if (error) {
           toaster.info({
@@ -25,15 +33,87 @@ export class ApiService {
             description: error,
           })
         }
-
-        return response
       },
     })
+
+    this.wrapRequestWithRefreshRetry()
+
     this.client = getSdk(this.graphQLClient)
   }
 
   public setToken(token: string | null) {
     this.graphQLClient.setHeaders(token ? { Authorization: `Bearer ${token}` } : {})
+  }
+
+  public setUnauthorizedHandler(handler: UnauthorizedHandler | null) {
+    this.onUnauthorized = handler
+  }
+
+  private wrapRequestWithRefreshRetry() {
+    const originalRequest = this.graphQLClient.request.bind(this.graphQLClient) as (
+      document: RequestDocument,
+      variables?: Variables,
+      requestHeaders?: Record<string, string>,
+    ) => Promise<unknown>
+
+    const wrapped = async (
+      document: RequestDocument,
+      variables?: Variables,
+      requestHeaders?: Record<string, string>,
+    ): Promise<unknown> => {
+      try {
+        return await originalRequest(document, variables, requestHeaders)
+      } catch (e) {
+        if (!ApiService.isUnauthorized(e) || !this.onUnauthorized) {
+          throw e
+        }
+        const refreshed = await this.onUnauthorized()
+        if (!refreshed) {
+          throw e
+        }
+        return await originalRequest(document, variables, requestHeaders)
+      }
+    }
+
+    ;(this.graphQLClient as unknown as { request: typeof wrapped }).request = wrapped
+  }
+
+  private static isUnauthorized(error: unknown): boolean {
+    if (!(error instanceof ClientError)) {
+      return false
+    }
+    if (error.response.status === 401) {
+      return true
+    }
+    // Yoga/NestJS GraphQL drivers return HTTP 200 with `errors[0].message`
+    // when a resolver throws UnauthorizedException. Detect that too, otherwise
+    // GraphQL requests never trigger the refresh/retry path.
+    const errors = (error.response as { errors?: unknown[] } | undefined)?.errors
+    if (!Array.isArray(errors) || errors.length === 0) {
+      return false
+    }
+    return errors.some((e) => {
+      if (typeof e !== 'object' || e === null) {
+        return false
+      }
+      const candidate = e as {
+        message?: unknown
+        extensions?: { code?: unknown; originalError?: { statusCode?: unknown } }
+      }
+      const message = typeof candidate.message === 'string' ? candidate.message : ''
+      if (/^unauthorized$/i.test(message.trim())) {
+        return true
+      }
+      const code = candidate.extensions?.code
+      if (typeof code === 'string' && /^UNAUTHENTICATED$/i.test(code)) {
+        return true
+      }
+      const statusCode = candidate.extensions?.originalError?.statusCode
+      if (statusCode === 401) {
+        return true
+      }
+      return false
+    })
   }
 }
 

--- a/src/shared/model/AuthService.ts
+++ b/src/shared/model/AuthService.ts
@@ -1,81 +1,159 @@
-import { makeAutoObservable, reaction, runInAction } from 'mobx'
+import { makeAutoObservable, runInAction } from 'mobx'
 import { UserFragment } from 'src/__generated__/graphql-request.ts'
 import { container } from 'src/shared/lib'
 import { PermissionService, SystemPermissions } from 'src/shared/model/AbilityService'
 import { ApiService } from 'src/shared/model/ApiService.ts'
 
-const TOKEN_KEY = 'token'
+const REFRESH_URL = '/api/auth/refresh'
+const LOGOUT_URL = '/api/auth/logout'
+
+// Presence cookie set by revisium-core alongside the httpOnly `rev_at` /
+// `rev_rt` credentials. Its value is always "1" and it is NOT httpOnly, so
+// this SPA can read it via `document.cookie` to decide whether to attempt
+// getMe on page load. Carries no credential. See ADR-0045.
+const SESSION_COOKIE_NAME = 'rev_session'
 
 export class AuthService {
   public isLoaded = false
 
   public user: UserFragment | null = null
+
   public token: string | null = null
 
+  private refreshPromise: Promise<boolean> | null = null
+
   constructor(
-    private readonly storage: Storage,
     private readonly apiService: ApiService,
     private readonly systemPermissions: SystemPermissions,
     private readonly permissionService: PermissionService,
   ) {
     makeAutoObservable(this)
+    this.apiService.setUnauthorizedHandler(() => this.tryRefresh())
   }
 
   public async initialize(): Promise<void> {
-    await this.init()
-  }
-
-  public async setToken(token: string | null) {
-    this.token = token
-    this.apiService.setToken(this.token)
-
-    if (this.token) {
-      await this.fetchMe()
+    // Skip the fetchMe dance entirely for visitors with no prior session —
+    // the server-set rev_session cookie is the presence indicator.
+    if (!AuthService.hasSessionCookie()) {
+      runInAction(() => {
+        this.isLoaded = true
+      })
+      return
     }
+
+    try {
+      await this.fetchMe()
+    } catch {
+      const refreshed = await this.tryRefresh()
+      if (refreshed) {
+        try {
+          await this.fetchMe()
+        } catch {
+          // still anonymous — server will clear rev_session on the next
+          // 401-triggered clearAuthCookies response
+        }
+      }
+    }
+    runInAction(() => {
+      this.isLoaded = true
+    })
   }
 
-  private async init() {
-    await this.setToken(this.loadToken())
-    this.signToToken()
-
-    this.setIsChecked(true)
+  public async afterLogin(accessToken?: string | null): Promise<void> {
+    if (accessToken !== undefined) {
+      runInAction(() => {
+        this.token = accessToken
+      })
+    }
+    // rev_session is set by the server's setAuthCookies response, no
+    // client-side bookkeeping required.
+    await this.fetchMe()
   }
 
-  private loadToken() {
-    return this.storage.getItem(TOKEN_KEY)
+  public setBearerToken(token: string | null): void {
+    runInAction(() => {
+      this.token = token
+    })
+    this.apiService.setToken(token)
   }
 
-  public async fetchMe() {
+  public async logout(): Promise<void> {
+    try {
+      await fetch(LOGOUT_URL, {
+        method: 'POST',
+        credentials: 'include',
+      })
+    } catch {
+      // ignore — we still clear local state below
+    }
+    this.apiService.setToken(null)
+    runInAction(() => {
+      this.user = null
+      this.token = null
+    })
+    this.systemPermissions.clearAll()
+  }
+
+  public async refresh(): Promise<boolean> {
+    return this.tryRefresh()
+  }
+
+  public async fetchMe(): Promise<void> {
     try {
       const result = await this.apiService.client.getMe()
-      this.user = result.me
+      runInAction(() => {
+        this.user = result.me
+      })
 
       this.systemPermissions.setUserRole(result.me.role ?? null)
       this.loadOrganizationPermissions(result.me)
     } catch (e) {
-      console.error(e)
-
       runInAction(() => {
-        this.token = null
+        this.user = null
       })
+      throw e
     }
   }
 
-  private setIsChecked(value: boolean) {
-    this.isLoaded = value
+  private tryRefresh(): Promise<boolean> {
+    if (this.refreshPromise) {
+      return this.refreshPromise
+    }
+
+    const promise = this.doRefresh()
+    runInAction(() => {
+      this.refreshPromise = promise
+    })
+    void promise.finally(() => {
+      runInAction(() => {
+        this.refreshPromise = null
+      })
+    })
+    return promise
   }
 
-  private signToToken() {
-    reaction(
-      () => this.token,
-      (nextToken) => {
-        if (nextToken) {
-          this.storage.setItem(TOKEN_KEY, nextToken)
-        } else {
-          this.storage.removeItem(TOKEN_KEY)
-        }
-      },
-    )
+  private async doRefresh(): Promise<boolean> {
+    try {
+      const response = await fetch(REFRESH_URL, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      return response.ok
+    } catch {
+      return false
+    }
+  }
+
+  private static hasSessionCookie(): boolean {
+    if (typeof document === 'undefined') {
+      return false
+    }
+    const cookieString = document.cookie
+    if (!cookieString) {
+      return false
+    }
+    // RFC 6265: cookies are separated by "; ". Match name = literal "1".
+    return cookieString.split(';').some((entry) => entry.trim() === `${SESSION_COOKIE_NAME}=1`)
   }
 
   private loadOrganizationPermissions(me: UserFragment): void {
@@ -92,13 +170,6 @@ export class AuthService {
       this.permissionService.addOrganizationPermissions(organizationId, permissions)
     }
   }
-
-  logout() {
-    this.token = null
-    this.user = null
-    this.apiService.setToken(null)
-    this.systemPermissions.clearAll()
-  }
 }
 
 container.register(
@@ -107,7 +178,7 @@ container.register(
     const apiService = container.get(ApiService)
     const systemPermissions = container.get(SystemPermissions)
     const permissionService = container.get(PermissionService)
-    const authService = new AuthService(localStorage, apiService, systemPermissions, permissionService)
+    const authService = new AuthService(apiService, systemPermissions, permissionService)
     void authService.initialize()
     return authService
   },

--- a/src/shared/model/FileService.ts
+++ b/src/shared/model/FileService.ts
@@ -38,9 +38,8 @@ export class FileService {
 
     return fetch(signedUrl, {
       method: 'POST',
-      headers: {
-        Authorization: `Bearer ${this.authService.token}`,
-      },
+      credentials: 'include',
+      headers: this.authService.token ? { Authorization: `Bearer ${this.authService.token}` } : {},
       body: formData,
     })
   }

--- a/src/shared/model/__tests__/ApiService.spec.ts
+++ b/src/shared/model/__tests__/ApiService.spec.ts
@@ -1,0 +1,253 @@
+import { ClientError } from 'graphql-request'
+import { ApiService } from 'src/shared/model/ApiService.ts'
+import { EnvironmentService } from 'src/shared/model/EnvironmentService.ts'
+
+const mockRequest = jest.fn()
+const mockSetHeaders = jest.fn()
+
+jest.mock('graphql-request', () => {
+  const actual = jest.requireActual('graphql-request')
+  return {
+    ...actual,
+    GraphQLClient: jest.fn().mockImplementation(() => ({
+      request: mockRequest,
+      setHeaders: mockSetHeaders,
+    })),
+  }
+})
+
+jest.mock('src/__generated__/graphql-request.ts', () => ({
+  getSdk: jest.fn(() => ({})),
+}))
+
+jest.mock('src/shared/ui', () => ({
+  toaster: {
+    info: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+  },
+}))
+
+jest.mock('src/shared/lib', () => ({
+  container: {
+    register: jest.fn(),
+    get: jest.fn(() => ({ client: {} })),
+  },
+}))
+
+type MinimalRequest = (document: unknown, variables?: unknown, headers?: Record<string, string>) => Promise<unknown>
+
+type ErrorShape = {
+  status?: number
+  errors?: Array<Record<string, unknown>>
+  data?: unknown
+}
+
+function makeClientError({ status = 200, errors, data = null }: ErrorShape): ClientError {
+  return new ClientError(
+    {
+      status,
+      errors: errors as never,
+      data: data as never,
+    },
+    { query: '{ me { id } }' },
+  )
+}
+
+function getWrappedRequest(service: ApiService): MinimalRequest {
+  return (service as unknown as { graphQLClient: { request: MinimalRequest } }).graphQLClient.request
+}
+
+describe('ApiService', () => {
+  let envService: EnvironmentService
+  let service: ApiService
+
+  beforeEach(() => {
+    mockRequest.mockReset()
+    mockSetHeaders.mockReset()
+
+    envService = {
+      get: jest.fn().mockReturnValue('/graphql'),
+    } as unknown as EnvironmentService
+
+    service = new ApiService(envService)
+  })
+
+  describe('isUnauthorized detection', () => {
+    const TRIGGERS_REFRESH = [
+      {
+        name: 'HTTP 401 (REST-style)',
+        shape: { status: 401, errors: [{ message: 'Unauthorized' }] },
+      },
+      {
+        name: 'HTTP 200 + errors[0].message = "Unauthorized" (Yoga/Nest default)',
+        shape: { status: 200, errors: [{ message: 'Unauthorized' }] },
+      },
+      {
+        name: 'HTTP 200 + errors[0].message = "unauthorized" (case-insensitive)',
+        shape: { status: 200, errors: [{ message: 'unauthorized' }] },
+      },
+      {
+        name: 'HTTP 200 + errors[0].extensions.code = "UNAUTHENTICATED"',
+        shape: {
+          status: 200,
+          errors: [{ message: 'Access denied', extensions: { code: 'UNAUTHENTICATED' } }],
+        },
+      },
+      {
+        name: 'HTTP 200 + errors[0].extensions.originalError.statusCode = 401',
+        shape: {
+          status: 200,
+          errors: [{ message: 'Forbidden', extensions: { originalError: { statusCode: 401 } } }],
+        },
+      },
+    ]
+
+    it.each(TRIGGERS_REFRESH)('triggers refresh handler for: $name', async ({ shape }) => {
+      const onUnauthorized = jest.fn().mockResolvedValue(true)
+      service.setUnauthorizedHandler(onUnauthorized)
+
+      mockRequest.mockRejectedValueOnce(makeClientError(shape))
+      mockRequest.mockResolvedValueOnce({ me: { id: 'admin' } })
+
+      const result = await getWrappedRequest(service)('{ me { id } }')
+
+      expect(onUnauthorized).toHaveBeenCalledTimes(1)
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(result).toEqual({ me: { id: 'admin' } })
+    })
+
+    const DOES_NOT_TRIGGER = [
+      {
+        name: 'HTTP 500 internal error',
+        shape: { status: 500, errors: [{ message: 'Internal server error' }] },
+      },
+      {
+        name: 'HTTP 200 + errors[0].message = "Rate limited"',
+        shape: { status: 200, errors: [{ message: 'Rate limited' }] },
+      },
+      {
+        name: 'HTTP 200 + errors[0].message = "Validation failed"',
+        shape: { status: 200, errors: [{ message: 'Validation failed' }] },
+      },
+      {
+        name: 'HTTP 400 bad request',
+        shape: { status: 400, errors: [{ message: 'Bad request' }] },
+      },
+      {
+        name: 'HTTP 200 + errors[0].extensions.code = "FORBIDDEN"',
+        shape: {
+          status: 200,
+          errors: [{ message: 'Forbidden', extensions: { code: 'FORBIDDEN' } }],
+        },
+      },
+      {
+        name: 'HTTP 200 + no errors array',
+        shape: { status: 200, errors: undefined },
+      },
+    ]
+
+    it.each(DOES_NOT_TRIGGER)('does not trigger refresh for: $name', async ({ shape }) => {
+      const onUnauthorized = jest.fn().mockResolvedValue(true)
+      service.setUnauthorizedHandler(onUnauthorized)
+
+      mockRequest.mockRejectedValueOnce(makeClientError(shape))
+
+      await expect(getWrappedRequest(service)('{ me { id } }')).rejects.toBeInstanceOf(ClientError)
+      expect(onUnauthorized).not.toHaveBeenCalled()
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not treat non-ClientError exceptions as unauthorized', async () => {
+      const onUnauthorized = jest.fn().mockResolvedValue(true)
+      service.setUnauthorizedHandler(onUnauthorized)
+
+      const networkError = new Error('fetch failed')
+      mockRequest.mockRejectedValueOnce(networkError)
+
+      await expect(getWrappedRequest(service)('{ me { id } }')).rejects.toBe(networkError)
+      expect(onUnauthorized).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('retry behavior', () => {
+    it('retries the original request with the same arguments when refresh succeeds', async () => {
+      const onUnauthorized = jest.fn().mockResolvedValue(true)
+      service.setUnauthorizedHandler(onUnauthorized)
+
+      mockRequest.mockRejectedValueOnce(makeClientError({ status: 200, errors: [{ message: 'Unauthorized' }] }))
+      mockRequest.mockResolvedValueOnce({ data: 'fresh' })
+
+      const doc = '{ getProject(id: "x") { id } }'
+      const vars = { id: 'x' }
+      const headers = { 'X-Foo': 'bar' }
+
+      const result = await getWrappedRequest(service)(doc, vars, headers)
+
+      expect(result).toEqual({ data: 'fresh' })
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+      expect(mockRequest).toHaveBeenNthCalledWith(1, doc, vars, headers)
+      expect(mockRequest).toHaveBeenNthCalledWith(2, doc, vars, headers)
+    })
+
+    it('throws the original error when refresh handler returns false', async () => {
+      const onUnauthorized = jest.fn().mockResolvedValue(false)
+      service.setUnauthorizedHandler(onUnauthorized)
+
+      const clientError = makeClientError({ status: 200, errors: [{ message: 'Unauthorized' }] })
+      mockRequest.mockRejectedValueOnce(clientError)
+
+      await expect(getWrappedRequest(service)('{ me { id } }')).rejects.toBe(clientError)
+      expect(onUnauthorized).toHaveBeenCalledTimes(1)
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws the original error when no unauthorized handler is registered', async () => {
+      const clientError = makeClientError({ status: 200, errors: [{ message: 'Unauthorized' }] })
+      mockRequest.mockRejectedValueOnce(clientError)
+
+      await expect(getWrappedRequest(service)('{ me { id } }')).rejects.toBe(clientError)
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+    })
+
+    it('caps at one retry — a second 401 after refresh bubbles up', async () => {
+      const onUnauthorized = jest.fn().mockResolvedValue(true)
+      service.setUnauthorizedHandler(onUnauthorized)
+
+      const firstError = makeClientError({ status: 200, errors: [{ message: 'Unauthorized' }] })
+      const secondError = makeClientError({ status: 200, errors: [{ message: 'Unauthorized' }] })
+      mockRequest.mockRejectedValueOnce(firstError)
+      mockRequest.mockRejectedValueOnce(secondError)
+
+      await expect(getWrappedRequest(service)('{ me { id } }')).rejects.toBe(secondError)
+      expect(onUnauthorized).toHaveBeenCalledTimes(1)
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+    })
+
+    it('passes successful requests through unchanged', async () => {
+      const onUnauthorized = jest.fn().mockResolvedValue(true)
+      service.setUnauthorizedHandler(onUnauthorized)
+
+      mockRequest.mockResolvedValueOnce({ me: { id: 'admin' } })
+
+      const result = await getWrappedRequest(service)('{ me { id } }')
+
+      expect(result).toEqual({ me: { id: 'admin' } })
+      expect(onUnauthorized).not.toHaveBeenCalled()
+      expect(mockRequest).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('setToken', () => {
+    it('forwards Authorization header when token is provided', () => {
+      service.setToken('jwt-value')
+      expect(mockSetHeaders).toHaveBeenCalledWith({ Authorization: 'Bearer jwt-value' })
+    })
+
+    it('clears headers when token is null', () => {
+      service.setToken(null)
+      expect(mockSetHeaders).toHaveBeenCalledWith({})
+    })
+  })
+})

--- a/src/shared/model/__tests__/AuthService.spec.ts
+++ b/src/shared/model/__tests__/AuthService.spec.ts
@@ -4,8 +4,12 @@ import type { PermissionService, SystemPermissions } from 'src/shared/model/Abil
 
 const SESSION_COOKIE_NAME = 'rev_session'
 
+let originalDocumentDescriptor: PropertyDescriptor | undefined
+let originalFetchDescriptor: PropertyDescriptor | undefined
+
 function installDocumentCookie(initial = ''): { set(value: string): void } {
   let current = initial
+  originalDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document')
   Object.defineProperty(globalThis, 'document', {
     configurable: true,
     writable: true,
@@ -25,9 +29,19 @@ function installDocumentCookie(initial = ''): { set(value: string): void } {
   }
 }
 
-function uninstallDocumentCookie(): void {
-  // biome-ignore lint: explicit teardown
-  delete (globalThis as { document?: unknown }).document
+function restoreGlobals(): void {
+  if (originalDocumentDescriptor) {
+    Object.defineProperty(globalThis, 'document', originalDocumentDescriptor)
+  } else {
+    delete (globalThis as { document?: unknown }).document
+  }
+  if (originalFetchDescriptor) {
+    Object.defineProperty(globalThis, 'fetch', originalFetchDescriptor)
+  } else {
+    delete (globalThis as { fetch?: unknown }).fetch
+  }
+  originalDocumentDescriptor = undefined
+  originalFetchDescriptor = undefined
 }
 
 function makeApiService(getMe: jest.Mock): ApiService {
@@ -68,6 +82,7 @@ describe('AuthService', () => {
   beforeEach(() => {
     cookieStore = installDocumentCookie('')
 
+    originalFetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'fetch')
     fetchMock = jest.fn()
     Object.defineProperty(globalThis, 'fetch', {
       value: fetchMock,
@@ -77,7 +92,7 @@ describe('AuthService', () => {
   })
 
   afterEach(() => {
-    uninstallDocumentCookie()
+    restoreGlobals()
     jest.clearAllMocks()
   })
 

--- a/src/shared/model/__tests__/AuthService.spec.ts
+++ b/src/shared/model/__tests__/AuthService.spec.ts
@@ -1,0 +1,246 @@
+import { AuthService } from 'src/shared/model/AuthService.ts'
+import type { ApiService } from 'src/shared/model/ApiService.ts'
+import type { PermissionService, SystemPermissions } from 'src/shared/model/AbilityService'
+
+const SESSION_COOKIE_NAME = 'rev_session'
+
+function installDocumentCookie(initial = ''): { set(value: string): void } {
+  let current = initial
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    writable: true,
+    value: {
+      get cookie() {
+        return current
+      },
+      set cookie(value: string) {
+        current = value
+      },
+    },
+  })
+  return {
+    set(value: string) {
+      current = value
+    },
+  }
+}
+
+function uninstallDocumentCookie(): void {
+  // biome-ignore lint: explicit teardown
+  delete (globalThis as { document?: unknown }).document
+}
+
+function makeApiService(getMe: jest.Mock): ApiService {
+  return {
+    client: { getMe },
+    setToken: jest.fn(),
+    setUnauthorizedHandler: jest.fn(),
+  } as unknown as ApiService
+}
+
+function makePermissions(): { system: SystemPermissions; perm: PermissionService } {
+  return {
+    system: {
+      setUserRole: jest.fn(),
+      clearAll: jest.fn(),
+    } as unknown as SystemPermissions,
+    perm: {
+      addOrganizationPermissions: jest.fn(),
+    } as unknown as PermissionService,
+  }
+}
+
+const ME_PAYLOAD = {
+  me: {
+    id: 'admin',
+    username: 'admin',
+    email: null,
+    roleId: 'systemAdmin',
+    role: null,
+    organization: null,
+  },
+}
+
+describe('AuthService', () => {
+  let fetchMock: jest.Mock
+  let cookieStore: { set(value: string): void }
+
+  beforeEach(() => {
+    cookieStore = installDocumentCookie('')
+
+    fetchMock = jest.fn()
+    Object.defineProperty(globalThis, 'fetch', {
+      value: fetchMock,
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    uninstallDocumentCookie()
+    jest.clearAllMocks()
+  })
+
+  describe('initialize() — anonymous visitor (no rev_session cookie)', () => {
+    it('does NOT call getMe when document.cookie is empty', async () => {
+      const getMe = jest.fn().mockResolvedValue(ME_PAYLOAD)
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+
+      const service = new AuthService(api, system, perm)
+      await service.initialize()
+
+      expect(getMe).not.toHaveBeenCalled()
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(service.user).toBeNull()
+      expect(service.isLoaded).toBe(true)
+    })
+
+    it('does NOT call getMe when only unrelated cookies are present', async () => {
+      cookieStore.set('analytics=abc123; theme=dark')
+      const getMe = jest.fn()
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+
+      const service = new AuthService(api, system, perm)
+      await service.initialize()
+
+      expect(getMe).not.toHaveBeenCalled()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('initialize() — returning visitor (rev_session=1 cookie present)', () => {
+    beforeEach(() => {
+      cookieStore.set(`${SESSION_COOKIE_NAME}=1`)
+    })
+
+    it('calls getMe and loads user on success', async () => {
+      const getMe = jest.fn().mockResolvedValue(ME_PAYLOAD)
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+
+      const service = new AuthService(api, system, perm)
+      await service.initialize()
+
+      expect(getMe).toHaveBeenCalledTimes(1)
+      expect(service.user).toEqual(ME_PAYLOAD.me)
+      expect(service.isLoaded).toBe(true)
+    })
+
+    it('detects rev_session when mixed with other cookies', async () => {
+      cookieStore.set(`analytics=abc; ${SESSION_COOKIE_NAME}=1; theme=dark`)
+      const getMe = jest.fn().mockResolvedValue(ME_PAYLOAD)
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+
+      const service = new AuthService(api, system, perm)
+      await service.initialize()
+
+      expect(getMe).toHaveBeenCalledTimes(1)
+      expect(service.user).toEqual(ME_PAYLOAD.me)
+    })
+
+    it('calls refresh then retries getMe on 401', async () => {
+      const getMe = jest.fn().mockRejectedValueOnce(new Error('Unauthorized')).mockResolvedValueOnce(ME_PAYLOAD)
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+      fetchMock.mockResolvedValue({ ok: true } as Response)
+
+      const service = new AuthService(api, system, perm)
+      await service.initialize()
+
+      expect(getMe).toHaveBeenCalledTimes(2)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock).toHaveBeenCalledWith('/api/auth/refresh', {
+        method: 'POST',
+        credentials: 'include',
+      })
+      expect(service.user).toEqual(ME_PAYLOAD.me)
+    })
+
+    it('stays anonymous when refresh fails and leaves cleanup to the server response', async () => {
+      const getMe = jest.fn().mockRejectedValue(new Error('Unauthorized'))
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+      fetchMock.mockResolvedValue({ ok: false } as Response)
+
+      const service = new AuthService(api, system, perm)
+      await service.initialize()
+
+      expect(service.user).toBeNull()
+      expect(service.isLoaded).toBe(true)
+    })
+  })
+
+  describe('afterLogin()', () => {
+    it('calls fetchMe and records the in-memory token', async () => {
+      const getMe = jest.fn().mockResolvedValue(ME_PAYLOAD)
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+
+      const service = new AuthService(api, system, perm)
+      await service.afterLogin('jwt-value')
+
+      expect(service.user).toEqual(ME_PAYLOAD.me)
+      expect(service.token).toBe('jwt-value')
+      // No localStorage writes — rev_session comes from the login response.
+      expect(getMe).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('logout()', () => {
+    it('awaits the server request before resolving, clears user and token', async () => {
+      cookieStore.set(`${SESSION_COOKIE_NAME}=1`)
+
+      let logoutResolved = false
+      fetchMock.mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            setTimeout(() => {
+              logoutResolved = true
+              resolve({ ok: true, status: 204 } as Response)
+            }, 20)
+          }),
+      )
+
+      const getMe = jest.fn().mockResolvedValue(ME_PAYLOAD)
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+
+      const service = new AuthService(api, system, perm)
+      await service.afterLogin('jwt-value')
+      expect(service.user).not.toBeNull()
+      expect(logoutResolved).toBe(false)
+
+      // Regression guard: the promise returned by logout() must NOT resolve
+      // before the server call finishes. LogoutPage relies on this await to
+      // avoid a race with checkGuest bouncing the user back to /.
+      await service.logout()
+
+      expect(logoutResolved).toBe(true)
+      expect(fetchMock).toHaveBeenCalledWith('/api/auth/logout', {
+        method: 'POST',
+        credentials: 'include',
+      })
+      expect(service.user).toBeNull()
+      expect(service.token).toBeNull()
+    })
+
+    it('still clears local state when the server call fails', async () => {
+      fetchMock.mockRejectedValue(new Error('network down'))
+
+      const getMe = jest.fn().mockResolvedValue(ME_PAYLOAD)
+      const api = makeApiService(getMe)
+      const { system, perm } = makePermissions()
+
+      const service = new AuthService(api, system, perm)
+      await service.afterLogin('jwt-value')
+
+      await service.logout()
+
+      expect(service.user).toBeNull()
+      expect(service.token).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch auth from localStorage JWTs to a server-managed, cookie-based session with silent refresh for a more secure and seamless login. Also fixes the logout race and hardens the noAuth bootstrap path.

- **New Features**
  - Cookie session per ADR-0045: server `rev_at`/`rev_rt` with a non-httpOnly presence cookie `rev_session`.
  - `ApiService`: uses `credentials: 'include'` and retries once on unauthorized (HTTP 401 or GraphQL UNAUTHENTICATED), suppressing 401 toasts.
  - `AuthService`: no localStorage; `afterLogin(accessToken?)` fetches user; refresh via POST `/api/auth/refresh` with a single in-flight mutex; `logout()` POSTs `/api/auth/logout` and clears state.
  - `FileService`: uploads send cookies and add Bearer only when a token exists.
  - Login flows now call `afterLogin(token)`; `checkAuth*` use `setBearerToken()` + `afterLogin()` in noAuth mode.
  - `nginx.conf`: forwards `Host`, `X-Real-IP`, and `X-Forwarded-*` headers for correct client IP/scheme with `trust proxy`.

- **Bug Fixes**
  - Logout now awaits the server call before navigating, removing the /login bounce (updated `LogoutViewModel` and `LogoutPage` with tests).
  - noAuth bootstrap is wrapped in try/catch to avoid loader crashes; on failure it logs and clears the bearer so protected routes redirect and public routes continue as anonymous.

<sup>Written for commit 12475886ae8a52cb1527507b22a91c88ddaae46c. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/326">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

