### PR TITLE
feat(apollo-sandbox): include browser cookies in sandbox requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ npm-debug.log*
 .vscode
 .idea
 *.code-workspace
+.claude-flow
 
 # generated
 #*.generated.ts

--- a/src/pages/ApolloSandboxPage/ui/ApolloSandboxPage/ApolloSandboxPage.tsx
+++ b/src/pages/ApolloSandboxPage/ui/ApolloSandboxPage/ApolloSandboxPage.tsx
@@ -26,6 +26,7 @@ export const ApolloSandboxPage = () => {
         initialEndpoint={url}
         initialState={{
           document: model.document,
+          includeCookies: true,
           headers: { ...(model.token ? { Authorization: `Bearer ${model.token}` } : {}) },
         }}
       />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apollo Sandbox now properly includes cookies in requests during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->