### PR TITLE
fix: guard latest release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Determine latest stable Docker tag eligibility
+        id: stable-tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          IS_LATEST_STABLE=false
+          if [[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ "$GITHUB_REF_NAME" == "$LATEST_STABLE_TAG" ]]; then
+              IS_LATEST_STABLE=true
+            fi
+          fi
+
+          echo "is_latest_stable=$IS_LATEST_STABLE" >> "$GITHUB_OUTPUT"
 
       - name: Log in to the Container registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -32,11 +50,13 @@ jobs:
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
-            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ steps.stable-tag.outputs.is_latest_stable == 'true' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -69,13 +71,21 @@ jobs:
       - name: Determine npm tag
         id: npm-tag
         run: |
+          set -euo pipefail
+
           VERSION="$TARGET_VERSION"
           if [[ "$VERSION" =~ -alpha ]]; then
             echo "tag=alpha" >> "$GITHUB_OUTPUT"
           elif [[ "$VERSION" =~ -rc ]]; then
             echo "tag=rc" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            LATEST_STABLE_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ "v$VERSION" == "$LATEST_STABLE_TAG" ]]; then
+              echo "tag=latest" >> "$GITHUB_OUTPUT"
+            else
+              IFS=. read -r MAJOR MINOR PATCH <<< "$VERSION"
+              echo "tag=release-$MAJOR-$MINOR" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Publish to npm


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Guard Docker and npm latest tags so they only point to the highest stable release. Prevents older or pre-release tags from overwriting latest.

- **Bug Fixes**
  - Docker: compute the latest stable `vX.Y.Z` tag and only publish `latest` for that; disable the metadata action’s default `latest`; keep semver tags.
  - npm: tag `alpha`/`rc` as-is; for stable, use `latest` only if it’s the highest stable, otherwise use `release-MAJOR-MINOR`.
  - Both workflows now use `fetch-depth: 0` to access git tags.

<sup>Written for commit 1573d2314b8f6c81d17cb3613e3a7962ecb5a0c0. Summary will update on new commits. <a href="https://cubic.dev/pr/revisium/revisium-admin/pull/335">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

