### PR TITLE
fix: fall back to session organizationId on main page

### DIFF
--- a/src/entities/Organization/model/OrganizationContext.ts
+++ b/src/entities/Organization/model/OrganizationContext.ts
@@ -12,7 +12,7 @@ export class OrganizationContext {
   }
 
   public get organizationId(): string {
-    return this.routerParams.organizationId ?? ''
+    return this.routerParams.organizationId ?? this.authService.user?.organizationId ?? ''
   }
 
   public get isAuthenticated(): boolean {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the session `organizationId` when the route param is missing on the main page. Fixes empty organization context and prevents blank loads.

<sup>Written for commit 7ffe73943714fe5ef981fb595a5bbb0e662c920f. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/327">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

