### PR TITLE
fix(auth): fix /get-token page after JWT 2.0

### DIFF
--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -169,8 +169,7 @@ export type CacheMetricModel = {
 
 export type CacheStatsModel = {
   __typename: 'CacheStatsModel'
-  byKey: Array<CacheMetricModel>
-  enabled: Scalars['Boolean']['output']
+  byCategory: Array<CacheMetricModel>
   overallHitRate: Scalars['Float']['output']
   totalClears: Scalars['Int']['output']
   totalDeletes: Scalars['Int']['output']
@@ -680,6 +679,7 @@ export type LoginInput = {
 export type LoginModel = {
   __typename: 'LoginModel'
   accessToken: Scalars['String']['output']
+  expiresIn: Scalars['Int']['output']
 }
 
 export type MeModel = {
@@ -1129,6 +1129,7 @@ export type Query = {
   configuration: ConfigurationModel
   /** @deprecated use RowModel.rowForeignKeysBy.totalCount */
   getRowCountForeignKeysTo: Scalars['Int']['output']
+  issueAccessToken: LoginModel
   me: MeModel
   meProjects: ProjectsConnection
   myApiKeys: Array<ApiKeyModel>

--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -163,7 +163,6 @@ export type CacheMetricModel = {
 
 export type CacheStatsModel = {
   byCategory: Array<CacheMetricModel>
-  enabled: Scalars['Boolean']['output']
   overallHitRate: Scalars['Float']['output']
   totalClears: Scalars['Int']['output']
   totalDeletes: Scalars['Int']['output']
@@ -654,6 +653,7 @@ export type LoginInput = {
 
 export type LoginModel = {
   accessToken: Scalars['String']['output']
+  expiresIn: Scalars['Int']['output']
 }
 
 export type MeModel = {
@@ -1086,6 +1086,7 @@ export type Query = {
   configuration: ConfigurationModel
   /** @deprecated use RowModel.rowForeignKeysBy.totalCount */
   getRowCountForeignKeysTo: Scalars['Int']['output']
+  issueAccessToken: LoginModel
   me: MeModel
   meProjects: ProjectsConnection
   myApiKeys: Array<ApiKeyModel>
@@ -2924,6 +2925,10 @@ export type DeleteEndpointMutationVariables = Exact<{
 }>
 
 export type DeleteEndpointMutation = { deleteEndpoint: boolean }
+
+export type IssueAccessTokenQueryVariables = Exact<{ [key: string]: never }>
+
+export type IssueAccessTokenQuery = { issueAccessToken: { accessToken: string } }
 
 export type LoginGithubMutationVariables = Exact<{
   data: LoginGithubInput
@@ -5284,6 +5289,13 @@ export const DeleteEndpointDocument = gql`
     deleteEndpoint(data: $data)
   }
 `
+export const IssueAccessTokenDocument = gql`
+  query issueAccessToken {
+    issueAccessToken {
+      accessToken
+    }
+  }
+`
 export const LoginGithubDocument = gql`
   mutation loginGithub($data: LoginGithubInput!) {
     loginGithub(data: $data) {
@@ -6618,6 +6630,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
           }),
         'deleteEndpoint',
         'mutation',
+        variables,
+      )
+    },
+    issueAccessToken(
+      variables?: IssueAccessTokenQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<IssueAccessTokenQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<IssueAccessTokenQuery>(IssueAccessTokenDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'issueAccessToken',
+        'query',
         variables,
       )
     },

--- a/src/__generated__/schema.graphql
+++ b/src/__generated__/schema.graphql
@@ -144,8 +144,7 @@ type CacheMetricModel {
 }
 
 type CacheStatsModel {
-  byKey: [CacheMetricModel!]!
-  enabled: Boolean!
+  byCategory: [CacheMetricModel!]!
   overallHitRate: Float!
   totalClears: Int!
   totalDeletes: Int!
@@ -655,6 +654,7 @@ input LoginInput {
 
 type LoginModel {
   accessToken: String!
+  expiresIn: Int!
 }
 
 type MeModel {
@@ -903,6 +903,7 @@ type Query {
   configuration: ConfigurationModel!
   getRowCountForeignKeysTo(data: GetRowCountForeignKeysByInput!): Int!
     @deprecated(reason: "use RowModel.rowForeignKeysBy.totalCount")
+  issueAccessToken: LoginModel!
   me: MeModel!
   meProjects(data: GetMeProjectsInput!): ProjectsConnection!
   myApiKeys: [ApiKeyModel!]!

--- a/src/pages/GetTokenPage/api/getAccessToken.graphql
+++ b/src/pages/GetTokenPage/api/getAccessToken.graphql
@@ -1,0 +1,5 @@
+query issueAccessToken {
+  issueAccessToken {
+    accessToken
+  }
+}

--- a/src/pages/GetTokenPage/model/GetTokenPageViewModel.ts
+++ b/src/pages/GetTokenPage/model/GetTokenPageViewModel.ts
@@ -1,19 +1,26 @@
-import { makeAutoObservable } from 'mobx'
+import { makeAutoObservable, runInAction } from 'mobx'
 import { IViewModel } from 'src/shared/config/types.ts'
 import { container, copyToClipboard } from 'src/shared/lib'
-import { AuthService } from 'src/shared/model'
+import { ApiService } from 'src/shared/model/ApiService.ts'
 
 export class GetTokenPageViewModel implements IViewModel {
-  constructor(private readonly authService: AuthService) {
+  private _accessToken: string | null = null
+  private _loading = false
+
+  constructor(private readonly apiService: ApiService) {
     makeAutoObservable(this, {}, { autoBind: true })
   }
 
   public get hasAccessToken(): boolean {
-    return Boolean(this.authService.token)
+    return Boolean(this._accessToken)
   }
 
   public get accessToken(): string {
-    return this.authService.token || ''
+    return this._accessToken || ''
+  }
+
+  public get loading(): boolean {
+    return this._loading
   }
 
   public get truncatedToken(): string {
@@ -23,25 +30,49 @@ export class GetTokenPageViewModel implements IViewModel {
   }
 
   public async copyAccessToken(): Promise<boolean> {
-    if (!this.authService.token) return false
+    if (!this._accessToken) return false
     try {
-      await copyToClipboard(this.authService.token)
+      await copyToClipboard(this._accessToken)
       return true
     } catch {
       return false
     }
   }
 
-  public init(): void {}
+  public init(): void {
+    void this.fetchAccessToken()
+  }
 
-  public dispose(): void {}
+  public dispose(): void {
+    this._accessToken = null
+  }
+
+  private async fetchAccessToken(): Promise<void> {
+    runInAction(() => {
+      this._loading = true
+    })
+    try {
+      const result = await this.apiService.client.issueAccessToken()
+      runInAction(() => {
+        this._accessToken = result.issueAccessToken.accessToken
+      })
+    } catch {
+      runInAction(() => {
+        this._accessToken = null
+      })
+    } finally {
+      runInAction(() => {
+        this._loading = false
+      })
+    }
+  }
 }
 
 container.register(
   GetTokenPageViewModel,
   () => {
-    const authService = container.get(AuthService)
-    return new GetTokenPageViewModel(authService)
+    const apiService = container.get(ApiService)
+    return new GetTokenPageViewModel(apiService)
   },
   { scope: 'request' },
 )

--- a/src/pages/GetTokenPage/ui/GetTokenPage/GetTokenPage.tsx
+++ b/src/pages/GetTokenPage/ui/GetTokenPage/GetTokenPage.tsx
@@ -25,6 +25,16 @@ export const GetTokenPage = observer(() => {
     navigate(ROOT_ROUTE)
   }, [navigate])
 
+  if (model.loading) {
+    return (
+      <Page hideSidebar>
+        <Flex alignItems="center" justifyContent="center" flex={1}>
+          <Text color="newGray.400">Loading access token...</Text>
+        </Flex>
+      </Page>
+    )
+  }
+
   if (!model.hasAccessToken) {
     return (
       <Page hideSidebar>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the /get-token page for JWT 2.0 by fetching a fresh token via GraphQL and storing it locally so the page works with httpOnly cookies. Adds a loading state and updates generated types.

- **Bug Fixes**
  - Added GraphQL `issueAccessToken` query and SDK method.
  - `GetTokenPageViewModel` now uses `ApiService` to fetch and store the token locally (not in `AuthService`).
  - Shows a loading message while fetching; copy uses the local token.
  - Updated generated schema/types: `LoginModel.expiresIn`, `Query.issueAccessToken`, and `CacheStatsModel.byCategory`.

<sup>Written for commit 40ee81285e39b3578cc7a2f794677b3c362e739f. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/328">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

