### PR TITLE
Add project file usage admin panel

### DIFF
--- a/__mocks__/sharedLibMock.ts
+++ b/__mocks__/sharedLibMock.ts
@@ -16,3 +16,4 @@ export const copyToClipboard = jest.fn().mockResolvedValue(undefined)
 export { StackItem, StackManager, createStackRequest, createStackContext } from '../src/shared/lib/Stack'
 export type { StackRequest } from '../src/shared/lib/Stack'
 export { ObservableRequest } from '../src/shared/lib/ObservableRequest'
+export { isAborted } from '../src/shared/lib/Either'

--- a/src/__generated__/globalTypes.ts
+++ b/src/__generated__/globalTypes.ts
@@ -716,6 +716,7 @@ export type Mutation = {
   addUserToOrganization: Scalars['Boolean']['output']
   addUserToProject: Scalars['Boolean']['output']
   adminResetAllCache: Scalars['Boolean']['output']
+  adminRestoreProjectFileBytes: RestoreProjectFileBytesResultModel
   applyMigrations: Array<ApplyMigrationResultModel>
   cancelSubscription: Scalars['Boolean']['output']
   confirmEmailCode: LoginModel
@@ -770,6 +771,10 @@ export type MutationAddUserToOrganizationArgs = {
 
 export type MutationAddUserToProjectArgs = {
   data: AddUserToProjectInput
+}
+
+export type MutationAdminRestoreProjectFileBytesArgs = {
+  data: RestoreProjectFileBytesInput
 }
 
 export type MutationApplyMigrationsArgs = {
@@ -1063,6 +1068,7 @@ export type PlanLimitsModel = {
   __typename: 'PlanLimitsModel'
   apiCallsPerDay?: Maybe<Scalars['Int']['output']>
   branchesPerProject?: Maybe<Scalars['Int']['output']>
+  endpointsPerProject?: Maybe<Scalars['Int']['output']>
   projects?: Maybe<Scalars['Int']['output']>
   rowVersions?: Maybe<Scalars['Int']['output']>
   rowsPerTable?: Maybe<Scalars['Int']['output']>
@@ -1087,10 +1093,21 @@ export type PluginsModel = {
   file: Scalars['Boolean']['output']
 }
 
+export type ProjectFileUsageReportModel = {
+  __typename: 'ProjectFileUsageReportModel'
+  currentFileBytes: Scalars['String']['output']
+  drift: Scalars['String']['output']
+  expectedFileBytes: Scalars['String']['output']
+  fileBlobCount: Scalars['Int']['output']
+  projectId: Scalars['ID']['output']
+  referenceCount: Scalars['Int']['output']
+}
+
 export type ProjectModel = {
   __typename: 'ProjectModel'
   allBranches: BranchesConnection
   createdAt: Scalars['DateTime']['output']
+  endpointUsage: UsageMetricModel
   id: Scalars['String']['output']
   isPublic: Scalars['Boolean']['output']
   name: Scalars['String']['output']
@@ -1122,6 +1139,7 @@ export type Query = {
   adminCacheStats: CacheStatsModel
   adminUser?: Maybe<UserModel>
   adminUsers: UsersConnection
+  adminValidateProjectFileBytes: ProjectFileUsageReportModel
   apiKeyById: ApiKeyModel
   availableProviders: Array<PaymentProviderModel>
   branch: BranchModel
@@ -1161,6 +1179,10 @@ export type QueryAdminUserArgs = {
 
 export type QueryAdminUsersArgs = {
   data: SearchUsersInput
+}
+
+export type QueryAdminValidateProjectFileBytesArgs = {
+  data: ValidateProjectFileBytesInput
 }
 
 export type QueryApiKeyByIdArgs = {
@@ -1318,6 +1340,20 @@ export type RenameTableResultModel = {
 export type ResetPasswordInput = {
   newPassword: Scalars['String']['input']
   userId: Scalars['String']['input']
+}
+
+export type RestoreProjectFileBytesInput = {
+  dryRun?: InputMaybe<Scalars['Boolean']['input']>
+  projectId: Scalars['ID']['input']
+}
+
+export type RestoreProjectFileBytesResultModel = {
+  __typename: 'RestoreProjectFileBytesResultModel'
+  drift: Scalars['String']['output']
+  dryRun: Scalars['Boolean']['output']
+  nextFileBytes: Scalars['String']['output']
+  previousFileBytes: Scalars['String']['output']
+  projectId: Scalars['ID']['output']
 }
 
 export type RevertChangesInput = {
@@ -1987,6 +2023,10 @@ export type UsersProjectModelEdge = {
   __typename: 'UsersProjectModelEdge'
   cursor: Scalars['String']['output']
   node: UsersProjectModel
+}
+
+export type ValidateProjectFileBytesInput = {
+  projectId: Scalars['ID']['input']
 }
 
 export type ViewChangeModel = {

--- a/src/__generated__/graphql-request.ts
+++ b/src/__generated__/graphql-request.ts
@@ -687,6 +687,7 @@ export type Mutation = {
   addUserToOrganization: Scalars['Boolean']['output']
   addUserToProject: Scalars['Boolean']['output']
   adminResetAllCache: Scalars['Boolean']['output']
+  adminRestoreProjectFileBytes: RestoreProjectFileBytesResultModel
   applyMigrations: Array<ApplyMigrationResultModel>
   cancelSubscription: Scalars['Boolean']['output']
   confirmEmailCode: LoginModel
@@ -741,6 +742,10 @@ export type MutationAddUserToOrganizationArgs = {
 
 export type MutationAddUserToProjectArgs = {
   data: AddUserToProjectInput
+}
+
+export type MutationAdminRestoreProjectFileBytesArgs = {
+  data: RestoreProjectFileBytesInput
 }
 
 export type MutationApplyMigrationsArgs = {
@@ -1026,6 +1031,7 @@ export type PermissionModel = {
 export type PlanLimitsModel = {
   apiCallsPerDay?: Maybe<Scalars['Int']['output']>
   branchesPerProject?: Maybe<Scalars['Int']['output']>
+  endpointsPerProject?: Maybe<Scalars['Int']['output']>
   projects?: Maybe<Scalars['Int']['output']>
   rowVersions?: Maybe<Scalars['Int']['output']>
   rowsPerTable?: Maybe<Scalars['Int']['output']>
@@ -1048,9 +1054,19 @@ export type PluginsModel = {
   file: Scalars['Boolean']['output']
 }
 
+export type ProjectFileUsageReportModel = {
+  currentFileBytes: Scalars['String']['output']
+  drift: Scalars['String']['output']
+  expectedFileBytes: Scalars['String']['output']
+  fileBlobCount: Scalars['Int']['output']
+  projectId: Scalars['ID']['output']
+  referenceCount: Scalars['Int']['output']
+}
+
 export type ProjectModel = {
   allBranches: BranchesConnection
   createdAt: Scalars['DateTime']['output']
+  endpointUsage: UsageMetricModel
   id: Scalars['String']['output']
   isPublic: Scalars['Boolean']['output']
   name: Scalars['String']['output']
@@ -1079,6 +1095,7 @@ export type Query = {
   adminCacheStats: CacheStatsModel
   adminUser?: Maybe<UserModel>
   adminUsers: UsersConnection
+  adminValidateProjectFileBytes: ProjectFileUsageReportModel
   apiKeyById: ApiKeyModel
   availableProviders: Array<PaymentProviderModel>
   branch: BranchModel
@@ -1118,6 +1135,10 @@ export type QueryAdminUserArgs = {
 
 export type QueryAdminUsersArgs = {
   data: SearchUsersInput
+}
+
+export type QueryAdminValidateProjectFileBytesArgs = {
+  data: ValidateProjectFileBytesInput
 }
 
 export type QueryApiKeyByIdArgs = {
@@ -1272,6 +1293,19 @@ export type RenameTableResultModel = {
 export type ResetPasswordInput = {
   newPassword: Scalars['String']['input']
   userId: Scalars['String']['input']
+}
+
+export type RestoreProjectFileBytesInput = {
+  dryRun?: InputMaybe<Scalars['Boolean']['input']>
+  projectId: Scalars['ID']['input']
+}
+
+export type RestoreProjectFileBytesResultModel = {
+  drift: Scalars['String']['output']
+  dryRun: Scalars['Boolean']['output']
+  nextFileBytes: Scalars['String']['output']
+  previousFileBytes: Scalars['String']['output']
+  projectId: Scalars['ID']['output']
 }
 
 export type RevertChangesInput = {
@@ -1894,6 +1928,10 @@ export type UsersProjectModel = {
 export type UsersProjectModelEdge = {
   cursor: Scalars['String']['output']
   node: UsersProjectModel
+}
+
+export type ValidateProjectFileBytesInput = {
+  projectId: Scalars['ID']['input']
 }
 
 export type ViewChangeModel = {
@@ -2853,7 +2891,7 @@ export type GetProjectEndpointsQueryVariables = Exact<{
 }>
 
 export type GetProjectEndpointsQuery = {
-  project: { id: string; endpointUsage?: { current: number; limit?: number | null; percentage?: number | null } | null }
+  project: { id: string; endpointUsage: { current: number; limit?: number | null; percentage?: number | null } }
   projectEndpoints: {
     totalCount: number
     edges: Array<{
@@ -3135,6 +3173,35 @@ export type RemoveUserFromOrganizationMutationVariables = Exact<{
 }>
 
 export type RemoveUserFromOrganizationMutation = { removeUserFromOrganization: boolean }
+
+export type AdminValidateProjectFileBytesQueryVariables = Exact<{
+  data: ValidateProjectFileBytesInput
+}>
+
+export type AdminValidateProjectFileBytesQuery = {
+  adminValidateProjectFileBytes: {
+    projectId: string
+    currentFileBytes: string
+    expectedFileBytes: string
+    drift: string
+    fileBlobCount: number
+    referenceCount: number
+  }
+}
+
+export type AdminRestoreProjectFileBytesMutationVariables = Exact<{
+  data: RestoreProjectFileBytesInput
+}>
+
+export type AdminRestoreProjectFileBytesMutation = {
+  adminRestoreProjectFileBytes: {
+    projectId: string
+    previousFileBytes: string
+    nextFileBytes: string
+    drift: string
+    dryRun: boolean
+  }
+}
 
 export type UpdateProjectMutationVariables = Exact<{
   data: UpdateProjectInput
@@ -5267,8 +5334,8 @@ export const GetProjectEndpointsDocument = gql`
       totalCount
     }
   }
-  ${EndpointFragmentDoc}
   ${UsageMetricFragmentDoc}
+  ${EndpointFragmentDoc}
 `
 export const GetBranchRevisionsDocument = gql`
   query getBranchRevisions($data: GetBranchInput!, $revisionsData: GetBranchRevisionsInput!) {
@@ -5458,6 +5525,29 @@ export const AddUserToOrganizationDocument = gql`
 export const RemoveUserFromOrganizationDocument = gql`
   mutation removeUserFromOrganization($organizationId: String!, $userId: String!) {
     removeUserFromOrganization(data: { organizationId: $organizationId, userId: $userId })
+  }
+`
+export const AdminValidateProjectFileBytesDocument = gql`
+  query adminValidateProjectFileBytes($data: ValidateProjectFileBytesInput!) {
+    adminValidateProjectFileBytes(data: $data) {
+      projectId
+      currentFileBytes
+      expectedFileBytes
+      drift
+      fileBlobCount
+      referenceCount
+    }
+  }
+`
+export const AdminRestoreProjectFileBytesDocument = gql`
+  mutation adminRestoreProjectFileBytes($data: RestoreProjectFileBytesInput!) {
+    adminRestoreProjectFileBytes(data: $data) {
+      projectId
+      previousFileBytes
+      nextFileBytes
+      drift
+      dryRun
+    }
   }
 `
 export const UpdateProjectDocument = gql`
@@ -6879,6 +6969,36 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'removeUserFromOrganization',
+        'mutation',
+        variables,
+      )
+    },
+    adminValidateProjectFileBytes(
+      variables: AdminValidateProjectFileBytesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminValidateProjectFileBytesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminValidateProjectFileBytesQuery>(AdminValidateProjectFileBytesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'adminValidateProjectFileBytes',
+        'query',
+        variables,
+      )
+    },
+    adminRestoreProjectFileBytes(
+      variables: AdminRestoreProjectFileBytesMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<AdminRestoreProjectFileBytesMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AdminRestoreProjectFileBytesMutation>(AdminRestoreProjectFileBytesDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'adminRestoreProjectFileBytes',
         'mutation',
         variables,
       )

--- a/src/__generated__/schema.graphql
+++ b/src/__generated__/schema.graphql
@@ -688,6 +688,7 @@ type Mutation {
   addUserToOrganization(data: AddUserToOrganizationInput!): Boolean!
   addUserToProject(data: AddUserToProjectInput!): Boolean!
   adminResetAllCache: Boolean!
+  adminRestoreProjectFileBytes(data: RestoreProjectFileBytesInput!): RestoreProjectFileBytesResultModel!
   applyMigrations(data: ApplyMigrationsInput!): [ApplyMigrationResultModel!]!
   cancelSubscription(data: CancelSubscriptionInput!): Boolean!
   confirmEmailCode(data: ConfirmEmailCodeInput!): LoginModel!
@@ -847,6 +848,7 @@ type PermissionModel {
 type PlanLimitsModel {
   apiCallsPerDay: Int
   branchesPerProject: Int
+  endpointsPerProject: Int
   projects: Int
   rowVersions: Int
   rowsPerTable: Int
@@ -869,9 +871,19 @@ type PluginsModel {
   file: Boolean!
 }
 
+type ProjectFileUsageReportModel {
+  currentFileBytes: String!
+  drift: String!
+  expectedFileBytes: String!
+  fileBlobCount: Int!
+  projectId: ID!
+  referenceCount: Int!
+}
+
 type ProjectModel {
   allBranches(data: GetProjectBranchesInput!): BranchesConnection!
   createdAt: DateTime!
+  endpointUsage: UsageMetricModel!
   id: String!
   isPublic: Boolean!
   name: String!
@@ -896,6 +908,7 @@ type Query {
   adminCacheStats: CacheStatsModel!
   adminUser(data: AdminUserInput!): UserModel
   adminUsers(data: SearchUsersInput!): UsersConnection!
+  adminValidateProjectFileBytes(data: ValidateProjectFileBytesInput!): ProjectFileUsageReportModel!
   apiKeyById(id: ID!): ApiKeyModel!
   availableProviders(country: String, method: String): [PaymentProviderModel!]!
   branch(data: GetBranchInput!): BranchModel!
@@ -980,6 +993,19 @@ type RenameTableResultModel {
 input ResetPasswordInput {
   newPassword: String!
   userId: String!
+}
+
+input RestoreProjectFileBytesInput {
+  dryRun: Boolean = true
+  projectId: ID!
+}
+
+type RestoreProjectFileBytesResultModel {
+  drift: String!
+  dryRun: Boolean!
+  nextFileBytes: String!
+  previousFileBytes: String!
+  projectId: ID!
 }
 
 input RevertChangesInput {
@@ -1580,6 +1606,10 @@ type UsersProjectModel {
 type UsersProjectModelEdge {
   cursor: String!
   node: UsersProjectModel!
+}
+
+input ValidateProjectFileBytesInput {
+  projectId: ID!
 }
 
 type ViewChangeModel {

--- a/src/pages/ProjectSettingsPage/api/projectFileUsage.graphql
+++ b/src/pages/ProjectSettingsPage/api/projectFileUsage.graphql
@@ -1,0 +1,20 @@
+query adminValidateProjectFileBytes($data: ValidateProjectFileBytesInput!) {
+  adminValidateProjectFileBytes(data: $data) {
+    projectId
+    currentFileBytes
+    expectedFileBytes
+    drift
+    fileBlobCount
+    referenceCount
+  }
+}
+
+mutation adminRestoreProjectFileBytes($data: RestoreProjectFileBytesInput!) {
+  adminRestoreProjectFileBytes(data: $data) {
+    projectId
+    previousFileBytes
+    nextFileBytes
+    drift
+    dryRun
+  }
+}

--- a/src/pages/ProjectSettingsPage/lib/fileUsageFormatters.ts
+++ b/src/pages/ProjectSettingsPage/lib/fileUsageFormatters.ts
@@ -1,0 +1,42 @@
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
+const BYTE_BASE = 1024n
+
+export function parseByteString(value: string): bigint {
+  return BigInt(value)
+}
+
+export function formatExactBytes(value: string): string {
+  return `${parseByteString(value).toLocaleString('en-US')} bytes`
+}
+
+export function formatHumanReadableBytes(value: string): string {
+  const bytes = parseByteString(value)
+
+  if (bytes === 0n) {
+    return '0 B'
+  }
+
+  const absoluteBytes = bytes < 0n ? -bytes : bytes
+  let unitIndex = 0
+  let unitValue = 1n
+
+  while (absoluteBytes >= unitValue * BYTE_BASE && unitIndex < BYTE_UNITS.length - 1) {
+    unitValue *= BYTE_BASE
+    unitIndex += 1
+  }
+
+  if (unitIndex === 0) {
+    return `${bytes.toLocaleString('en-US')} ${BYTE_UNITS[unitIndex]}`
+  }
+
+  const scaled = (absoluteBytes * 10n) / unitValue
+  const whole = scaled / 10n
+  const fraction = scaled % 10n
+  const sign = bytes < 0n ? '-' : ''
+
+  return `${sign}${whole.toLocaleString('en-US')}.${fraction.toString()} ${BYTE_UNITS[unitIndex]}`
+}
+
+export function formatByteValue(value: string): string {
+  return `${formatHumanReadableBytes(value)} (${formatExactBytes(value)})`
+}

--- a/src/pages/ProjectSettingsPage/lib/fileUsageFormatters.ts
+++ b/src/pages/ProjectSettingsPage/lib/fileUsageFormatters.ts
@@ -1,16 +1,12 @@
 const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
 const BYTE_BASE = 1024n
 
-export function parseByteString(value: string): bigint {
-  return BigInt(value)
-}
-
 export function formatExactBytes(value: string): string {
-  return `${parseByteString(value).toLocaleString('en-US')} bytes`
+  return `${BigInt(value).toLocaleString('en-US')} bytes`
 }
 
 export function formatHumanReadableBytes(value: string): string {
-  const bytes = parseByteString(value)
+  const bytes = BigInt(value)
 
   if (bytes === 0n) {
     return '0 B'

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.spec.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.spec.ts
@@ -1,0 +1,216 @@
+import { ClientError } from 'graphql-request'
+import { PermissionService, ProjectPermissions } from 'src/shared/model/AbilityService'
+import { ProjectFileUsageViewModel } from './ProjectFileUsageViewModel'
+
+jest.mock('src/shared/model/ApiService.ts', () => ({
+  client: {
+    adminValidateProjectFileBytes: jest.fn(),
+    adminRestoreProjectFileBytes: jest.fn(),
+  },
+}))
+
+jest.mock('src/shared/ui', () => ({
+  toaster: {
+    success: jest.fn(),
+  },
+}))
+
+const { client } = jest.requireMock('src/shared/model/ApiService.ts') as {
+  client: {
+    adminValidateProjectFileBytes: jest.Mock
+    adminRestoreProjectFileBytes: jest.Mock
+  }
+}
+
+const { toaster } = jest.requireMock('src/shared/ui') as {
+  toaster: {
+    success: jest.Mock
+  }
+}
+
+const adminValidateProjectFileBytes = client.adminValidateProjectFileBytes
+const adminRestoreProjectFileBytes = client.adminRestoreProjectFileBytes
+const toasterSuccess = toaster.success
+
+function createClientError(message: string, status = 200): ClientError {
+  return new ClientError(
+    {
+      status,
+      errors: [{ message }] as never,
+      data: null as never,
+    },
+    { query: 'mutation test { test }' },
+  )
+}
+
+describe('ProjectFileUsageViewModel', () => {
+  let permissionService: PermissionService
+  let projectPermissions: ProjectPermissions
+
+  beforeEach(() => {
+    adminValidateProjectFileBytes.mockReset()
+    adminRestoreProjectFileBytes.mockReset()
+    toasterSuccess.mockReset()
+
+    permissionService = new PermissionService()
+    projectPermissions = new ProjectPermissions(permissionService)
+    projectPermissions.setContextProvider(() => ({
+      projectId: 'project-1',
+      organizationId: 'org-1',
+      isPublic: false,
+      projectRoleName: 'Admin',
+    }))
+  })
+
+  it('loads validate data and exposes zero-drift state', async () => {
+    adminValidateProjectFileBytes.mockResolvedValue({
+      adminValidateProjectFileBytes: {
+        projectId: 'project-1',
+        currentFileBytes: '0',
+        expectedFileBytes: '0',
+        drift: '0',
+        fileBlobCount: 0,
+        referenceCount: 0,
+      },
+    })
+
+    const vm = new ProjectFileUsageViewModel(projectPermissions, permissionService)
+    await Promise.resolve()
+
+    expect(adminValidateProjectFileBytes).toHaveBeenCalledWith({ data: { projectId: 'project-1' } })
+    expect(vm.currentBytesLabel).toBe('0 B (0 bytes)')
+    expect(vm.expectedBytesLabel).toBe('0 B (0 bytes)')
+    expect(vm.driftLabel).toBe('0 B (0 bytes)')
+    expect(vm.fileBlobCount).toBe(0)
+    expect(vm.referenceCount).toBe(0)
+    expect(vm.canRestore).toBe(false)
+
+    vm.dispose()
+  })
+
+  it('shows restore action only when drift is non-zero and manage permission exists', async () => {
+    permissionService.addProjectPermissions('project-1', [
+      { id: 'manage-file-usage', action: 'manage', subject: 'FileUsage' },
+    ])
+    adminValidateProjectFileBytes.mockResolvedValue({
+      adminValidateProjectFileBytes: {
+        projectId: 'project-1',
+        currentFileBytes: '1024',
+        expectedFileBytes: '2048',
+        drift: '1024',
+        fileBlobCount: 1,
+        referenceCount: 2,
+      },
+    })
+
+    const vm = new ProjectFileUsageViewModel(projectPermissions, permissionService)
+    await Promise.resolve()
+
+    expect(vm.hasManagePermission).toBe(true)
+    expect(vm.canRestore).toBe(true)
+    expect(vm.driftColor).toBe('orange.600')
+
+    vm.dispose()
+  })
+
+  it('runs dry-run preview before apply and refreshes after success', async () => {
+    permissionService.addProjectPermissions('project-1', [
+      { id: 'manage-file-usage', action: 'manage', subject: 'FileUsage' },
+    ])
+
+    adminValidateProjectFileBytes
+      .mockResolvedValueOnce({
+        adminValidateProjectFileBytes: {
+          projectId: 'project-1',
+          currentFileBytes: '1024',
+          expectedFileBytes: '2048',
+          drift: '1024',
+          fileBlobCount: 1,
+          referenceCount: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        adminValidateProjectFileBytes: {
+          projectId: 'project-1',
+          currentFileBytes: '2048',
+          expectedFileBytes: '2048',
+          drift: '0',
+          fileBlobCount: 1,
+          referenceCount: 2,
+        },
+      })
+
+    adminRestoreProjectFileBytes
+      .mockResolvedValueOnce({
+        adminRestoreProjectFileBytes: {
+          projectId: 'project-1',
+          previousFileBytes: '1024',
+          nextFileBytes: '2048',
+          drift: '1024',
+          dryRun: true,
+        },
+      })
+      .mockResolvedValueOnce({
+        adminRestoreProjectFileBytes: {
+          projectId: 'project-1',
+          previousFileBytes: '1024',
+          nextFileBytes: '2048',
+          drift: '1024',
+          dryRun: false,
+        },
+      })
+
+    const vm = new ProjectFileUsageViewModel(projectPermissions, permissionService)
+    await Promise.resolve()
+
+    await vm.previewRestore()
+
+    expect(adminRestoreProjectFileBytes).toHaveBeenNthCalledWith(1, {
+      data: { projectId: 'project-1', dryRun: true },
+    })
+    expect(vm.restoreDialogOpen).toBe(true)
+    expect(vm.previewPreviousBytesLabel).toBe('1.0 KB (1,024 bytes)')
+    expect(vm.previewNextBytesLabel).toBe('2.0 KB (2,048 bytes)')
+
+    await vm.applyRestore()
+
+    expect(adminRestoreProjectFileBytes).toHaveBeenNthCalledWith(2, {
+      data: { projectId: 'project-1', dryRun: false },
+    })
+    expect(adminValidateProjectFileBytes).toHaveBeenCalledTimes(2)
+    expect(vm.drift).toBe('0')
+    expect(vm.restoreDialogOpen).toBe(false)
+    expect(toasterSuccess).toHaveBeenCalledWith({ description: 'Project file usage restored successfully' })
+
+    vm.dispose()
+  })
+
+  it('surfaces restore errors inline', async () => {
+    permissionService.addProjectPermissions('project-1', [
+      { id: 'manage-file-usage', action: 'manage', subject: 'FileUsage' },
+    ])
+
+    adminValidateProjectFileBytes.mockResolvedValue({
+      adminValidateProjectFileBytes: {
+        projectId: 'project-1',
+        currentFileBytes: '1024',
+        expectedFileBytes: '2048',
+        drift: '1024',
+        fileBlobCount: 1,
+        referenceCount: 2,
+      },
+    })
+
+    adminRestoreProjectFileBytes.mockRejectedValue(createClientError('Forbidden', 403))
+
+    const vm = new ProjectFileUsageViewModel(projectPermissions, permissionService)
+    await Promise.resolve()
+
+    await vm.previewRestore()
+
+    expect(vm.restoreDialogOpen).toBe(true)
+    expect(vm.restoreError).toBe('Forbidden')
+
+    vm.dispose()
+  })
+})

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.spec.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.spec.ts
@@ -63,6 +63,10 @@ describe('ProjectFileUsageViewModel', () => {
   })
 
   it('loads validate data and exposes zero-drift state', async () => {
+    permissionService.addProjectPermissions('project-1', [
+      { id: 'manage-file-usage', action: 'manage', subject: 'FileUsage' },
+    ])
+
     adminValidateProjectFileBytes.mockResolvedValue({
       adminValidateProjectFileBytes: {
         projectId: 'project-1',
@@ -84,6 +88,17 @@ describe('ProjectFileUsageViewModel', () => {
     expect(vm.fileBlobCount).toBe(0)
     expect(vm.referenceCount).toBe(0)
     expect(vm.canRestore).toBe(false)
+
+    vm.dispose()
+  })
+
+  it('does not auto-validate without manage permission', async () => {
+    const vm = new ProjectFileUsageViewModel(projectPermissions, permissionService)
+    await Promise.resolve()
+
+    expect(adminValidateProjectFileBytes).not.toHaveBeenCalled()
+    expect(vm.hasManagePermission).toBe(false)
+    expect(vm.currentBytesLabel).toBe('0 B (0 bytes)')
 
     vm.dispose()
   })
@@ -210,6 +225,39 @@ describe('ProjectFileUsageViewModel', () => {
 
     expect(vm.restoreDialogOpen).toBe(true)
     expect(vm.restoreError).toBe('Forbidden')
+
+    vm.dispose()
+  })
+
+  it('clears stale validate data before a new request', async () => {
+    permissionService.addProjectPermissions('project-1', [
+      { id: 'manage-file-usage', action: 'manage', subject: 'FileUsage' },
+    ])
+
+    adminValidateProjectFileBytes
+      .mockResolvedValueOnce({
+        adminValidateProjectFileBytes: {
+          projectId: 'project-1',
+          currentFileBytes: '1024',
+          expectedFileBytes: '2048',
+          drift: '1024',
+          fileBlobCount: 1,
+          referenceCount: 2,
+        },
+      })
+      .mockRejectedValueOnce(createClientError('Validate failed', 500))
+
+    const vm = new ProjectFileUsageViewModel(projectPermissions, permissionService)
+    await Promise.resolve()
+
+    expect(vm.currentBytesLabel).toBe('1.0 KB (1,024 bytes)')
+
+    await vm.validate()
+
+    expect(vm.validateError).toBe('Validate failed')
+    expect(vm.currentBytesLabel).toBe('0 B (0 bytes)')
+    expect(vm.expectedBytesLabel).toBe('0 B (0 bytes)')
+    expect(vm.driftLabel).toBe('0 B (0 bytes)')
 
     vm.dispose()
   })

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.spec.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.spec.ts
@@ -261,4 +261,45 @@ describe('ProjectFileUsageViewModel', () => {
 
     vm.dispose()
   })
+
+  it('does not apply restore without current manage permission', async () => {
+    permissionService.addProjectPermissions('project-1', [
+      { id: 'manage-file-usage', action: 'manage', subject: 'FileUsage' },
+    ])
+
+    adminValidateProjectFileBytes.mockResolvedValue({
+      adminValidateProjectFileBytes: {
+        projectId: 'project-1',
+        currentFileBytes: '1024',
+        expectedFileBytes: '2048',
+        drift: '1024',
+        fileBlobCount: 1,
+        referenceCount: 2,
+      },
+    })
+
+    adminRestoreProjectFileBytes.mockResolvedValue({
+      adminRestoreProjectFileBytes: {
+        projectId: 'project-1',
+        previousFileBytes: '1024',
+        nextFileBytes: '2048',
+        drift: '1024',
+        dryRun: true,
+      },
+    })
+
+    const vm = new ProjectFileUsageViewModel(projectPermissions, permissionService)
+    await Promise.resolve()
+
+    await vm.previewRestore()
+
+    permissionService.clearAll()
+
+    await vm.applyRestore()
+
+    expect(adminRestoreProjectFileBytes).toHaveBeenCalledTimes(1)
+    expect(vm.hasManagePermission).toBe(false)
+
+    vm.dispose()
+  })
 })

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
@@ -1,0 +1,317 @@
+import { ClientError } from 'graphql-request'
+import { IReactionDisposer, makeAutoObservable, reaction, runInAction } from 'mobx'
+import { ProjectFileUsageReportModel, RestoreProjectFileBytesResultModel } from 'src/__generated__/graphql-request.ts'
+import { IViewModel } from 'src/shared/config/types.ts'
+import { container, isAborted, ObservableRequest } from 'src/shared/lib'
+import { PermissionService, ProjectPermissions } from 'src/shared/model/AbilityService'
+import { client } from 'src/shared/model/ApiService.ts'
+import { toaster } from 'src/shared/ui'
+import {
+  formatByteValue,
+  formatExactBytes,
+  formatHumanReadableBytes,
+  parseByteString,
+} from '../lib/fileUsageFormatters.ts'
+
+function getGraphQLErrorMessage(error: unknown): string {
+  if (error instanceof ClientError) {
+    const graphQLError = error.response.errors?.[0]
+    if (graphQLError?.message) {
+      return graphQLError.message
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  return 'Request failed'
+}
+
+export class ProjectFileUsageViewModel implements IViewModel {
+  private readonly validateRequest = ObservableRequest.of(
+    (projectId: string) => client.adminValidateProjectFileBytes({ data: { projectId } }),
+    { skipResetting: true },
+  )
+  private readonly previewRestoreRequest = ObservableRequest.of((projectId: string) =>
+    client.adminRestoreProjectFileBytes({ data: { projectId, dryRun: true } }),
+  )
+  private readonly applyRestoreRequest = ObservableRequest.of((projectId: string) =>
+    client.adminRestoreProjectFileBytes({ data: { projectId, dryRun: false } }),
+  )
+
+  private readonly disposer: IReactionDisposer
+
+  private _restoreDialogOpen = false
+  private _restoreError: string | null = null
+  private _lastProjectId: string | null = null
+
+  constructor(
+    private readonly projectPermissions: ProjectPermissions,
+    private readonly permissionService: PermissionService,
+  ) {
+    makeAutoObservable(this, {}, { autoBind: true })
+
+    this.disposer = reaction(
+      () => this.projectPermissions.projectId,
+      (projectId) => {
+        runInAction(() => {
+          this._lastProjectId = projectId
+        })
+
+        if (!projectId) {
+          return
+        }
+
+        void this.validate()
+      },
+      { fireImmediately: true },
+    )
+  }
+
+  public get projectId(): string | null {
+    return this.projectPermissions.projectId ?? this._lastProjectId
+  }
+
+  public get organizationId(): string | null {
+    return this.projectPermissions.organizationId
+  }
+
+  public get report(): ProjectFileUsageReportModel | null {
+    return this.validateRequest.data?.adminValidateProjectFileBytes ?? null
+  }
+
+  public get preview(): RestoreProjectFileBytesResultModel | null {
+    return this.previewRestoreRequest.data?.adminRestoreProjectFileBytes ?? null
+  }
+
+  public get isLoading(): boolean {
+    return this.validateRequest.isLoading && !this.validateRequest.isLoaded
+  }
+
+  public get isRefreshing(): boolean {
+    return this.validateRequest.isLoading && this.validateRequest.isLoaded
+  }
+
+  public get isPreviewLoading(): boolean {
+    return this.previewRestoreRequest.isLoading
+  }
+
+  public get isApplyingRestore(): boolean {
+    return this.applyRestoreRequest.isLoading
+  }
+
+  public get validateError(): string | null {
+    return this.validateRequest.error ? getGraphQLErrorMessage(this.validateRequest.error) : null
+  }
+
+  public get restoreError(): string | null {
+    return this._restoreError
+  }
+
+  public get hasManagePermission(): boolean {
+    const projectId = this.projectPermissions.projectId
+    const organizationId = this.projectPermissions.organizationId
+
+    if (!projectId) {
+      return false
+    }
+
+    const context: Record<string, string> = { projectId }
+
+    if (organizationId) {
+      context.organizationId = organizationId
+    }
+
+    return this.permissionService.can('manage', 'FileUsage', context)
+  }
+
+  public get currentBytes(): string {
+    return this.report?.currentFileBytes ?? '0'
+  }
+
+  public get expectedBytes(): string {
+    return this.report?.expectedFileBytes ?? '0'
+  }
+
+  public get drift(): string {
+    return this.report?.drift ?? '0'
+  }
+
+  public get fileBlobCount(): number {
+    return this.report?.fileBlobCount ?? 0
+  }
+
+  public get referenceCount(): number {
+    return this.report?.referenceCount ?? 0
+  }
+
+  public get hasDrift(): boolean {
+    return parseByteString(this.drift) !== 0n
+  }
+
+  public get canRestore(): boolean {
+    return this.hasDrift && this.hasManagePermission
+  }
+
+  public get restoreDialogOpen(): boolean {
+    return this._restoreDialogOpen
+  }
+
+  public get currentBytesLabel(): string {
+    return formatByteValue(this.currentBytes)
+  }
+
+  public get expectedBytesLabel(): string {
+    return formatByteValue(this.expectedBytes)
+  }
+
+  public get driftLabel(): string {
+    const drift = parseByteString(this.drift)
+
+    if (drift === 0n) {
+      return '0 B (0 bytes)'
+    }
+
+    return `${formatHumanReadableBytes(this.drift)} (${formatExactBytes(this.drift)})`
+  }
+
+  public get driftColor(): string {
+    const drift = parseByteString(this.drift)
+
+    if (drift === 0n) {
+      return 'green.600'
+    }
+
+    return drift > 0n ? 'orange.600' : 'red.600'
+  }
+
+  public get previewPreviousBytesLabel(): string {
+    return formatByteValue(this.preview?.previousFileBytes ?? '0')
+  }
+
+  public get previewNextBytesLabel(): string {
+    return formatByteValue(this.preview?.nextFileBytes ?? '0')
+  }
+
+  public get previewDriftLabel(): string {
+    if (!this.preview) {
+      return '0 B (0 bytes)'
+    }
+
+    const drift = parseByteString(this.preview.drift)
+
+    if (drift === 0n) {
+      return '0 B (0 bytes)'
+    }
+
+    return `${formatHumanReadableBytes(this.preview.drift)} (${formatExactBytes(this.preview.drift)})`
+  }
+
+  public openRestoreDialog(): void {
+    this._restoreDialogOpen = true
+  }
+
+  public closeRestoreDialog(): void {
+    this._restoreDialogOpen = false
+    this._restoreError = null
+    this.previewRestoreRequest.abort()
+    this.applyRestoreRequest.abort()
+  }
+
+  public async validate(): Promise<void> {
+    const projectId = this.projectPermissions.projectId
+
+    if (!projectId) {
+      return
+    }
+
+    const result = await this.validateRequest.fetch(projectId)
+
+    if (!result.isRight && isAborted(result)) {
+      return
+    }
+  }
+
+  public async previewRestore(): Promise<void> {
+    const projectId = this.projectPermissions.projectId
+
+    if (!projectId || !this.canRestore) {
+      return
+    }
+
+    runInAction(() => {
+      this._restoreDialogOpen = true
+      this._restoreError = null
+    })
+
+    const result = await this.previewRestoreRequest.fetch(projectId)
+
+    if (!result.isRight) {
+      if (isAborted(result)) {
+        return
+      }
+
+      runInAction(() => {
+        this._restoreError = getGraphQLErrorMessage(result.error)
+      })
+    }
+  }
+
+  public async applyRestore(): Promise<void> {
+    const projectId = this.projectPermissions.projectId
+
+    if (!projectId || !this.preview) {
+      return
+    }
+
+    runInAction(() => {
+      this._restoreError = null
+    })
+
+    const result = await this.applyRestoreRequest.fetch(projectId)
+
+    if (!result.isRight) {
+      if (isAborted(result)) {
+        return
+      }
+
+      runInAction(() => {
+        this._restoreError = getGraphQLErrorMessage(result.error)
+      })
+
+      return
+    }
+
+    runInAction(() => {
+      this._restoreDialogOpen = false
+      this._restoreError = null
+    })
+
+    toaster.success({
+      description: 'Project file usage restored successfully',
+    })
+
+    await this.validate()
+  }
+
+  public init(): void {}
+
+  public dispose(): void {
+    this.disposer()
+    this.validateRequest.abort()
+    this.previewRestoreRequest.abort()
+    this.applyRestoreRequest.abort()
+  }
+}
+
+container.register(
+  ProjectFileUsageViewModel,
+  () => {
+    const projectPermissions = container.get(ProjectPermissions)
+    const permissionService = container.get(PermissionService)
+
+    return new ProjectFileUsageViewModel(projectPermissions, permissionService)
+  },
+  { scope: 'request' },
+)

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
@@ -250,7 +250,7 @@ export class ProjectFileUsageViewModel implements IViewModel {
   public async applyRestore(): Promise<void> {
     const projectId = this.projectPermissions.projectId
 
-    if (!projectId || !this.preview) {
+    if (!projectId || !this.preview || !this.canRestore) {
       return
     }
 

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
@@ -29,9 +29,8 @@ function getGraphQLErrorMessage(error: unknown): string {
 }
 
 export class ProjectFileUsageViewModel implements IViewModel {
-  private readonly validateRequest = ObservableRequest.of(
-    (projectId: string) => client.adminValidateProjectFileBytes({ data: { projectId } }),
-    { skipResetting: true },
+  private readonly validateRequest = ObservableRequest.of((projectId: string) =>
+    client.adminValidateProjectFileBytes({ data: { projectId } }),
   )
   private readonly previewRestoreRequest = ObservableRequest.of((projectId: string) =>
     client.adminRestoreProjectFileBytes({ data: { projectId, dryRun: true } }),
@@ -57,7 +56,12 @@ export class ProjectFileUsageViewModel implements IViewModel {
       (projectId) => {
         runInAction(() => {
           this._lastProjectId = projectId
+          this._restoreDialogOpen = false
+          this._restoreError = null
         })
+
+        this.previewRestoreRequest.abort()
+        this.applyRestoreRequest.abort()
 
         if (!projectId) {
           return
@@ -222,7 +226,7 @@ export class ProjectFileUsageViewModel implements IViewModel {
   public async validate(): Promise<void> {
     const projectId = this.projectPermissions.projectId
 
-    if (!projectId) {
+    if (!projectId || !this.hasManagePermission) {
       return
     }
 

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
@@ -43,7 +43,6 @@ export class ProjectFileUsageViewModel implements IViewModel {
 
   private _restoreDialogOpen = false
   private _restoreError: string | null = null
-  private _lastProjectId: string | null = null
 
   constructor(
     private readonly projectPermissions: ProjectPermissions,
@@ -55,7 +54,6 @@ export class ProjectFileUsageViewModel implements IViewModel {
       () => this.projectPermissions.projectId,
       (projectId) => {
         runInAction(() => {
-          this._lastProjectId = projectId
           this._restoreDialogOpen = false
           this._restoreError = null
         })
@@ -71,14 +69,6 @@ export class ProjectFileUsageViewModel implements IViewModel {
       },
       { fireImmediately: true },
     )
-  }
-
-  public get projectId(): string | null {
-    return this.projectPermissions.projectId ?? this._lastProjectId
-  }
-
-  public get organizationId(): string | null {
-    return this.projectPermissions.organizationId
   }
 
   public get report(): ProjectFileUsageReportModel | null {

--- a/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts
@@ -6,12 +6,7 @@ import { container, isAborted, ObservableRequest } from 'src/shared/lib'
 import { PermissionService, ProjectPermissions } from 'src/shared/model/AbilityService'
 import { client } from 'src/shared/model/ApiService.ts'
 import { toaster } from 'src/shared/ui'
-import {
-  formatByteValue,
-  formatExactBytes,
-  formatHumanReadableBytes,
-  parseByteString,
-} from '../lib/fileUsageFormatters.ts'
+import { formatByteValue, formatExactBytes, formatHumanReadableBytes } from '../lib/fileUsageFormatters.ts'
 
 function getGraphQLErrorMessage(error: unknown): string {
   if (error instanceof ClientError) {
@@ -141,7 +136,7 @@ export class ProjectFileUsageViewModel implements IViewModel {
   }
 
   public get hasDrift(): boolean {
-    return parseByteString(this.drift) !== 0n
+    return BigInt(this.drift) !== 0n
   }
 
   public get canRestore(): boolean {
@@ -161,7 +156,7 @@ export class ProjectFileUsageViewModel implements IViewModel {
   }
 
   public get driftLabel(): string {
-    const drift = parseByteString(this.drift)
+    const drift = BigInt(this.drift)
 
     if (drift === 0n) {
       return '0 B (0 bytes)'
@@ -171,7 +166,7 @@ export class ProjectFileUsageViewModel implements IViewModel {
   }
 
   public get driftColor(): string {
-    const drift = parseByteString(this.drift)
+    const drift = BigInt(this.drift)
 
     if (drift === 0n) {
       return 'green.600'
@@ -193,7 +188,7 @@ export class ProjectFileUsageViewModel implements IViewModel {
       return '0 B (0 bytes)'
     }
 
-    const drift = parseByteString(this.preview.drift)
+    const drift = BigInt(this.preview.drift)
 
     if (drift === 0n) {
       return '0 B (0 bytes)'

--- a/src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts
+++ b/src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts
@@ -52,6 +52,18 @@ export class ProjectSettingsPageModel {
     return this.permissionService.can('manage', 'ApiKey', { organizationId: this.context.organizationId })
   }
 
+  public get canManageFileUsage(): boolean {
+    const projectId = this.projectPermissions.projectId
+    if (!projectId) {
+      return false
+    }
+
+    return this.permissionService.can('manage', 'FileUsage', {
+      projectId,
+      organizationId: this.context.organizationId,
+    })
+  }
+
   public get organizationSettingsLink(): string {
     return `/app/${this.context.organizationId}/-/settings`
   }

--- a/src/pages/ProjectSettingsPage/ui/ProjectFileUsagePanel/ProjectFileUsagePanel.stories.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectFileUsagePanel/ProjectFileUsagePanel.stories.tsx
@@ -1,0 +1,79 @@
+import { ProjectFileUsagePanel, ProjectFileUsagePanelModel } from './ProjectFileUsagePanel.tsx'
+
+const createModel = (overrides: Partial<ProjectFileUsagePanelModel> = {}): ProjectFileUsagePanelModel => ({
+  isLoading: false,
+  isRefreshing: false,
+  isPreviewLoading: false,
+  isApplyingRestore: false,
+  validateError: null,
+  restoreError: null,
+  currentBytesLabel: '0 B (0 bytes)',
+  expectedBytesLabel: '0 B (0 bytes)',
+  driftLabel: '0 B (0 bytes)',
+  driftColor: 'green.600',
+  fileBlobCount: 0,
+  referenceCount: 0,
+  canRestore: false,
+  restoreDialogOpen: false,
+  preview: null,
+  previewPreviousBytesLabel: '0 B (0 bytes)',
+  previewNextBytesLabel: '0 B (0 bytes)',
+  previewDriftLabel: '0 B (0 bytes)',
+  validate: async () => undefined,
+  previewRestore: async () => undefined,
+  applyRestore: async () => undefined,
+  closeRestoreDialog: () => undefined,
+  ...overrides,
+})
+
+export default {
+  title: 'Project Settings/ProjectFileUsagePanel',
+  component: ProjectFileUsagePanel,
+}
+
+export const Loading = () => <ProjectFileUsagePanel model={createModel({ isLoading: true })} />
+
+export const ZeroDrift = () => <ProjectFileUsagePanel model={createModel()} />
+
+export const DriftPresent = () => (
+  <ProjectFileUsagePanel
+    model={createModel({
+      currentBytesLabel: '1.0 KB (1,024 bytes)',
+      expectedBytesLabel: '2.0 KB (2,048 bytes)',
+      driftLabel: '1.0 KB (1,024 bytes)',
+      driftColor: 'orange.600',
+      fileBlobCount: 1,
+      referenceCount: 2,
+      canRestore: true,
+    })}
+  />
+)
+
+export const ErrorState = () => (
+  <ProjectFileUsagePanel
+    model={createModel({
+      validateError: 'Network request failed',
+      currentBytesLabel: '1.0 KB (1,024 bytes)',
+      expectedBytesLabel: '2.0 KB (2,048 bytes)',
+      driftLabel: '1.0 KB (1,024 bytes)',
+      driftColor: 'red.600',
+      fileBlobCount: 1,
+      referenceCount: 2,
+      canRestore: true,
+    })}
+  />
+)
+
+export const NoPermission = () => (
+  <ProjectFileUsagePanel
+    model={createModel({
+      currentBytesLabel: '1.0 KB (1,024 bytes)',
+      expectedBytesLabel: '2.0 KB (2,048 bytes)',
+      driftLabel: '1.0 KB (1,024 bytes)',
+      driftColor: 'orange.600',
+      fileBlobCount: 1,
+      referenceCount: 2,
+      canRestore: false,
+    })}
+  />
+)

--- a/src/pages/ProjectSettingsPage/ui/ProjectFileUsagePanel/ProjectFileUsagePanel.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectFileUsagePanel/ProjectFileUsagePanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react/dialog'
 import { observer } from 'mobx-react-lite'
 import React from 'react'
+import { RestoreProjectFileBytesResultModel } from 'src/__generated__/graphql-request.ts'
 
 interface MetricCardProps {
   label: string
@@ -47,7 +48,7 @@ export interface ProjectFileUsagePanelModel {
   referenceCount: number
   canRestore: boolean
   restoreDialogOpen: boolean
-  preview: unknown
+  preview: RestoreProjectFileBytesResultModel | null
   previewPreviousBytesLabel: string
   previewNextBytesLabel: string
   previewDriftLabel: string
@@ -73,7 +74,13 @@ export const ProjectFileUsagePanel: React.FC<ProjectFileUsagePanelProps> = obser
             Validate tracked file bytes and preview a restore before applying it.
           </Text>
         </Box>
-        <Button variant="outline" size="sm" onClick={model.validate} loading={model.isRefreshing}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={model.validate}
+          loading={model.isLoading || model.isRefreshing}
+          disabled={model.isLoading}
+        >
           Refresh
         </Button>
       </HStack>

--- a/src/pages/ProjectSettingsPage/ui/ProjectFileUsagePanel/ProjectFileUsagePanel.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectFileUsagePanel/ProjectFileUsagePanel.tsx
@@ -1,0 +1,182 @@
+import { Box, Button, Grid, HStack, Portal, Spinner, Text, VStack } from '@chakra-ui/react'
+import {
+  DialogActionTrigger,
+  DialogBackdrop,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogPositioner,
+  DialogRoot,
+  DialogTitle,
+} from '@chakra-ui/react/dialog'
+import { observer } from 'mobx-react-lite'
+import React from 'react'
+
+interface MetricCardProps {
+  label: string
+  value: string
+  color?: string
+}
+
+const MetricCard: React.FC<MetricCardProps> = ({ label, value, color = 'gray.800' }) => {
+  return (
+    <Box borderWidth="1px" borderColor="gray.200" borderRadius="lg" bg="white" p={4}>
+      <Text fontSize="xs" fontWeight="600" color="gray.500" mb={2}>
+        {label}
+      </Text>
+      <Text fontSize="sm" fontWeight="600" color={color}>
+        {value}
+      </Text>
+    </Box>
+  )
+}
+
+export interface ProjectFileUsagePanelModel {
+  isLoading: boolean
+  isRefreshing: boolean
+  isPreviewLoading: boolean
+  isApplyingRestore: boolean
+  validateError: string | null
+  restoreError: string | null
+  currentBytesLabel: string
+  expectedBytesLabel: string
+  driftLabel: string
+  driftColor: string
+  fileBlobCount: number
+  referenceCount: number
+  canRestore: boolean
+  restoreDialogOpen: boolean
+  preview: unknown
+  previewPreviousBytesLabel: string
+  previewNextBytesLabel: string
+  previewDriftLabel: string
+  validate: () => Promise<void>
+  previewRestore: () => Promise<void>
+  applyRestore: () => Promise<void>
+  closeRestoreDialog: () => void
+}
+
+interface ProjectFileUsagePanelProps {
+  model: ProjectFileUsagePanelModel
+}
+
+export const ProjectFileUsagePanel: React.FC<ProjectFileUsagePanelProps> = observer(({ model }) => {
+  return (
+    <Box>
+      <HStack justify="space-between" align="center" mb={3}>
+        <Box>
+          <Text fontSize="sm" fontWeight="600" color="gray.600">
+            File Usage
+          </Text>
+          <Text fontSize="xs" color="gray.500" mt={1}>
+            Validate tracked file bytes and preview a restore before applying it.
+          </Text>
+        </Box>
+        <Button variant="outline" size="sm" onClick={model.validate} loading={model.isRefreshing}>
+          Refresh
+        </Button>
+      </HStack>
+
+      <Box borderWidth="1px" borderColor="gray.200" borderRadius="lg" bg="gray.50" p={4}>
+        {model.isLoading ? (
+          <HStack gap={3}>
+            <Spinner size="sm" color="gray.400" />
+            <Text fontSize="sm" color="gray.600">
+              Loading file usage…
+            </Text>
+          </HStack>
+        ) : (
+          <VStack align="stretch" gap={4}>
+            <Grid templateColumns={{ base: '1fr', md: 'repeat(2, minmax(0, 1fr))' }} gap={3}>
+              <MetricCard label="Current Bytes" value={model.currentBytesLabel} />
+              <MetricCard label="Expected Bytes" value={model.expectedBytesLabel} />
+              <MetricCard label="Drift" value={model.driftLabel} color={model.driftColor} />
+              <MetricCard label="File Blobs" value={model.fileBlobCount.toLocaleString('en-US')} />
+              <MetricCard label="References" value={model.referenceCount.toLocaleString('en-US')} />
+            </Grid>
+
+            {model.validateError && (
+              <Text fontSize="sm" color="red.600">
+                {model.validateError}
+              </Text>
+            )}
+
+            {model.canRestore && (
+              <HStack justify="space-between" align="center" flexWrap="wrap" gap={3}>
+                <Text fontSize="sm" color="gray.600">
+                  Drift detected. Preview the restore before applying any changes.
+                </Text>
+                <Button size="sm" colorPalette="orange" onClick={model.previewRestore} loading={model.isPreviewLoading}>
+                  Restore File Bytes
+                </Button>
+              </HStack>
+            )}
+          </VStack>
+        )}
+      </Box>
+
+      <DialogRoot open={model.restoreDialogOpen} onOpenChange={({ open }) => !open && model.closeRestoreDialog()}>
+        <Portal>
+          <DialogBackdrop />
+          <DialogPositioner>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Restore Project File Bytes</DialogTitle>
+              </DialogHeader>
+
+              <DialogBody>
+                <VStack align="stretch" gap={4}>
+                  {model.isPreviewLoading ? (
+                    <HStack gap={3}>
+                      <Spinner size="sm" color="gray.400" />
+                      <Text fontSize="sm" color="gray.600">
+                        Preparing restore preview…
+                      </Text>
+                    </HStack>
+                  ) : (
+                    <>
+                      {model.preview && (
+                        <Grid templateColumns="1fr" gap={3}>
+                          <MetricCard label="Previous Bytes" value={model.previewPreviousBytesLabel} />
+                          <MetricCard label="Next Bytes" value={model.previewNextBytesLabel} />
+                          <MetricCard label="Drift" value={model.previewDriftLabel} />
+                        </Grid>
+                      )}
+
+                      {model.restoreError && (
+                        <Text fontSize="sm" color="red.600">
+                          {model.restoreError}
+                        </Text>
+                      )}
+
+                      {!model.restoreError && model.preview && (
+                        <Text fontSize="sm" color="gray.600">
+                          Confirm to apply the previewed restore.
+                        </Text>
+                      )}
+                    </>
+                  )}
+                </VStack>
+              </DialogBody>
+
+              <DialogFooter>
+                <DialogActionTrigger asChild>
+                  <Button variant="outline">Cancel</Button>
+                </DialogActionTrigger>
+                <Button
+                  colorPalette="orange"
+                  onClick={model.applyRestore}
+                  disabled={!model.preview || model.isPreviewLoading || !!model.restoreError}
+                  loading={model.isApplyingRestore}
+                >
+                  Confirm Restore
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </DialogPositioner>
+        </Portal>
+      </DialogRoot>
+    </Box>
+  )
+})

--- a/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -29,7 +29,9 @@ import React from 'react'
 import { PiArrowRightLight, PiCloudLight, PiLockSimpleLight } from 'react-icons/pi'
 import { Link as RouterLink } from 'react-router-dom'
 import { ApiKeyList } from 'src/features/ApiKeyManager'
+import { ProjectFileUsageViewModel } from 'src/pages/ProjectSettingsPage/model/ProjectFileUsageViewModel.ts'
 import { ProjectSettingsPageModel } from 'src/pages/ProjectSettingsPage/model/ProjectSettingsPageModel.ts'
+import { ProjectFileUsagePanel } from 'src/pages/ProjectSettingsPage/ui/ProjectFileUsagePanel/ProjectFileUsagePanel.tsx'
 import { useViewModel } from 'src/shared/lib'
 import { Page } from 'src/shared/ui'
 import { ProjectSidebar } from 'src/widgets/ProjectSidebar/ui/ProjectSidebar/ProjectSidebar.tsx'
@@ -95,6 +97,7 @@ const VisibilityCard: React.FC<VisibilityCardProps> = ({
 
 export const ProjectSettingsPage: React.FC = observer(() => {
   const store = useViewModel(ProjectSettingsPageModel)
+  const fileUsageModel = useViewModel(ProjectFileUsageViewModel)
 
   return (
     <Page sidebar={<ProjectSidebar />}>
@@ -196,6 +199,8 @@ export const ProjectSettingsPage: React.FC = observer(() => {
                 </Box>
               )}
             </Box>
+
+            <ProjectFileUsagePanel model={fileUsageModel} />
 
             {store.hasDeletePermission && (
               <Box>

--- a/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -97,7 +97,7 @@ const VisibilityCard: React.FC<VisibilityCardProps> = ({
 
 export const ProjectSettingsPage: React.FC = observer(() => {
   const store = useViewModel(ProjectSettingsPageModel)
-  const fileUsageModel = store.canManageFileUsage ? useViewModel(ProjectFileUsageViewModel) : null
+  const fileUsageModel = useViewModel(ProjectFileUsageViewModel)
 
   return (
     <Page sidebar={<ProjectSidebar />}>
@@ -200,7 +200,7 @@ export const ProjectSettingsPage: React.FC = observer(() => {
               )}
             </Box>
 
-            {fileUsageModel && <ProjectFileUsagePanel model={fileUsageModel} />}
+            {store.canManageFileUsage && <ProjectFileUsagePanel model={fileUsageModel} />}
 
             {store.hasDeletePermission && (
               <Box>

--- a/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
+++ b/src/pages/ProjectSettingsPage/ui/ProjectSettingsPage/ProjectSettingsPage.tsx
@@ -97,7 +97,7 @@ const VisibilityCard: React.FC<VisibilityCardProps> = ({
 
 export const ProjectSettingsPage: React.FC = observer(() => {
   const store = useViewModel(ProjectSettingsPageModel)
-  const fileUsageModel = useViewModel(ProjectFileUsageViewModel)
+  const fileUsageModel = store.canManageFileUsage ? useViewModel(ProjectFileUsageViewModel) : null
 
   return (
     <Page sidebar={<ProjectSidebar />}>
@@ -200,7 +200,7 @@ export const ProjectSettingsPage: React.FC = observer(() => {
               )}
             </Box>
 
-            <ProjectFileUsagePanel model={fileUsageModel} />
+            {fileUsageModel && <ProjectFileUsagePanel model={fileUsageModel} />}
 
             {store.hasDeletePermission && (
               <Box>

--- a/src/shared/model/AbilityService/types.ts
+++ b/src/shared/model/AbilityService/types.ts
@@ -18,6 +18,7 @@ export enum PermissionSubject {
   Endpoint = 'Endpoint',
   User = 'User',
   ApiKey = 'ApiKey',
+  FileUsage = 'FileUsage',
 }
 
 export type Actions = `${PermissionAction}`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a project-scoped File Usage panel in Project Settings to validate and restore tracked file bytes when drift is detected. The panel is gated by `FileUsage.manage`, with dry-run preview, clear metrics, inline errors, and stricter action guards.

- **New Features**
  - Validate on load with manual refresh; panel hidden and no requests without permission; state resets on project change.
  - Clear metrics: current, expected, drift, blobs, and references with human-readable byte labels.
  - Restore flow: preview (`dryRun`) then confirm; re-checks permission on apply; inline errors and a success toast.
  - GraphQL `adminValidateProjectFileBytes` query and `adminRestoreProjectFileBytes` mutation with generated types; ViewModel with abort-safe requests, unit tests, Storybook states, and a new `FileUsage` permission subject.

- **Refactors**
  - Simplified byte formatters with inline BigInt parsing for accurate human-readable labels.

<sup>Written for commit 0ee6f2a611479a637b1965bed45ffd010b607da6. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/331">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



