### PR TITLE
feat: show endpoint billing limits

### DIFF
--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -2853,6 +2853,7 @@ export type GetProjectEndpointsQueryVariables = Exact<{
 }>
 
 export type GetProjectEndpointsQuery = {
+  project: { id: string; endpointUsage?: { current: number; limit?: number | null; percentage?: number | null } | null }
   projectEndpoints: {
     totalCount: number
     edges: Array<{
@@ -3038,7 +3039,13 @@ export type LimitsPagePlanFragment = {
   monthlyPriceUsd: number
   yearlyPriceUsd: number
   features: { [key: string]: any } | string | number | boolean | null
-  limits: { rowVersions?: number | null; projects?: number | null; seats?: number | null; storageBytes?: number | null }
+  limits: {
+    rowVersions?: number | null
+    projects?: number | null
+    seats?: number | null
+    storageBytes?: number | null
+    endpointsPerProject?: number | null
+  }
 }
 
 export type GetLimitsPageDataQueryVariables = Exact<{
@@ -3063,6 +3070,7 @@ export type GetLimitsPageDataQuery = {
       projects: { current: number; limit?: number | null; percentage?: number | null }
       seats: { current: number; limit?: number | null; percentage?: number | null }
       storageBytes: { current: number; limit?: number | null; percentage?: number | null }
+      endpointsPerProject: { current: number; limit?: number | null; percentage?: number | null }
     } | null
   }
 }
@@ -3082,6 +3090,7 @@ export type GetLimitsPagePlansQuery = {
       projects?: number | null
       seats?: number | null
       storageBytes?: number | null
+      endpointsPerProject?: number | null
     }
   }>
 }
@@ -4391,6 +4400,7 @@ export const LimitsPagePlanFragmentDoc = gql`
       projects
       seats
       storageBytes
+      endpointsPerProject
     }
     features
   }
@@ -5227,6 +5237,12 @@ export const GetProjectEndpointsDocument = gql`
     $branchId: String
     $type: EndpointType
   ) {
+    project(data: { organizationId: $organizationId, projectName: $projectName }) {
+      id
+      endpointUsage {
+        ...UsageMetric
+      }
+    }
     projectEndpoints(
       data: {
         organizationId: $organizationId
@@ -5253,6 +5269,7 @@ export const GetProjectEndpointsDocument = gql`
     }
   }
   ${EndpointFragmentDoc}
+  ${UsageMetricFragmentDoc}
 `
 export const GetBranchRevisionsDocument = gql`
   query getBranchRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
@@ -5398,6 +5415,9 @@ export const GetLimitsPageDataDocument = gql`
           ...UsageMetric
         }
         storageBytes {
+          ...UsageMetric
+        }
+        endpointsPerProject {
           ...UsageMetric
         }
       }

--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -3070,7 +3070,6 @@ export type GetLimitsPageDataQuery = {
       projects: { current: number; limit?: number | null; percentage?: number | null }
       seats: { current: number; limit?: number | null; percentage?: number | null }
       storageBytes: { current: number; limit?: number | null; percentage?: number | null }
-      endpointsPerProject: { current: number; limit?: number | null; percentage?: number | null }
     } | null
   }
 }
