### PR TITLE
fix(limits): hide Downgrade button on Free plan card

### DIFF
--- a/src/pages/OrganizationLimitsPage/model/PlanItemViewModel.ts
+++ b/src/pages/OrganizationLimitsPage/model/PlanItemViewModel.ts
@@ -58,6 +58,10 @@ export class PlanItemViewModel {
     return !this.canUpgrade && !this.canDowngrade
   }
 
+  public get buttonHidden(): boolean {
+    return this.canDowngrade
+  }
+
   public get projectsLimit(): string {
     return formatLimitNumber(this.plan.limits.projects)
   }

--- a/src/pages/OrganizationLimitsPage/ui/PlanCard/PlanCard.tsx
+++ b/src/pages/OrganizationLimitsPage/ui/PlanCard/PlanCard.tsx
@@ -54,6 +54,7 @@ export const PlanCard: FC<PlanCardProps> = observer(({ model, parentModel }) => 
           size="sm"
           variant={model.isCurrent ? 'outline' : 'solid'}
           width="100%"
+          visibility={model.buttonHidden ? 'hidden' : 'visible'}
           disabled={model.buttonDisabled || parentModel.isActionLoading}
           onClick={model.handleClick}
         >


### PR DESCRIPTION
https://github.com/revisium/qa/issues/35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downgrade buttons now hide when plans are eligible for downgrade, providing a cleaner interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/revisium/revisium-admin/pull/342)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->