@@ -5415,9 +5414,6 @@ export const GetLimitsPageDataDocument = gql`
           ...UsageMetric
         }
         storageBytes {
-          ...UsageMetric
-        }
-        endpointsPerProject {
           ...UsageMetric
         }
       }

--- a/src/pages/EndpointsPage/api/EndpointsDataSource.ts
+++ b/src/pages/EndpointsPage/api/EndpointsDataSource.ts
@@ -6,6 +6,7 @@ import {
   EndpointBranchFragment,
   EndpointFragment,
   EndpointType,
+  UsageMetricFragment,
 } from 'src/__generated__/graphql-request'
 
 export interface CreateEndpointInput {
@@ -27,6 +28,7 @@ export interface EndpointsResult {
   hasNextPage: boolean
   endCursor: string | null
   totalCount: number
+  endpointUsage: UsageMetricFragment | null
 }
 
 export interface BranchWithRevisions {
@@ -125,6 +127,7 @@ export class EndpointsDataSource {
       hasNextPage: result.data.projectEndpoints.pageInfo.hasNextPage,
       endCursor: result.data.projectEndpoints.pageInfo.endCursor ?? null,
       totalCount: result.data.projectEndpoints.totalCount,
+      endpointUsage: result.data.project.endpointUsage ?? null,
     }
   }
 

--- a/src/pages/EndpointsPage/api/projectEndpoints.graphql
+++ b/src/pages/EndpointsPage/api/projectEndpoints.graphql
@@ -59,6 +59,12 @@ query getProjectEndpoints(
   $branchId: String
   $type: EndpointType
 ) {
+  project(data: { organizationId: $organizationId, projectName: $projectName }) {
+    id
+    endpointUsage {
+      ...UsageMetric
+    }
+  }
   projectEndpoints(
     data: {
       organizationId: $organizationId

--- a/src/pages/EndpointsPage/model/BranchEndpointsViewModel.ts
+++ b/src/pages/EndpointsPage/model/BranchEndpointsViewModel.ts
@@ -2,13 +2,18 @@ import { makeAutoObservable } from 'mobx'
 import { container } from 'src/shared/lib'
 import { EndpointType } from 'src/__generated__/graphql-request'
 import { BranchWithRevisions } from '../api/EndpointsDataSource.ts'
-import { EndpointCardViewModel, EndpointCardViewModelFactory } from './EndpointCardViewModel.ts'
+import {
+  EndpointCardViewModel,
+  EndpointCardViewModelFactory,
+  EndpointLimitDependencies,
+} from './EndpointCardViewModel.ts'
 
 export type BranchEndpointsViewModelFactoryFn = (
   branch: BranchWithRevisions,
   endpointType: EndpointType,
   draftEndpointId: string | null,
   headEndpointId: string | null,
+  limitDeps: EndpointLimitDependencies,
   onChanged: () => void,
 ) => BranchEndpointsViewModel
 
@@ -26,6 +31,7 @@ export class BranchEndpointsViewModel {
     endpointType: EndpointType,
     draftEndpointId: string | null,
     headEndpointId: string | null,
+    limitDeps: EndpointLimitDependencies,
     onChanged: () => void,
   ) {
     makeAutoObservable(this, {}, { autoBind: true })
@@ -41,6 +47,7 @@ export class BranchEndpointsViewModel {
         endpointId: draftEndpointId,
       },
       onChanged,
+      limitDeps,
     )
 
     this.headCard = endpointCardFactory.create(
@@ -54,6 +61,7 @@ export class BranchEndpointsViewModel {
         endpointId: headEndpointId,
       },
       onChanged,
+      limitDeps,
     )
   }
 
@@ -73,17 +81,20 @@ export class BranchEndpointsViewModel {
 container.register(
   BranchEndpointsViewModelFactory,
   () => {
-    return new BranchEndpointsViewModelFactory((branch, endpointType, draftEndpointId, headEndpointId, onChanged) => {
-      const endpointCardFactory = container.get(EndpointCardViewModelFactory)
-      return new BranchEndpointsViewModel(
-        endpointCardFactory,
-        branch,
-        endpointType,
-        draftEndpointId,
-        headEndpointId,
-        onChanged,
-      )
-    })
+    return new BranchEndpointsViewModelFactory(
+      (branch, endpointType, draftEndpointId, headEndpointId, limitDeps, onChanged) => {
+        const endpointCardFactory = container.get(EndpointCardViewModelFactory)
+        return new BranchEndpointsViewModel(
+          endpointCardFactory,
+          branch,
+          endpointType,
+          draftEndpointId,
+          headEndpointId,
+          limitDeps,
+          onChanged,
+        )
+      },
+    )
   },
   { scope: 'request' },
 )

--- a/src/pages/EndpointsPage/model/CreateEndpointDialogViewModel.spec.ts
+++ b/src/pages/EndpointsPage/model/CreateEndpointDialogViewModel.spec.ts
@@ -228,6 +228,21 @@ describe('CreateEndpointDialogViewModel', () => {
 
       expect(vm.canCreate).toBe(false)
     })
+
+    it('should return false when endpoint limit is reached', () => {
+      const vm = new CreateEndpointDialogViewModel(
+        createMockContext() as never,
+        createMockDataSource(),
+        createMockBranches(),
+        jest.fn(),
+        () => true,
+        () => 'Limit reached',
+      )
+
+      expect(vm.canCreate).toBe(false)
+      expect(vm.endpointLimitReached).toBe(true)
+      expect(vm.endpointLimitMessage).toBe('Limit reached')
+    })
   })
 
   describe('hasNoCustomRevisions', () => {

--- a/src/pages/EndpointsPage/model/CreateEndpointDialogViewModel.ts
+++ b/src/pages/EndpointsPage/model/CreateEndpointDialogViewModel.ts
@@ -14,6 +14,8 @@ interface RevisionOption {
 
 export type CreateEndpointDialogViewModelFactoryFn = (
   branches: BranchWithRevisions[],
+  isCreationLocked: () => boolean,
+  getCreationLockedReason: () => string | null,
   onCreated: () => void,
 ) => CreateEndpointDialogViewModel
 
@@ -36,7 +38,9 @@ export class CreateEndpointDialogViewModel {
     private readonly context: ProjectContext,
     private readonly dataSource: EndpointsDataSource,
     private readonly branches: BranchWithRevisions[],
-    private readonly onCreated: () => void,
+    private readonly onCreated: () => void = () => undefined,
+    private readonly isCreationLocked: () => boolean = () => false,
+    private readonly getCreationLockedReason: () => string | null = () => null,
   ) {
     makeAutoObservable(this, {}, { autoBind: true })
   }
@@ -89,7 +93,7 @@ export class CreateEndpointDialogViewModel {
   }
 
   public get canCreate(): boolean {
-    if (!this._selectedRevisionId || this._isCreating) {
+    if (!this._selectedRevisionId || this._isCreating || this.endpointLimitReached) {
       return false
     }
 
@@ -114,6 +118,14 @@ export class CreateEndpointDialogViewModel {
       return revision.hasGraphql
     }
     return revision.hasRestApi
+  }
+
+  public get endpointLimitReached(): boolean {
+    return this.isCreationLocked()
+  }
+
+  public get endpointLimitMessage(): string | null {
+    return this.getCreationLockedReason()
   }
 
   public open(): void {
@@ -222,11 +234,20 @@ export class CreateEndpointDialogViewModel {
 container.register(
   CreateEndpointDialogViewModelFactory,
   () => {
-    return new CreateEndpointDialogViewModelFactory((branches, onCreated) => {
-      const context = container.get(ProjectContext)
-      const dataSource = container.get(EndpointsDataSource)
-      return new CreateEndpointDialogViewModel(context, dataSource, branches, onCreated)
-    })
+    return new CreateEndpointDialogViewModelFactory(
+      (branches, isCreationLocked, getCreationLockedReason, onCreated) => {
+        const context = container.get(ProjectContext)
+        const dataSource = container.get(EndpointsDataSource)
+        return new CreateEndpointDialogViewModel(
+          context,
+          dataSource,
+          branches,
+          onCreated,
+          isCreationLocked,
+          getCreationLockedReason,
+        )
+      },
+    )
   },
   { scope: 'request' },
 )

--- a/src/pages/EndpointsPage/model/EndpointCardViewModel.spec.ts
+++ b/src/pages/EndpointsPage/model/EndpointCardViewModel.spec.ts
@@ -179,6 +179,25 @@ describe('EndpointCardViewModel', () => {
 
       expect(vm.canDelete).toBe(false)
     })
+
+    it('should block creation when endpoint limit is reached', () => {
+      const vm = new EndpointCardViewModel(
+        createMockContext() as never,
+        createMockProjectPermissions() as never,
+        createMockDataSource(),
+        createMockData(),
+        jest.fn(),
+        { urlBuilder: createMockUrlBuilder(), copyToClipboard: jest.fn() },
+        {
+          isCreationLocked: () => true,
+          getCreationLockedReason: () => 'Limit reached',
+        },
+      )
+
+      expect(vm.canCreate).toBe(false)
+      expect(vm.isLockedDisabled).toBe(true)
+      expect(vm.creationLockedReason).toBe('Limit reached')
+    })
   })
 
   describe('URLs', () => {
@@ -261,6 +280,27 @@ describe('EndpointCardViewModel', () => {
       await vm.enable()
 
       expect(dataSource.createEndpoint).not.toHaveBeenCalled()
+    })
+
+    it('should not create endpoint when endpoint limit is reached', async () => {
+      const dataSource = createMockDataSource()
+      const vm = new EndpointCardViewModel(
+        createMockContext() as never,
+        createMockProjectPermissions() as never,
+        dataSource,
+        createMockData({ endpointId: null }),
+        jest.fn(),
+        { urlBuilder: createMockUrlBuilder(), copyToClipboard: jest.fn() },
+        {
+          isCreationLocked: () => true,
+          getCreationLockedReason: () => 'Limit reached',
+        },
+      )
+
+      await vm.enable()
+
+      expect(dataSource.createEndpoint).not.toHaveBeenCalled()
+      expect(vm.isEnabled).toBe(false)
     })
 
     it('should not create endpoint if already creating', async () => {

--- a/src/pages/EndpointsPage/model/EndpointCardViewModel.ts
+++ b/src/pages/EndpointsPage/model/EndpointCardViewModel.ts
@@ -23,12 +23,26 @@ export interface EndpointCardDependencies {
   copyToClipboard: (text: string) => Promise<void>
 }
 
+export interface EndpointLimitDependencies {
+  isCreationLocked: () => boolean
+  getCreationLockedReason: () => string | null
+}
+
 const defaultDependencies: EndpointCardDependencies = {
   urlBuilder: new EndpointUrlBuilder(),
   copyToClipboard,
 }
 
-export type EndpointCardViewModelFactoryFn = (data: EndpointCardData, onChanged: () => void) => EndpointCardViewModel
+const defaultLimitDependencies: EndpointLimitDependencies = {
+  isCreationLocked: () => false,
+  getCreationLockedReason: () => null,
+}
+
+export type EndpointCardViewModelFactoryFn = (
+  data: EndpointCardData,
+  onChanged: () => void,
+  limitDeps?: EndpointLimitDependencies,
+) => EndpointCardViewModel
 
 export class EndpointCardViewModelFactory {
   constructor(public readonly create: EndpointCardViewModelFactoryFn) {}
@@ -47,6 +61,7 @@ export class EndpointCardViewModel {
     private readonly data: EndpointCardData,
     private readonly onChanged: () => void,
     private readonly deps: EndpointCardDependencies = defaultDependencies,
+    private readonly limitDeps: EndpointLimitDependencies = defaultLimitDependencies,
   ) {
     makeAutoObservable(this, {}, { autoBind: true })
     this._endpointId = data.endpointId
@@ -104,11 +119,23 @@ export class EndpointCardViewModel {
   }
 
   public get canCreate(): boolean {
-    return this.projectPermissions.canCreateEndpoint
+    return this.projectPermissions.canCreateEndpoint && !this.isCreationLocked
   }
 
   public get canDelete(): boolean {
     return this.projectPermissions.canDeleteEndpoint
+  }
+
+  public get isCreationLocked(): boolean {
+    return this.limitDeps.isCreationLocked()
+  }
+
+  public get creationLockedReason(): string | null {
+    return this.limitDeps.getCreationLockedReason()
+  }
+
+  public get isLockedDisabled(): boolean {
+    return !this.isEnabled && this.isCreationLocked
   }
 
   public get graphqlUrl(): string {
@@ -143,7 +170,7 @@ export class EndpointCardViewModel {
   }
 
   public async enable(): Promise<void> {
-    if (this._isCreating || this._endpointId) {
+    if (this._isCreating || this._endpointId || this.isCreationLocked) {
       return
     }
 
@@ -203,11 +230,19 @@ export class EndpointCardViewModel {
 container.register(
   EndpointCardViewModelFactory,
   () => {
-    return new EndpointCardViewModelFactory((data, onChanged) => {
+    return new EndpointCardViewModelFactory((data, onChanged, limitDeps = defaultLimitDependencies) => {
       const context = container.get(ProjectContext)
       const projectPermissions = container.get(ProjectPermissions)
       const dataSource = container.get(EndpointsDataSource)
-      return new EndpointCardViewModel(context, projectPermissions, dataSource, data, onChanged)
+      return new EndpointCardViewModel(
+        context,
+        projectPermissions,
+        dataSource,
+        data,
+        onChanged,
+        defaultDependencies,
+        limitDeps,
+      )
     })
   },
   { scope: 'request' },

--- a/src/pages/EndpointsPage/model/EndpointsPageViewModel.ts
+++ b/src/pages/EndpointsPage/model/EndpointsPageViewModel.ts
@@ -4,7 +4,7 @@ import { ProjectContext } from 'src/entities/Project/model/ProjectContext.ts'
 import { IViewModel } from 'src/shared/config/types.ts'
 import { container } from 'src/shared/lib'
 import { ProjectPermissions } from 'src/shared/model/AbilityService'
-import { EndpointFragment, EndpointType } from 'src/__generated__/graphql-request'
+import { EndpointFragment, EndpointType, UsageMetricFragment } from 'src/__generated__/graphql-request'
 import { BranchWithRevisions, EndpointsDataSource } from '../api/EndpointsDataSource.ts'
 import { BranchEndpointsViewModel, BranchEndpointsViewModelFactory } from './BranchEndpointsViewModel.ts'
 import { CreateEndpointDialogViewModel, CreateEndpointDialogViewModelFactory } from './CreateEndpointDialogViewModel.ts'
@@ -27,6 +27,7 @@ export class EndpointsPageViewModel implements IViewModel {
   private _branchViewModels: BranchEndpointsViewModel[] = []
   private _customEndpointViewModels: CustomEndpointCardViewModel[] = []
   private _createDialogViewModel: CreateEndpointDialogViewModel | null = null
+  private _endpointUsage: UsageMetricFragment | null = null
 
   public readonly systemApi: SystemApiViewModel
 
@@ -122,6 +123,46 @@ export class EndpointsPageViewModel implements IViewModel {
     return this.projectPermissions.canCreateEndpoint
   }
 
+  public get endpointUsage(): UsageMetricFragment | null {
+    return this._endpointUsage
+  }
+
+  public get endpointLimitLabel(): string {
+    const limit = this._endpointUsage?.limit
+    if (limit === null || limit === undefined) {
+      return 'Unlimited'
+    }
+    return String(limit)
+  }
+
+  public get endpointUsageLabel(): string {
+    const current = this._endpointUsage?.current ?? 0
+    const limit = this._endpointUsage?.limit
+    if (limit === null || limit === undefined) {
+      return `${current} used`
+    }
+    return `${current} / ${limit}`
+  }
+
+  public get isEndpointCreationLocked(): boolean {
+    const usage = this._endpointUsage
+    if (!usage || usage.limit === null || usage.limit === undefined) {
+      return false
+    }
+    return usage.current >= usage.limit
+  }
+
+  public get endpointLimitMessage(): string | null {
+    if (!this.isEndpointCreationLocked) {
+      return null
+    }
+    return 'Endpoint limit reached for this project. Upgrade your plan or remove an endpoint to create another one.'
+  }
+
+  public get canOpenCreateDialog(): boolean {
+    return this.canCreateEndpoint && !this.isEndpointCreationLocked
+  }
+
   public get canDeleteEndpoint(): boolean {
     return this.projectPermissions.canDeleteEndpoint
   }
@@ -131,7 +172,16 @@ export class EndpointsPageViewModel implements IViewModel {
   }
 
   public openCreateDialog(): void {
-    this._createDialogViewModel ??= this.createDialogFactory.create(this._branches, this.handleEndpointChanged)
+    if (!this.canOpenCreateDialog) {
+      return
+    }
+
+    this._createDialogViewModel ??= this.createDialogFactory.create(
+      this._branches,
+      () => this.isEndpointCreationLocked,
+      () => this.endpointLimitMessage,
+      this.handleEndpointChanged,
+    )
     this._createDialogViewModel.open()
   }
 
@@ -174,6 +224,7 @@ export class EndpointsPageViewModel implements IViewModel {
 
       this._branches = this.sortBranches(branches)
       this._endpoints = endpointsResult.items
+      this._endpointUsage = endpointsResult.endpointUsage
       this.rebuildViewModels()
       this._state = State.ready
     })
@@ -189,6 +240,7 @@ export class EndpointsPageViewModel implements IViewModel {
     runInAction(() => {
       if (endpointsResult) {
         this._endpoints = endpointsResult.items
+        this._endpointUsage = endpointsResult.endpointUsage
         this.rebuildViewModels()
       }
     })
@@ -222,6 +274,10 @@ export class EndpointsPageViewModel implements IViewModel {
         endpointType,
         draftEndpointId,
         headEndpointId,
+        {
+          isCreationLocked: () => this.isEndpointCreationLocked,
+          getCreationLockedReason: () => this.endpointLimitMessage,
+        },
         this.handleEndpointChanged,
       )
     })

--- a/src/pages/EndpointsPage/ui/CreateEndpointDialog/CreateEndpointDialog.tsx
+++ b/src/pages/EndpointsPage/ui/CreateEndpointDialog/CreateEndpointDialog.tsx
@@ -101,6 +101,12 @@ export const CreateEndpointDialog: FC<CreateEndpointDialogProps> = observer(({ m
                     endpoint.
                   </Text>
                 )}
+
+                {model.endpointLimitMessage && (
+                  <Text fontSize="sm" color="orange.500">
+                    {model.endpointLimitMessage}
+                  </Text>
+                )}
               </VStack>
             </Dialog.Body>
             <Dialog.Footer>

--- a/src/pages/EndpointsPage/ui/EndpointCard/EndpointCard.tsx
+++ b/src/pages/EndpointsPage/ui/EndpointCard/EndpointCard.tsx
@@ -94,47 +94,47 @@ export const EndpointCard: FC<EndpointCardProps> = observer(({ model }) => {
           </HStack>
 
           {(model.canCreate || model.canDelete || model.isLockedDisabled) && (
-            <Tooltip content={switchTooltip ?? ''} disabled={!switchTooltip}>
-              <Popover.Root
-                open={isDisablePopoverOpen}
-                onOpenChange={(e) => setIsDisablePopoverOpen(e.open)}
-                positioning={{ placement: 'bottom-end' }}
-              >
-                <Popover.Anchor>
-                  <Switch.Root
-                    size="sm"
-                    checked={model.isEnabled}
-                    disabled={switchDisabled}
-                    onCheckedChange={handleToggle}
-                  >
-                    <Switch.HiddenInput />
+            <Popover.Root
+              open={isDisablePopoverOpen}
+              onOpenChange={(e) => setIsDisablePopoverOpen(e.open)}
+              positioning={{ placement: 'bottom-end' }}
+            >
+              <Popover.Anchor asChild>
+                <Switch.Root
+                  size="sm"
+                  checked={model.isEnabled}
+                  disabled={switchDisabled}
+                  onCheckedChange={handleToggle}
+                >
+                  <Switch.HiddenInput />
+                  <Tooltip content={switchTooltip ?? ''} disabled={!switchTooltip}>
                     <Switch.Control />
-                  </Switch.Root>
-                </Popover.Anchor>
-                <Portal>
-                  <Popover.Positioner>
-                    <Popover.Content maxWidth="280px">
-                      <Popover.Arrow>
-                        <Popover.ArrowTip />
-                      </Popover.Arrow>
-                      <Popover.Body>
-                        <Text fontSize="sm" mb={3}>
-                          Are you sure? This endpoint will be disabled and API consumers will lose access.
-                        </Text>
-                        <HStack justify="flex-end" gap={2}>
-                          <Button size="xs" variant="ghost" onClick={handleDisableCancel}>
-                            Cancel
-                          </Button>
-                          <Button size="xs" colorPalette="red" onClick={handleDisableConfirm}>
-                            Disable
-                          </Button>
-                        </HStack>
-                      </Popover.Body>
-                    </Popover.Content>
-                  </Popover.Positioner>
-                </Portal>
-              </Popover.Root>
-            </Tooltip>
+                  </Tooltip>
+                </Switch.Root>
+              </Popover.Anchor>
+              <Portal>
+                <Popover.Positioner>
+                  <Popover.Content maxWidth="280px">
+                    <Popover.Arrow>
+                      <Popover.ArrowTip />
+                    </Popover.Arrow>
+                    <Popover.Body>
+                      <Text fontSize="sm" mb={3}>
+                        Are you sure? This endpoint will be disabled and API consumers will lose access.
+                      </Text>
+                      <HStack justify="flex-end" gap={2}>
+                        <Button size="xs" variant="ghost" onClick={handleDisableCancel}>
+                          Cancel
+                        </Button>
+                        <Button size="xs" colorPalette="red" onClick={handleDisableConfirm}>
+                          Disable
+                        </Button>
+                      </HStack>
+                    </Popover.Body>
+                  </Popover.Content>
+                </Popover.Positioner>
+              </Portal>
+            </Popover.Root>
           )}
         </HStack>
       </Flex>

--- a/src/pages/EndpointsPage/ui/EndpointCard/EndpointCard.tsx
+++ b/src/pages/EndpointsPage/ui/EndpointCard/EndpointCard.tsx
@@ -34,6 +34,9 @@ export const EndpointCard: FC<EndpointCardProps> = observer(({ model }) => {
   }, [])
 
   const tooltipContent = model.revisionType === 'draft' ? DRAFT_TOOLTIP : HEAD_TOOLTIP
+  const switchDisabled =
+    model.isLoading || (!model.canCreate && !model.isEnabled) || (!model.canDelete && model.isEnabled)
+  const switchTooltip = model.isLockedDisabled ? model.creationLockedReason : null
 
   return (
     <Box
@@ -90,48 +93,48 @@ export const EndpointCard: FC<EndpointCardProps> = observer(({ model }) => {
             />
           </HStack>
 
-          {(model.canCreate || model.canDelete) && (
-            <Popover.Root
-              open={isDisablePopoverOpen}
-              onOpenChange={(e) => setIsDisablePopoverOpen(e.open)}
-              positioning={{ placement: 'bottom-end' }}
-            >
-              <Popover.Anchor>
-                <Switch.Root
-                  size="sm"
-                  checked={model.isEnabled}
-                  disabled={
-                    model.isLoading || (!model.canCreate && !model.isEnabled) || (!model.canDelete && model.isEnabled)
-                  }
-                  onCheckedChange={handleToggle}
-                >
-                  <Switch.HiddenInput />
-                  <Switch.Control />
-                </Switch.Root>
-              </Popover.Anchor>
-              <Portal>
-                <Popover.Positioner>
-                  <Popover.Content maxWidth="280px">
-                    <Popover.Arrow>
-                      <Popover.ArrowTip />
-                    </Popover.Arrow>
-                    <Popover.Body>
-                      <Text fontSize="sm" mb={3}>
-                        Are you sure? This endpoint will be disabled and API consumers will lose access.
-                      </Text>
-                      <HStack justify="flex-end" gap={2}>
-                        <Button size="xs" variant="ghost" onClick={handleDisableCancel}>
-                          Cancel
-                        </Button>
-                        <Button size="xs" colorPalette="red" onClick={handleDisableConfirm}>
-                          Disable
-                        </Button>
-                      </HStack>
-                    </Popover.Body>
-                  </Popover.Content>
-                </Popover.Positioner>
-              </Portal>
-            </Popover.Root>
+          {(model.canCreate || model.canDelete || model.isLockedDisabled) && (
+            <Tooltip content={switchTooltip ?? ''} disabled={!switchTooltip}>
+              <Popover.Root
+                open={isDisablePopoverOpen}
+                onOpenChange={(e) => setIsDisablePopoverOpen(e.open)}
+                positioning={{ placement: 'bottom-end' }}
+              >
+                <Popover.Anchor>
+                  <Switch.Root
+                    size="sm"
+                    checked={model.isEnabled}
+                    disabled={switchDisabled}
+                    onCheckedChange={handleToggle}
+                  >
+                    <Switch.HiddenInput />
+                    <Switch.Control />
+                  </Switch.Root>
+                </Popover.Anchor>
+                <Portal>
+                  <Popover.Positioner>
+                    <Popover.Content maxWidth="280px">
+                      <Popover.Arrow>
+                        <Popover.ArrowTip />
+                      </Popover.Arrow>
+                      <Popover.Body>
+                        <Text fontSize="sm" mb={3}>
+                          Are you sure? This endpoint will be disabled and API consumers will lose access.
+                        </Text>
+                        <HStack justify="flex-end" gap={2}>
+                          <Button size="xs" variant="ghost" onClick={handleDisableCancel}>
+                            Cancel
+                          </Button>
+                          <Button size="xs" colorPalette="red" onClick={handleDisableConfirm}>
+                            Disable
+                          </Button>
+                        </HStack>
+                      </Popover.Body>
+                    </Popover.Content>
+                  </Popover.Positioner>
+                </Portal>
+              </Popover.Root>
+            </Tooltip>
           )}
         </HStack>
       </Flex>

--- a/src/pages/EndpointsPage/ui/EndpointsPage/EndpointsPage.tsx
+++ b/src/pages/EndpointsPage/ui/EndpointsPage/EndpointsPage.tsx
@@ -1,4 +1,17 @@
-import { Box, Button, Flex, HStack, HoverCard, Icon, Portal, Spinner, Tabs, Text, VStack } from '@chakra-ui/react'
+import {
+  Badge,
+  Box,
+  Button,
+  Flex,
+  HStack,
+  HoverCard,
+  Icon,
+  Portal,
+  Spinner,
+  Tabs,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
 import { observer } from 'mobx-react-lite'
 import { PiInfoLight, PiPlusLight } from 'react-icons/pi'
 import { EndpointsPageViewModel, TabType } from 'src/pages/EndpointsPage/model/EndpointsPageViewModel.ts'
@@ -48,14 +61,35 @@ export const EndpointsPage = observer(() => {
             />
           </HStack>
           {model.canCreateEndpoint && (
-            <Tooltip content="Create endpoint for a specific revision (not just Draft/Head)">
-              <Button size="xs" variant="ghost" color="newGray.400" onClick={model.openCreateDialog}>
+            <Tooltip
+              content={model.endpointLimitMessage ?? 'Create endpoint for a specific revision (not just Draft/Head)'}
+            >
+              <Button
+                size="xs"
+                variant="ghost"
+                color="newGray.400"
+                onClick={model.openCreateDialog}
+                disabled={!model.canOpenCreateDialog}
+              >
                 <PiPlusLight />
                 Add custom
               </Button>
             </Tooltip>
           )}
         </HStack>
+        <HStack gap={2} mb={4}>
+          <Badge colorPalette={model.isEndpointCreationLocked ? 'orange' : 'green'} variant="subtle" size="sm">
+            {model.endpointLimitLabel === 'Unlimited' ? 'Unlimited' : `Limit ${model.endpointLimitLabel}`}
+          </Badge>
+          <Text fontSize="xs" color="newGray.500">
+            Endpoints in this project: {model.endpointUsageLabel}
+          </Text>
+        </HStack>
+        {model.endpointLimitMessage && (
+          <Text fontSize="xs" color="orange.500" mb={4}>
+            {model.endpointLimitMessage}
+          </Text>
+        )}
         <HStack gap={1} mb={6}>
           <Text fontSize="xs" color="newGray.400">
             Auto-generated APIs from your table schemas.

--- a/src/pages/OrganizationLimitsPage/api/get-limits-page.graphql
+++ b/src/pages/OrganizationLimitsPage/api/get-limits-page.graphql
@@ -54,9 +54,6 @@ query getLimitsPageData($data: GetOrganizationInput!) {
       storageBytes {
         ...UsageMetric
       }
-      endpointsPerProject {
-        ...UsageMetric
-      }
     }
   }
 }

--- a/src/pages/OrganizationLimitsPage/api/get-limits-page.graphql
+++ b/src/pages/OrganizationLimitsPage/api/get-limits-page.graphql
@@ -25,6 +25,7 @@ fragment LimitsPagePlan on PlanModel {
     projects
     seats
     storageBytes
+    endpointsPerProject
   }
   features
 }
@@ -51,6 +52,9 @@ query getLimitsPageData($data: GetOrganizationInput!) {
         ...UsageMetric
       }
       storageBytes {
+        ...UsageMetric
+      }
+      endpointsPerProject {
         ...UsageMetric
       }
     }

--- a/src/pages/OrganizationLimitsPage/model/LimitsPageViewModel.ts
+++ b/src/pages/OrganizationLimitsPage/model/LimitsPageViewModel.ts
@@ -145,6 +145,7 @@ export class LimitsPageViewModel implements IViewModel {
       new UsageItemViewModel(u.projects, 'Projects', 'number'),
       new UsageItemViewModel(u.seats, 'Members', 'number'),
       new UsageItemViewModel(u.storageBytes, 'Storage', 'storage'),
+      new UsageItemViewModel(u.endpointsPerProject, 'Endpoints / Project', 'number'),
     ]
   }
 

--- a/src/pages/OrganizationLimitsPage/model/LimitsPageViewModel.ts
+++ b/src/pages/OrganizationLimitsPage/model/LimitsPageViewModel.ts
@@ -145,7 +145,6 @@ export class LimitsPageViewModel implements IViewModel {
       new UsageItemViewModel(u.projects, 'Projects', 'number'),
       new UsageItemViewModel(u.seats, 'Members', 'number'),
       new UsageItemViewModel(u.storageBytes, 'Storage', 'storage'),
-      new UsageItemViewModel(u.endpointsPerProject, 'Endpoints / Project', 'number'),
     ]
   }
 

--- a/src/pages/OrganizationLimitsPage/model/PlanItemViewModel.ts
+++ b/src/pages/OrganizationLimitsPage/model/PlanItemViewModel.ts
@@ -74,6 +74,10 @@ export class PlanItemViewModel {
     return formatLimitStorage(this.plan.limits.storageBytes)
   }
 
+  public get endpointsPerProjectLimit(): string {
+    return formatLimitNumber(this.plan.limits.endpointsPerProject)
+  }
+
   public async handleClick(): Promise<void> {
     if (this.canUpgrade) {
       if (this.earlyAccessAvailable) {

--- a/src/pages/OrganizationLimitsPage/ui/PlanCard/PlanCard.tsx
+++ b/src/pages/OrganizationLimitsPage/ui/PlanCard/PlanCard.tsx
@@ -46,6 +46,9 @@ export const PlanCard: FC<PlanCardProps> = observer(({ model, parentModel }) => 
           <Text fontSize="xs" color="gray.500">
             {model.storageLimit} storage
           </Text>
+          <Text fontSize="xs" color="gray.500">
+            {model.endpointsPerProjectLimit} endpoints / project
+          </Text>
         </VStack>
         <Button
           size="sm"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show “endpoints per project” limits and current usage, and block creating new endpoints when a project hits its limit. Adds clear badges, tooltips, and messages on Endpoints and Organization Limits pages.

- **New Features**
  - Endpoints page: fetches `project.endpointUsage`; shows a limit badge and used/limit text; disables “Add custom” and endpoint toggles when at limit with a tooltip; blocks creation in cards and the Create Endpoint dialog with an inline warning.
  - Organization Limits page: adds `endpointsPerProject` to plan limits; displays “endpoints / project” on plan cards.
  - GraphQL/types: extends `getProjectEndpoints` with `project { endpointUsage }`; adds `endpointsPerProject` to limits and `getLimitsPageData`; updates generated types.
  - Tests: adds coverage for locked creation in card and dialog view models.
  - Refactor: removes the organization endpoint usage card.

- **Bug Fixes**
  - Attaches the limit tooltip directly to the endpoint switch control so users see the reason when the toggle is disabled.

<sup>Written for commit 2a29a2308f53160ee1c365d9d91e422fa946b061. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/330">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

